### PR TITLE
add development branch

### DIFF
--- a/.github/workflows/branch-check.yaml
+++ b/.github/workflows/branch-check.yaml
@@ -1,0 +1,21 @@
+name: Check branch
+
+on:
+  pull_request_target: # Do not combine with explicit checkout for security reasons
+    types: [opened] # Not triggering on "edited" to allow a forced path to main
+
+jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Vankka/pr-target-branch-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          target: main
+          exclude: dev # Don't prevent going from development -> main
+          change-to: dev
+          comment: |
+              Your PR was set to target `main`. PRs should be target `dev`.
+              The base branch of this PR has been automatically changed to `dev`.
+              If you really intend to target `main`, edit the PR.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ To deploy the contracts in some other network configured in the Hardhat config y
 ```bash
 make deploy-ipc NETWORK=<network-name>
 ```
+## Branching Strategy
+
+### Production branch
+
+The production branch is `main`.
+The `main` branch is always compatible with the "stable" release of the IPC agent that's running on Spacenet.
+Updates to `main` **always** come from the `dev` branch.
+
+### Development branch
+
+The primary development branch is `dev`.
+`dev` contains the most up-to-date software but may not be compatible with the version of the contracts deployed on spacenet and the `main` branch of the IPC agent. Only use `dev` if doing a full local deployment, but note that the packaged deployment scripts default to checking out `main` branches instead of `dev`.
 
 # Actors overview
 


### PR DESCRIPTION
With the diamond implementation of the contracts we are going to include a breaking change that may break the agent and other dependencies. To avoid this from happening, let's use the same branching strategy that we are using in the rest of the IPC repos.