### PR TITLE
Fix reentrancy

### DIFF
--- a/src/Gateway.sol
+++ b/src/Gateway.sol
@@ -491,7 +491,9 @@ contract Gateway is IGateway, ReentrancyGuard, Voting {
         CrossMsg storage crossMsg = postbox[msgCid];
 
         (bool shouldBurn, bool shouldDistributeRewards) = _commitCrossMessage(crossMsg);
-
+// We must delete the message first to prevent potential re-entrancies, 
+// and as the message is deleted and we don't have a reference to the object
+// anymore, we need to pull the data from the message to trigger the side-effects.
         uint256 v = crossMsg.message.value;
         SubnetID memory toSubnetId = crossMsg.message.to.subnetId.down(networkName);
         delete postbox[msgCid];

--- a/src/Gateway.sol
+++ b/src/Gateway.sol
@@ -491,9 +491,9 @@ contract Gateway is IGateway, ReentrancyGuard, Voting {
         CrossMsg storage crossMsg = postbox[msgCid];
 
         (bool shouldBurn, bool shouldDistributeRewards) = _commitCrossMessage(crossMsg);
-// We must delete the message first to prevent potential re-entrancies, 
-// and as the message is deleted and we don't have a reference to the object
-// anymore, we need to pull the data from the message to trigger the side-effects.
+        // We must delete the message first to prevent potential re-entrancies,
+        // and as the message is deleted and we don't have a reference to the object
+        // anymore, we need to pull the data from the message to trigger the side-effects.
         uint256 v = crossMsg.message.value;
         SubnetID memory toSubnetId = crossMsg.message.to.subnetId.down(networkName);
         delete postbox[msgCid];

--- a/src/Gateway.sol
+++ b/src/Gateway.sol
@@ -510,7 +510,12 @@ contract Gateway is IGateway, ReentrancyGuard, Voting {
         // commit cross-message for propagation
         (bool shouldBurn, bool shouldDistributeRewards) = _commitCrossMessage(crossMsg);
 
-        _crossMsgSideEffects(crossMsg.message.value, crossMsg.message.to.subnetId.down(_networkName), shouldBurn, shouldDistributeRewards);
+        _crossMsgSideEffects(
+            crossMsg.message.value,
+            crossMsg.message.to.subnetId.down(_networkName),
+            shouldBurn,
+            shouldDistributeRewards
+        );
     }
 
     /// @notice whitelist a series of addresses as propagator of a cross net message
@@ -679,7 +684,12 @@ contract Gateway is IGateway, ReentrancyGuard, Voting {
     /// @param toSubnetId - the destination subnet of the committed cross-net message
     /// @param shouldBurn - flag if the message should burn funds
     /// @param shouldDistributeRewards - flag if the message should distribute rewards
-    function _crossMsgSideEffects(uint256 v, SubnetID memory toSubnetId, bool shouldBurn, bool shouldDistributeRewards) internal {
+    function _crossMsgSideEffects(
+        uint256 v,
+        SubnetID memory toSubnetId,
+        bool shouldBurn,
+        bool shouldDistributeRewards
+    ) internal {
         if (shouldBurn) {
             payable(BURNT_FUNDS_ACTOR).sendValue(v);
         }


### PR DESCRIPTION
This PR fixes a potential vulnerability to reentrancy attacks - https://github.com/consensus-shipyard/ipc-solidity-actors/issues/94.
To eliminate a race, I just use the values of the message instead of one.