### PR TITLE
add list subnets and fix deploy

### DIFF
--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -4,7 +4,7 @@ set -e
 
 if [ $# -ne 1 ]
 then
-    echo "Expected a single argument with the name of the network to deploy (localnet, calibrationnet)"
+    echo "Expected a single argument with the name of the network to deploy (localnet, calibrationnet, mainnet)"
     exit 1
 fi
 

--- a/scripts/deploy-gateway.template
+++ b/scripts/deploy-gateway.template
@@ -12,6 +12,8 @@ export async function deploy(libs: { [key in string]: string }) {
     let chainId = 31415926;
     if (process.env.NETWORK == "calibrationnet") {
         chainId = 314159;
+    } else if (process.env.NETWORK == "mainnet") {
+        chainId = 314;
     }
 
     await hre.run('compile');

--- a/src/Gateway.sol
+++ b/src/Gateway.sol
@@ -876,9 +876,12 @@ contract Gateway is IGateway, ReentrancyGuard, Voting {
     function listSubnets() external view returns (Subnet[] memory) {
         uint256 size = subnetKeys.length;
         Subnet[] memory out = new Subnet[](size);
-        for (uint256 i = 0; i < size; ++i) {
+        for (uint256 i = 0; i < size; ) {
             bytes32 key = subnetKeys[i];
             out[i] = subnets[key];
+            unchecked {
+                ++i;
+            }
         }
         return out;
     }

--- a/src/Gateway.sol
+++ b/src/Gateway.sol
@@ -469,7 +469,7 @@ contract Gateway is IGateway, ReentrancyGuard, Voting {
         }
 
         totalWeight = totalValidatorsWeight;
-        revert MethodNotSupportedYet()
+        // revert MethodNotSupportedYet();
     }
 
     /// @notice allows a validator to submit a batch of messages in a top-down commitment

--- a/src/Gateway.sol
+++ b/src/Gateway.sol
@@ -57,6 +57,9 @@ contract Gateway is IGateway, ReentrancyGuard, Voting {
     /// SubnetID => Subnet
     mapping(bytes32 => Subnet) public subnets;
 
+    /// @notice Keys of the registered subnets. Useful to iterate through them
+    bytes32[] public subnetKeys;
+
     /// @notice bottom-up period in number of epochs for the subnet
     uint64 public immutable bottomUpCheckPeriod;
 
@@ -135,6 +138,7 @@ contract Gateway is IGateway, ReentrancyGuard, Voting {
     error ValidatorsAndWeightsLengthMismatch();
     error ValidatorWeightIsZero();
     error NotEnoughFundsForMembership();
+    error MethodNotSupportedYet();
 
     function _signableOnly() private view {
         if (!msg.sender.isAccount()) {
@@ -250,6 +254,8 @@ contract Gateway is IGateway, ReentrancyGuard, Voting {
         subnet.stake = msg.value;
         subnet.status = Status.Active;
         subnet.genesisEpoch = block.number;
+
+        subnetKeys.push(subnetId.toHash());
 
         totalSubnets += 1;
     }
@@ -463,6 +469,7 @@ contract Gateway is IGateway, ReentrancyGuard, Voting {
         }
 
         totalWeight = totalValidatorsWeight;
+        revert MethodNotSupportedYet()
     }
 
     /// @notice allows a validator to submit a batch of messages in a top-down commitment
@@ -536,6 +543,7 @@ contract Gateway is IGateway, ReentrancyGuard, Voting {
             shouldBurn,
             shouldDistributeRewards
         );
+        // revert MethodNotSupportedYet();
     }
 
     /// @notice propagates the populated cross net message for the given cid
@@ -558,6 +566,7 @@ contract Gateway is IGateway, ReentrancyGuard, Voting {
         if (feeRemainder > 0) {
             payable(msg.sender).sendValue(feeRemainder);
         }
+        // revert MethodNotSupportedYet();
     }
 
     /// @notice whether a validator has voted for a checkpoint submission during an epoch
@@ -860,5 +869,16 @@ contract Gateway is IGateway, ReentrancyGuard, Voting {
     function _getSubnet(SubnetID memory subnetId) internal view returns (bool found, Subnet storage subnet) {
         subnet = subnets[subnetId.toHash()];
         found = !subnet.id.isEmpty();
+    }
+
+    /// @notice returns the list of registered subnets in IPC
+    /// @return subnet - the list of subnets
+    function listSubnets() external view returns (Subnet[] memory) {
+        Subnet[] memory out = new Subnet[](subnetKeys.length);
+        for (uint256 i = 0; i < subnetKeys.length; i++) {
+            bytes32 key = subnetKeys[i];
+            out[i] = subnets[key];
+        }
+        return out;
     }
 }

--- a/src/Gateway.sol
+++ b/src/Gateway.sol
@@ -874,8 +874,9 @@ contract Gateway is IGateway, ReentrancyGuard, Voting {
     /// @notice returns the list of registered subnets in IPC
     /// @return subnet - the list of subnets
     function listSubnets() external view returns (Subnet[] memory) {
-        Subnet[] memory out = new Subnet[](subnetKeys.length);
-        for (uint256 i = 0; i < subnetKeys.length; i++) {
+        uint256 size = subnetKeys.length;
+        Subnet[] memory out = new Subnet[](size);
+        for (uint256 i = 0; i < size; ++i) {
             bytes32 key = subnetKeys[i];
             out[i] = subnets[key];
         }

--- a/test/Gateway.t.sol
+++ b/test/Gateway.t.sol
@@ -181,6 +181,8 @@ contract GatewayDeploymentTest is StdInvariant, Test {
         registerSubnet(subnetCollateral, subnetAddress);
 
         require(gw.totalSubnets() == 1);
+        Subnet[] memory subnets = gw.listSubnets();
+        require(subnets.length == 1, "subnets.length == 1");
     }
 
     function test_InitGenesisEpoch_Works() public {
@@ -214,6 +216,8 @@ contract GatewayDeploymentTest is StdInvariant, Test {
         }
 
         require(gw.totalSubnets() == numberOfSubnets);
+        Subnet[] memory subnets = gw.listSubnets();
+        require(subnets.length == numberOfSubnets, "subnets.length == numberOfSubnets");
     }
 
     function test_Register_Fail_InsufficientCollateral(uint256 collateral) public {


### PR DESCRIPTION
This PR: 
- Includes a `listSubnet` function in the gateway (the size have increased so to deploy the contract now we need to comment `propagate`, `setMembership` and `sendCross` which won't be supported until the next version of IPC)
- Add support for mainnet in the deploy scripts. 
- Add a new error of `MethodNotSupportedYet` for the mainnet deployment