### PR TITLE
fix bug in compile-abi and deploy-gateway

### DIFF
--- a/ops/compile-abi.sh
+++ b/ops/compile-abi.sh
@@ -11,7 +11,7 @@ fi
 OUTPUT=$1
 
 echo "[*] Compiling contracts and output core contracts ABI in $OUTPUT" 
-forge build --via-ir --extra-output=abi --out=$OUTPUT
+forge build --via-ir --sizes --skip test --out=$OUTPUT
 mkdir -p $OUTPUT
 cp $OUTPUT/SubnetActor.sol/* $OUTPUT
 cp $OUTPUT/Gateway.sol/* $OUTPUT

--- a/scripts/deploy-gateway.template
+++ b/scripts/deploy-gateway.template
@@ -38,6 +38,7 @@ export async function deploy(libs: { [key in string]: string }) {
     const { address: gatewayAddress } = await deployContractWithDeployer(deployer, "Gateway", LIBMAP, gatewayConstructorParams, txArgs);
 
     return {
+        "ChainID": chainId,
         "Gateway": gatewayAddress
     }
 


### PR DESCRIPTION
Fix bug for which including tests in the abi compilation led to the intermediate representation created by the compiler with `--via-ir` reached the depth stack of the IR. 

In the process, I got a quick fix for which the deployment of the gateway also notifies about the chainID of the network where the gateway is being deployed.