### PR TITLE
Fix commit child check

### DIFF
--- a/src/Gateway.sol
+++ b/src/Gateway.sol
@@ -297,16 +297,15 @@ contract Gateway is IGateway, ReentrancyGuard, Voting {
             }
         }
 
-        (bool checkpointExists, uint64 currentEpoch, BottomUpCheckpoint storage checkpoint) =
-            _getCurrentBottomUpCheckpoint();
+        BottomUpCheckpoint storage checkpoint = bottomUpCheckpoints[commit.epoch];
 
         // create checkpoint if not exists
-        if (!checkpointExists) {
+        if (checkpoint.source.isEmpty()) {
             checkpoint.source = networkName;
-            checkpoint.epoch = currentEpoch;
+            checkpoint.epoch = commit.epoch;
         }
 
-        checkpoint.setChildCheck(commit, children, checks, currentEpoch);
+        checkpoint.setChildCheck(commit, children, checks, commit.epoch);
 
         uint256 totalValue = 0;
         uint256 crossMsgLength = commit.crossMsgs.length;


### PR DESCRIPTION
Previous implementation is using `_getCurrentBottomUpCheckpoint`, which the epoch is pointing to the next epoch to submit. So what happens is when submitting checkpoint with target epoch, say 10, the `_getCurrentBottomUpCheckpoint` will fetch the `epoch` at 20. 
We should instead directly use the epoch provided in the checkpoint instead of using the next epoch.