### PR TITLE
get chain-id automatically in deploy-ipc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # ==============================================================================
 # Deployment
 
-NETWORK ?= localnet
+NETWORK ?= auto
 OUTPUT ?= ./out
 
 deploy-ipc:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To deploy the IPC Solidity contracts in an FEVM network, you can directly run th
 ```bash
 make deploy-ipc
 ```
-The scripts run by `make` make use of hardhat under the hood. The default network for the deployment is `localnet` as configured in `hardhat.config.ts`.
+The scripts run by `make` make use of hardhat under the hood. If no network has been configured, the script will automatically try to fetch the chainID of the target network, and perform the deployment according to the configuration in `hardhat.config.ts`.
 To deploy the contracts in some other network configured in the Hardhat config you can run the following: 
 ```bash
 make deploy-ipc NETWORK=<network-name>

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -93,7 +93,7 @@ task('deploy-sa-diamond-and-facets', 'Builds and deploys Subnet Actor diamond an
   const network = hre.network.name;
   const deployments = await getDeployments(network);
   const { deployDiamond } = await lazyImport('./scripts/deploy-sa-diamond');
-  const subnetActorDiamond = await deployDiamond(deployments.GatewayActorDiamond,deployments.libs);
+  const subnetActorDiamond = await deployDiamond(deployments.GatewayActorDiamond, deployments.libs);
   console.log(subnetActorDiamond);
   await saveDeployments(network, subnetActorDiamond);
 });
@@ -136,6 +136,14 @@ const config: HardhatUserConfig = {
       chainId: 31415926,
       url: process.env.RPC_URL!,
       accounts: [process.env.PRIVATE_KEY!],
+    },
+    // automatically fetch chainID for network
+    auto: {
+      chainId: parseInt(process.env.CHAIN_ID!, 16),
+      url: process.env.RPC_URL!,
+      accounts: [process.env.PRIVATE_KEY!],
+      // timeout to support also slow networks (like calibration/mainnet)
+      timeout: 1000000,
     }
   },
   solidity: {

--- a/ops/chain-id.sh
+++ b/ops/chain-id.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Check if RPC_URL is set
+if [[ -z "$RPC_URL" ]]; then
+    echo "RPC_URL is not set. Sourcing .env file..."
+    source .env
+fi
+
+# Make a JSON-RPC call to get the chain ID using curl
+response=$(curl -s -X POST -H "Content-Type: application/json" --data '{
+  "jsonrpc":"2.0",
+  "method":"eth_chainId",
+  "params":[],
+  "id":1
+}' $RPC_URL)
+
+# Extract the chain ID from the response using jq (ensure jq is installed)
+chain_id=$(echo $response | jq -r '.result')
+
+# Export the chain ID as an environmental variable
+export CHAIN_ID=$chain_id
+
+# Print the chain ID for verification (optional)
+echo "[*] Target network Chain ID: $CHAIN_ID"

--- a/ops/chain-id.sh
+++ b/ops/chain-id.sh
@@ -17,8 +17,13 @@ response=$(curl -s -X POST -H "Content-Type: application/json" --data '{
 # Extract the chain ID from the response using jq (ensure jq is installed)
 chain_id=$(echo $response | jq -r '.result')
 
-# Export the chain ID as an environmental variable
-export CHAIN_ID=$chain_id
-
-# Print the chain ID for verification (optional)
-echo "[*] Target network Chain ID: $CHAIN_ID"
+# Double-check that this is a valid chain-id
+if [[ "$chain_id" =~ ^0x[0-9a-fA-F]+$ ]]; then
+   # Export the chain ID as an environmental variable
+   export CHAIN_ID=$chain_id
+   # Print the chain ID for verification (optional)
+   echo "[*] Target network Chain ID: $CHAIN_ID"
+else
+  echo "[*] Error getting a valid hexadecimal chain ID"
+  exit 1
+fi

--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -12,6 +12,11 @@ LIB_OUTPUT="libraries.out"
 GATEWAY_OUTPUT="gateway.out"
 NETWORK=$1
 
+if [ "$NETWORK" = "auto" ]; then
+  echo "[*] Automatically getting chainID for network"
+  source ops/chain-id.sh
+fi
+
 echo "[*] Deploying libraries"
 (npx hardhat deploy-libraries --network ${NETWORK} |  sed -n '/{/,/}/p') > scripts/${LIB_OUTPUT}
 echo "const LIBMAP =" | cat - scripts/${LIB_OUTPUT}  > temp && mv temp scripts/${LIB_OUTPUT}

--- a/scripts/deploy-gateway.template
+++ b/scripts/deploy-gateway.template
@@ -16,6 +16,8 @@ export async function deploy(libs: { [key in string]: string }) {
         chainId = 314159;
     } else if (process.env.NETWORK == "mainnet") {
         chainId = 314;
+    } else if (process.env.NETWORK == "auto") {
+        chainId = parseInt(process.env.CHAIN_ID!, 16);
     }
 
     await hre.run('compile');


### PR DESCRIPTION
This PR updates the deployment scripts in a way that by default or if `NETWORK=auto` is enabled, the deployment scripts automatically fetch the chain ID of the network `RPC_URL` is pointing to in order to deploy the IPC contracts with the right ID.  