### PR TITLE
add makefile rule to compile actors abi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,12 @@
 # Deployment
 
 NETWORK ?= localnet
+OUTPUT ?= ./out
 
 deploy-ipc:
 	./ops/deploy.sh $(NETWORK)
-
+compile-abi:
+	./ops/compile-abi.sh $(OUTPUT)
 # ==============================================================================
 # Running security checks within the local computer
 

--- a/ops/README.md
+++ b/ops/README.md
@@ -1,3 +1,4 @@
 # IPC deployment operations
 This directory includes a set of scripts to ease the deployment of the IPC Solidity contracts to any network using hardhat.
 - `deploy.sh`: Deploys the IPC solidity contracts into a specific network.
+- `compile-abi.sh`: Compiles all contracts and outputs the ABI for the high-level contracts in the desired folder (by default `./out`).

--- a/ops/compile-abi.sh
+++ b/ops/compile-abi.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Compile contract and output core contracts ABI
+set -e
+
+if [ $# -ne 1 ]
+then
+    echo "Expected a single argument with the output directory for the compiled contracts"
+    exit 1
+fi
+
+OUTPUT=$1
+
+echo "[*] Compiling contracts and output core contracts ABI in $OUTPUT" 
+forge build --via-ir --extra-output=abi --out=$OUTPUT
+mkdir -p $OUTPUT
+cp $OUTPUT/SubnetActor.sol/* $OUTPUT
+cp $OUTPUT/Gateway.sol/* $OUTPUT
+cp $OUTPUT/SubnetRegistry.sol/* $OUTPUT


### PR DESCRIPTION
This PR adds a handy makefile rule to help with compiling the ABI of the contracts.