### PR TITLE
fix deployment in calibration and config chainID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ OUTPUT ?= ./out
 
 deploy-ipc:
 	./ops/deploy.sh $(NETWORK)
+
 compile-abi:
 	./ops/compile-abi.sh $(OUTPUT)
 # ==============================================================================

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -95,6 +95,7 @@ const config: HardhatUserConfig = {
       chainId: 314159,
       url: process.env.RPC_URL!,
       accounts: [process.env.PRIVATE_KEY!],
+      timeout: 1000000,
     },
     localnet: {
       chainId: 31415926,

--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -4,7 +4,7 @@ set -e
 
 if [ $# -ne 1 ]
 then
-    echo "Expected a single argument with the name of the network to deploy (localnet, calibrationet)"
+    echo "Expected a single argument with the name of the network to deploy (localnet, calibrationnet)"
     exit 1
 fi
 

--- a/scripts/deploy-gateway.template
+++ b/scripts/deploy-gateway.template
@@ -7,6 +7,13 @@ import { deployContractWithDeployer, getTransactionFees } from './util';
 export async function deploy(libs: { [key in string]: string }) {
     if (!libs || Object.keys(libs).length === 0) throw new Error(`Libraries are missing`);
 
+    // choose chain ID according to the network in 
+    // environmental variable
+    let chainId = 31415926;
+    if (process.env.NETWORK == "calibrationnet") {
+        chainId = 314159;
+    }
+
     await hre.run('compile');
 
     const [deployer] = await ethers.getSigners();
@@ -17,7 +24,7 @@ export async function deploy(libs: { [key in string]: string }) {
 
     const gatewayConstructorParams = {
         networkName: {
-            root: 314159,
+            root: chainId,
             route: []
         },
         bottomUpCheckPeriod: 10,


### PR DESCRIPTION
This PR makes `chainID` configurable depending on the network where the IPC gateway is deployed, and adds a timeout when deploying in calibration to avoid the deployment transaction timing out. 