### PR TITLE
Remove unused constants and fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,4 @@ test:
 	forge test
 
 # ==============================================================================
-.PHONY: deploy-ipc lint format check-subnet slither check-gateway format
+.PHONY: deploy-ipc lint format check-subnet slither check-gateway test

--- a/src/constants/Constants.sol
+++ b/src/constants/Constants.sol
@@ -1,13 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.18;
 
-address constant INIT_ACTOR = address(1);
-address constant REWARD_ACTOR = address(2);
-address constant CRON_ACTOR = address(3);
-address constant STORAGE_POWER_ACTOR = address(4);
-address constant STORAGE_MARKET_ACTOR = address(5);
-address constant VERIFIED_REGISTRY_ACTOR = address(6);
-address constant DATACAP_TOKEN_ACTOR = address(7);
 address constant BURNT_FUNDS_ACTOR = address(99);
 bytes32 constant EMPTY_HASH = bytes32("");
 bytes constant EMPTY_BYTES = bytes("");


### PR DESCRIPTION
This PR: 
- Removes constant that are available in the `fevmate` library. 
- Fixes slight bug in `Makefile`.