### PR TITLE
Add examples of using SendCrossMessage in contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ check-subnet:
 # Development support
 
 lint:
-	solhint 'src/**/*.sol'
+	solhint 'src/**/*.sol' 'examples/contracts/**/*.sol'
 
 format:
-	npx prettier --check -w 'src/**/*.sol' 'test/*.sol'
+	npx prettier --check -w 'src/**/*.sol' 'test/*.sol' 'examples/contracts/**/*.sol'
 
 build:
 	forge build

--- a/examples/contracts/Messenger.sol
+++ b/examples/contracts/Messenger.sol
@@ -62,13 +62,7 @@ contract Messenger {
         });
 
         // emit event and increase nonce
-        emit MessageSent({
-            from: from,
-            to:to,
-            nonce: nonce++,
-            messageBody:messageBody
-        });
-
+        emit MessageSent({from: from, to: to, nonce: nonce++, messageBody: messageBody});
 
         // slither-disable-next-line arbitrary-send-eth
         messenger.sendCrossMessage{value: DEFAULT_CROSS_MSG_FEE}(crossMsg);

--- a/examples/contracts/Messenger.sol
+++ b/examples/contracts/Messenger.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {METHOD_SEND} from "../../src/constants/Constants.sol";
+import {METHOD_SEND, EMPTY_BYTES} from "../../src/constants/Constants.sol";
 import {FvmAddress} from "../../src/structs/FvmAddress.sol";
-import {GatewayCannotBeZero, ZeroAddress} from "../../src/errors/IPCErrors.sol";
+import {GatewayCannotBeZero, ZeroAddress, NotEnoughFunds} from "../../src/errors/IPCErrors.sol";
 import {IGateway} from "../../src/interfaces/IGateway.sol";
 import {GatewayMessengerFacet} from "../../src/gateway/GatewayMessengerFacet.sol";
 import {IPCAddress, SubnetID} from "../../src/structs/Subnet.sol";
@@ -13,14 +13,14 @@ import {CrossMsgHelper} from "../../src/lib/CrossMsgHelper.sol";
 
 /**
  * @title Messenger
- * @notice An example of a contract that allows users to send messages cross-subnet.
+ * @notice An example of a simple wrapper-contract that allows users to send messages cross-subnet using a gateway.
  */
 contract Messenger {
     using FvmAddressHelper for FvmAddress;
     using CrossMsgHelper for CrossMsg;
 
     // Gateway facet used to send messages
-    GatewayMessengerFacet private immutable messenger;
+    GatewayMessengerFacet private immutable gateway;
     // Subnet for which the contract is deployed
     SubnetID public localSubnet;
     // Message nonce
@@ -28,46 +28,90 @@ contract Messenger {
     // Cross-net fee
     uint256 public constant DEFAULT_CROSS_MSG_FEE = 10 gwei;
 
+    event ValueSent(IPCAddress from, IPCAddress to, uint64 nonce, uint256 value);
     event MessageSent(IPCAddress from, IPCAddress to, uint64 nonce, bytes messageBody);
 
     constructor(address gw, SubnetID memory subnet) {
         if (gw == address(0)) {
             revert GatewayCannotBeZero();
         }
-        messenger = GatewayMessengerFacet(address(gw));
+        gateway = GatewayMessengerFacet(address(gw));
         nonce = 0;
         localSubnet = subnet;
     }
 
-    function sendMessage(
+    function sendValue(
         SubnetID calldata destinationSubnet,
-        address receiver,
-        bytes calldata messageBody
+        address receiver
     ) public payable returns (bytes32) {
         if (receiver == address(0)) {
             revert ZeroAddress();
+        }
+        if (msg.value <= DEFAULT_CROSS_MSG_FEE) {
+            revert NotEnoughFunds();
         }
 
         IPCAddress memory from = IPCAddress({subnetId: localSubnet, rawAddress: FvmAddressHelper.from(msg.sender)});
         IPCAddress memory to = IPCAddress({subnetId: destinationSubnet, rawAddress: FvmAddressHelper.from(receiver)});
 
+        uint256 value = msg.value - DEFAULT_CROSS_MSG_FEE;
+
+        CrossMsg memory crossMsg = CrossMsg({
+                message: StorableMsg({
+                from: from,
+                to: to,
+                value: value,
+                nonce: nonce,
+                method: METHOD_SEND,
+                params: EMPTY_BYTES
+            }),
+            wrapped: false
+        });
+
+        // emit event and increase nonce
+        emit ValueSent({from: from, to: to, nonce: nonce++, value: value});
+
+        // slither-disable-next-line arbitrary-send-eth
+        gateway.sendCrossMessage{value: msg.value}(crossMsg);
+
+        return crossMsg.toHash();
+    }
+
+    function sendMessage(
+        SubnetID calldata destinationSubnet,
+        address receiver,
+        bytes4 method,
+        bytes calldata messageBody
+    ) public payable returns (bytes32) {
+        if (receiver == address(0)) {
+            revert ZeroAddress();
+        }
+        if (msg.value < DEFAULT_CROSS_MSG_FEE) {
+            revert NotEnoughFunds();
+        }
+
+        IPCAddress memory from = IPCAddress({subnetId: localSubnet, rawAddress: FvmAddressHelper.from(msg.sender)});
+        IPCAddress memory to = IPCAddress({subnetId: destinationSubnet, rawAddress: FvmAddressHelper.from(receiver)});
+
+        uint256 value = msg.value - DEFAULT_CROSS_MSG_FEE;
+
         CrossMsg memory crossMsg = CrossMsg({
             message: StorableMsg({
                 from: from,
                 to: to,
-                value: msg.value,
+                value: value,
                 nonce: nonce,
-                method: METHOD_SEND,
+                method: method,
                 params: messageBody
             }),
-            wrapped: true
+            wrapped: false
         });
 
         // emit event and increase nonce
         emit MessageSent({from: from, to: to, nonce: nonce++, messageBody: messageBody});
 
         // slither-disable-next-line arbitrary-send-eth
-        messenger.sendCrossMessage{value: msg.value}(crossMsg);
+        gateway.sendCrossMessage{value: msg.value}(crossMsg);
 
         return crossMsg.toHash();
     }

--- a/examples/contracts/Messenger.sol
+++ b/examples/contracts/Messenger.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.19;
 
 import {METHOD_SEND} from "../../src/constants/Constants.sol";
 import {FvmAddress} from "../../src/structs/FvmAddress.sol";
-import {GatewayCannotBeZero, ZeroAddress, InvalidAmount} from "../../src/errors/IPCErrors.sol";
+import {GatewayCannotBeZero, ZeroAddress} from "../../src/errors/IPCErrors.sol";
 import {IGateway} from "../../src/interfaces/IGateway.sol";
 import {GatewayMessengerFacet} from "../../src/gateway/GatewayMessengerFacet.sol";
 import {IPCAddress, SubnetID} from "../../src/structs/Subnet.sol";
@@ -12,61 +12,65 @@ import {FvmAddressHelper} from "../../src/lib/FvmAddressHelper.sol";
 
 /**
  * @title Messenger
- * @notice An example of a contract that allows users to send transactions cross-subnet.
+ * @notice An example of a contract that allows users to send messages cross-subnet.
  */
-contract DemoCrossMessenger {
+contract Messenger {
     using FvmAddressHelper for FvmAddress;
 
-    GatewayMessengerFacet private messenger;
+    // Gateway facet used to send messages
+    GatewayMessengerFacet private immutable messenger;
+    // Subnet for which the contract is deployed
     SubnetID public localSubnet;
+    // Message nonce
     uint64 public nonce;
+    // Cross-net fee
     uint256 public constant DEFAULT_CROSS_MSG_FEE = 10 gwei;
 
-    event MessageSent(IPCAddress from, IPCAddress to, uint256 value);
+    event MessageSent(IPCAddress from, IPCAddress to, uint64 nonce, bytes messageBody);
 
     constructor(address gw, SubnetID memory subnet) {
         if (gw == address(0)) {
             revert GatewayCannotBeZero();
         }
+        messenger = GatewayMessengerFacet(address(gw));
         nonce = 0;
         localSubnet = subnet;
-        messenger = new GatewayMessengerFacet();
-        messenger = GatewayMessengerFacet(address(gw));
     }
 
-    function sendMessage(SubnetID memory destinationSubnet, address receiver, uint256 amount) public payable {
-        sendMessageFrom(msg.sender, destinationSubnet, receiver, amount);
-    }
-
-    function sendMessageFrom(address sender, SubnetID memory destinationSubnet, address receiver, uint256 amount) public payable {
+    function sendMessage(
+        SubnetID calldata destinationSubnet,
+        address receiver,
+        bytes calldata messageBody
+    ) public payable {
         if (receiver == address(0)) {
             revert ZeroAddress();
         }
-        if (amount < DEFAULT_CROSS_MSG_FEE) {
-            revert InvalidAmount();
-        }
 
-        IPCAddress memory from = IPCAddress({subnetId: localSubnet, rawAddress: FvmAddressHelper.from(sender)});
+        IPCAddress memory from = IPCAddress({subnetId: localSubnet, rawAddress: FvmAddressHelper.from(msg.sender)});
         IPCAddress memory to = IPCAddress({subnetId: destinationSubnet, rawAddress: FvmAddressHelper.from(receiver)});
-
-        uint256 value = amount;
 
         CrossMsg memory crossMsg = CrossMsg({
             message: StorableMsg({
-            from: from,
-            to: to,
-            value: value,
-            nonce: nonce,
-            method: METHOD_SEND,
-            params: new bytes(0)
-        }),
+                from: from,
+                to: to,
+                value: DEFAULT_CROSS_MSG_FEE,
+                nonce: nonce,
+                method: METHOD_SEND,
+                params: messageBody
+            }),
             wrapped: true
         });
 
-        ++nonce;
-        emit MessageSent(from, to, value);
+        // emit event and increase nonce
+        emit MessageSent({
+            from: from,
+            to:to,
+            nonce: nonce++,
+            messageBody:messageBody
+        });
 
-        //slither-disable-next-line arbitrary-send-eth
-        messenger.sendCrossMessage{value: value}(crossMsg);
+
+        // slither-disable-next-line arbitrary-send-eth
+        messenger.sendCrossMessage{value: DEFAULT_CROSS_MSG_FEE}(crossMsg);
     }
 }

--- a/examples/contracts/Messenger.sol
+++ b/examples/contracts/Messenger.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.19;
+
+import {GatewayCannotBeZero} from "../../src/errors/IPCErrors.sol";
+import {IGateway} from "../../src/interfaces/IGateway.sol";
+import {GatewayMessengerFacet} from "../../src/gateway/GatewayMessengerFacet.sol";
+import {CrossMsg} from "../../src/structs/Checkpoint.sol";
+
+contract Messenger {
+    GatewayMessengerFacet private sender;
+
+    uint256 constant CROSS_MSG_FEE = 10 gwei;
+
+    constructor(address _gateway){
+        if (_gateway == address(0)) {
+            revert GatewayCannotBeZero();
+        }
+        sender = new GatewayMessengerFacet();
+        sender = GatewayMessengerFacet(address(_gateway));
+    }
+
+    function sendMessage(CrossMsg calldata crossMsg) external payable {
+        sender.sendCrossMessage{value: CROSS_MSG_FEE + 1}(crossMsg);
+    }
+ }

--- a/examples/contracts/Messenger.sol
+++ b/examples/contracts/Messenger.sol
@@ -1,25 +1,46 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
+import {METHOD_SEND} from "../../src/constants/Constants.sol";
+import {FvmAddress} from "../../src/structs/FvmAddress.sol";
 import {GatewayCannotBeZero} from "../../src/errors/IPCErrors.sol";
 import {IGateway} from "../../src/interfaces/IGateway.sol";
 import {GatewayMessengerFacet} from "../../src/gateway/GatewayMessengerFacet.sol";
-import {CrossMsg} from "../../src/structs/Checkpoint.sol";
+import {IPCAddress, SubnetID} from "../../src/structs/Subnet.sol";
+import {CrossMsg, StorableMsg} from "../../src/structs/Checkpoint.sol";
+import {FvmAddressHelper} from "../../src/lib/FvmAddressHelper.sol";
 
 contract Messenger {
+    using FvmAddressHelper for FvmAddress;
+
     GatewayMessengerFacet private sender;
+    SubnetID public subnet;
+    uint64 public nonce;
+    uint256 public constant CROSS_MSG_FEE = 10 gwei;
 
-    uint256 constant CROSS_MSG_FEE = 10 gwei;
-
-    constructor(address _gateway){
+    constructor(address _gateway, SubnetID memory _subnet) {
         if (_gateway == address(0)) {
             revert GatewayCannotBeZero();
         }
+        nonce = 0;
+        subnet = _subnet;
         sender = new GatewayMessengerFacet();
         sender = GatewayMessengerFacet(address(_gateway));
     }
 
-    function sendMessage(CrossMsg calldata crossMsg) external payable {
+    function sendMessage(SubnetID memory dstSubnet, address dstUser) external payable {
+        CrossMsg memory crossMsg = CrossMsg({
+            message: StorableMsg({
+                from: IPCAddress({subnetId: subnet, rawAddress: FvmAddressHelper.from(msg.sender)}),
+                to: IPCAddress({subnetId: dstSubnet, rawAddress: FvmAddressHelper.from(dstUser)}),
+                value: CROSS_MSG_FEE + 1,
+                nonce: nonce,
+                method: METHOD_SEND,
+                params: new bytes(0)
+            }),
+            wrapped: true
+        });
+        ++nonce;
         sender.sendCrossMessage{value: CROSS_MSG_FEE + 1}(crossMsg);
     }
- }
+}

--- a/examples/contracts/Messenger.sol
+++ b/examples/contracts/Messenger.sol
@@ -14,7 +14,7 @@ import {FvmAddressHelper} from "../../src/lib/FvmAddressHelper.sol";
  * @title Messenger
  * @notice An example of a contract that allows users to send transactions cross-subnet.
  */
-contract Messenger {
+contract DemoCrossMessenger {
     using FvmAddressHelper for FvmAddress;
 
     event MessageSent(IPCAddress from, IPCAddress to, uint256 value);

--- a/examples/contracts/README.md
+++ b/examples/contracts/README.md
@@ -1,0 +1,12 @@
+# Examples
+
+**‼️ The IPC Agent, the IPC actors (Rust, Solidity), and Eudico haven't been audited, tested in depth, or otherwise verified.
+Moreover, the system is missing critical recovery functionality in case of crashes.
+There are multiple ways in which you may lose funds moved into an IPC subnet,
+and we strongly advise against deploying IPC on mainnet and/or using it with tokens with real value.**
+
+## Messenger
+Messenger sends arbitrary messages cross-subnet.
+
+## TokenMessenger
+TokenMessenger sends ERC20 tokens cross-subnet.

--- a/examples/contracts/TokenMessenger.sol
+++ b/examples/contracts/TokenMessenger.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.19;
+
+import {IPCAddress, SubnetID} from "../../src/structs/Subnet.sol";
+import {ZeroAddress} from "../../src/errors/IPCErrors.sol";
+import {DemoCrossMessenger} from "./Messenger.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+
+error NoTransfer();
+
+contract DemoTokenMessenger is ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    uint256 public lastEventNonce = 0;
+    DemoCrossMessenger messenger;
+
+    constructor(address _messenger){
+        if (_messenger == address(0)) {
+            revert ZeroAddress();
+        }
+        messenger = DemoCrossMessenger(_messenger);
+    }
+
+    function sendToken(address tokenContract, SubnetID memory destinationSubnet, address receiver, uint256 amount) external nonReentrant {
+        uint256 startingBalance = IERC20(tokenContract).balanceOf(address(this));
+        IERC20(tokenContract).safeTransferFrom(msg.sender, address(this), amount);
+        uint256 endingBalance = IERC20(tokenContract).balanceOf(address(this));
+
+        if (endingBalance <= startingBalance) {
+            revert NoTransfer();
+        }
+
+        ++lastEventNonce;
+        messenger.sendMessageFrom(tokenContract, destinationSubnet, receiver, amount);
+    }
+
+    receive() external payable{}
+
+}

--- a/examples/contracts/TokenMessenger.sol
+++ b/examples/contracts/TokenMessenger.sol
@@ -44,11 +44,7 @@ contract TokenMessenger is ReentrancyGuard {
     ) external nonReentrant {
         uint256 startingBalance = IERC20(tokenContract).balanceOf(address(this));
 
-        IERC20(tokenContract).safeTransferFrom({
-            from: msg.sender,
-            to: address(this),
-            value: amount
-        });
+        IERC20(tokenContract).safeTransferFrom({from: msg.sender, to: address(this), value: amount});
 
         uint256 endingBalance = IERC20(tokenContract).balanceOf(address(this));
 
@@ -64,14 +60,10 @@ contract TokenMessenger is ReentrancyGuard {
             destinationSubnet: destinationSubnet,
             receiver: receiver,
             nonce: lastEventNonce++,
-            value:amount
+            value: amount
         });
 
-        messenger.sendMessage({
-            destinationSubnet: destinationSubnet,
-            receiver: receiver,
-            messageBody: payload
-        });
+        messenger.sendMessage({destinationSubnet: destinationSubnet, receiver: receiver, messageBody: payload});
     }
 
     receive() external payable {}

--- a/examples/contracts/TokenMessenger.sol
+++ b/examples/contracts/TokenMessenger.sol
@@ -4,9 +4,9 @@ pragma solidity 0.8.19;
 import {IPCAddress, SubnetID} from "../../src/structs/Subnet.sol";
 import {ZeroAddress} from "../../src/errors/IPCErrors.sol";
 import {Messenger} from "./Messenger.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import {IERC20} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "../../lib/openzeppelin-contracts/contracts/security/ReentrancyGuard.sol";
 
 error NoTransfer();
 

--- a/examples/contracts/TokenMessenger.sol
+++ b/examples/contracts/TokenMessenger.sol
@@ -3,39 +3,76 @@ pragma solidity 0.8.19;
 
 import {IPCAddress, SubnetID} from "../../src/structs/Subnet.sol";
 import {ZeroAddress} from "../../src/errors/IPCErrors.sol";
-import {DemoCrossMessenger} from "./Messenger.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import {Messenger} from "./Messenger.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
 error NoTransfer();
 
-contract DemoTokenMessenger is ReentrancyGuard {
+/**
+ * @title TokenMessenger
+ * @notice An example of a contract that allows users to send a token cross-subnet.
+ */
+contract TokenMessenger is ReentrancyGuard {
     using SafeERC20 for IERC20;
 
-    uint256 public lastEventNonce = 0;
-    DemoCrossMessenger messenger;
+    uint64 public lastEventNonce = 0;
+    Messenger private immutable messenger;
 
-    constructor(address _messenger){
+    event TokenSent(
+        address tokenContract,
+        address sender,
+        SubnetID destinationSubnet,
+        address receiver,
+        uint64 nonce,
+        uint256 value
+    );
+
+    constructor(address _messenger) {
         if (_messenger == address(0)) {
             revert ZeroAddress();
         }
-        messenger = DemoCrossMessenger(_messenger);
+        messenger = Messenger(_messenger);
     }
 
-    function sendToken(address tokenContract, SubnetID memory destinationSubnet, address receiver, uint256 amount) external nonReentrant {
+    function sendToken(
+        address tokenContract,
+        SubnetID memory destinationSubnet,
+        address receiver,
+        uint256 amount
+    ) external nonReentrant {
         uint256 startingBalance = IERC20(tokenContract).balanceOf(address(this));
-        IERC20(tokenContract).safeTransferFrom(msg.sender, address(this), amount);
+
+        IERC20(tokenContract).safeTransferFrom({
+            from: msg.sender,
+            to: address(this),
+            value: amount
+        });
+
         uint256 endingBalance = IERC20(tokenContract).balanceOf(address(this));
 
         if (endingBalance <= startingBalance) {
             revert NoTransfer();
         }
 
-        ++lastEventNonce;
-        messenger.sendMessageFrom(tokenContract, destinationSubnet, receiver, amount);
+        bytes memory payload = abi.encode(msg.sender, amount);
+
+        emit TokenSent({
+            tokenContract: tokenContract,
+            sender: msg.sender,
+            destinationSubnet: destinationSubnet,
+            receiver: receiver,
+            nonce: lastEventNonce++,
+            value:amount
+        });
+
+        messenger.sendMessage({
+            destinationSubnet: destinationSubnet,
+            receiver: receiver,
+            messageBody: payload
+        });
     }
 
-    receive() external payable{}
-
+    receive() external payable {}
 }

--- a/ops/deploy-gw.sh
+++ b/ops/deploy-gw.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Deploys IPC on an EVM-compatible subnet using hardhat
+set -e
+
+if [ $# -ne 1 ]
+then
+    echo "Expected a single argument with the name of the network to deploy (localnet, calibrationnet, mainnet)"
+    exit 1
+fi
+
+LIB_OUTPUT="libraries.out"
+GATEWAY_OUTPUT="gateway.out"
+NETWORK=$1
+
+if [ "$NETWORK" = "auto" ]; then
+  echo "[*] Automatically getting chainID for network"
+  source ops/chain-id.sh
+fi
+
+echo "[*] Populating deploy-gateway script"
+cat scripts/${LIB_OUTPUT} |  cat - scripts/deploy-gateway.template > temp && mv temp scripts/deploy-gateway.ts
+echo "[*] Gateway script in $PWD/scripts/deploy-gateway.ts"
+(npx hardhat deploy-gateway --network ${NETWORK} |  sed -n '/{/,/}/p') > scripts/${GATEWAY_OUTPUT}
+echo "[*] Gateway deployed: " | cat - scripts/${GATEWAY_OUTPUT}
+echo "const GATEWAY =" | cat - scripts/${GATEWAY_OUTPUT}  > temp && mv temp scripts/${GATEWAY_OUTPUT}
+echo "[*] Output gateway address in $PWD/scripts/${GATEWAY_OUTPUT}"

--- a/ops/deploy-libs.sh
+++ b/ops/deploy-libs.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Deploys IPC on an EVM-compatible subnet using hardhat
+set -e
+
+if [ $# -ne 1 ]
+then
+    echo "Expected a single argument with the name of the network to deploy (localnet, calibrationnet, mainnet)"
+    exit 1
+fi
+
+LIB_OUTPUT="libraries.out"
+GATEWAY_OUTPUT="gateway.out"
+NETWORK=$1
+
+if [ "$NETWORK" = "auto" ]; then
+  echo "[*] Automatically getting chainID for network"
+  source ops/chain-id.sh
+fi
+
+echo "[*] Deploying libraries"
+(npx hardhat deploy-libraries --network ${NETWORK} |  sed -n '/{/,/}/p') > scripts/${LIB_OUTPUT}
+echo "const LIBMAP =" | cat - scripts/${LIB_OUTPUT}  > temp && mv temp scripts/${LIB_OUTPUT}
+echo "[*] Output libraries availableo in $PWD/scripts/${LIB_OUTPUT}"

--- a/ops/deploy-reg.sh
+++ b/ops/deploy-reg.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Deploys IPC on an EVM-compatible subnet using hardhat
+set -e
+
+if [ $# -ne 1 ]
+then
+    echo "Expected a single argument with the name of the network to deploy (localnet, calibrationnet, mainnet)"
+    exit 1
+fi
+
+LIB_OUTPUT="libraries.out"
+GATEWAY_OUTPUT="gateway.out"
+NETWORK=$1
+
+if [ "$NETWORK" = "auto" ]; then
+  echo "[*] Automatically getting chainID for network"
+  source ops/chain-id.sh
+fi
+
+
+echo "[*] Populating deploy-registry script"
+cat scripts/${LIB_OUTPUT} | sed '/StorableMsgHelper/d' | cat - scripts/deploy-registry.template > temp && mv temp scripts/deploy-registry.ts
+cat scripts/${GATEWAY_OUTPUT} |  cat - scripts/deploy-registry.ts > temp && mv temp scripts/deploy-registry.ts
+echo "[*] Registry script in $PWD/scripts/deploy-registry.ts"
+npx hardhat run scripts/deploy-registry.ts --network ${NETWORK}
+echo "[*] IPC actors successfully deployed"

--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -2,37 +2,8 @@
 # Deploys IPC on an EVM-compatible subnet using hardhat
 set -e
 
-if [ $# -ne 1 ]
-then
-    echo "Expected a single argument with the name of the network to deploy (localnet, calibrationnet, mainnet)"
-    exit 1
-fi
+source ./ops/deploy-libs.sh "$@"
 
-LIB_OUTPUT="libraries.out"
-GATEWAY_OUTPUT="gateway.out"
-NETWORK=$1
+source ./ops/deploy-gw.sh "$@"
 
-if [ "$NETWORK" = "auto" ]; then
-  echo "[*] Automatically getting chainID for network"
-  source ops/chain-id.sh
-fi
-
-echo "[*] Deploying libraries"
-(npx hardhat deploy-libraries --network ${NETWORK} |  sed -n '/{/,/}/p') > scripts/${LIB_OUTPUT}
-echo "const LIBMAP =" | cat - scripts/${LIB_OUTPUT}  > temp && mv temp scripts/${LIB_OUTPUT}
-echo "[*] Output libraries available in $PWD/scripts/${LIB_OUTPUT}"
-
-echo "[*] Populating deploy-gateway script"
-cat scripts/${LIB_OUTPUT} |  cat - scripts/deploy-gateway.template > temp && mv temp scripts/deploy-gateway.ts
-echo "[*] Gateway script in $PWD/scripts/deploy-gateway.ts"
-(npx hardhat deploy-gateway --network ${NETWORK} |  sed -n '/{/,/}/p') > scripts/${GATEWAY_OUTPUT}
-echo "[*] Gateway deployed: " | cat - scripts/${GATEWAY_OUTPUT}
-echo "const GATEWAY =" | cat - scripts/${GATEWAY_OUTPUT}  > temp && mv temp scripts/${GATEWAY_OUTPUT}
-echo "[*] Output gateway address in $PWD/scripts/${GATEWAY_OUTPUT}"
-
-echo "[*] Populating deploy-registry script"
-cat scripts/${LIB_OUTPUT} | sed '/StorableMsgHelper/d' | cat - scripts/deploy-registry.template > temp && mv temp scripts/deploy-registry.ts
-cat scripts/${GATEWAY_OUTPUT} |  cat - scripts/deploy-registry.ts > temp && mv temp scripts/deploy-registry.ts
-echo "[*] Registry script in $PWD/scripts/deploy-registry.ts"
-npx hardhat run scripts/deploy-registry.ts --network ${NETWORK}
-echo "[*] IPC actors successfully deployed"
+source ./ops/deploy-reg.sh "$@"

--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -2,8 +2,8 @@
 # Deploys IPC on an EVM-compatible subnet using hardhat
 set -e
 
-source ./ops/deploy-libs.sh "$@"
+./ops/deploy-libs.sh "$@"
 
-source ./ops/deploy-gw.sh "$@"
+./ops/deploy-gw.sh "$@"
 
-source ./ops/deploy-reg.sh "$@"
+./ops/deploy-reg.sh "$@"

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,3 +1,3 @@
 {
-    "filter_paths": "lib,test"
+    "filter_paths": "lib,test,node_modules"
 }

--- a/src/errors/IPCErrors.sol
+++ b/src/errors/IPCErrors.sol
@@ -46,3 +46,4 @@ error ValidatorWeightIsZero();
 error ValidatorsAndWeightsLengthMismatch();
 error WorkerAddressInvalid();
 error WrongCheckpointSource();
+error ZeroAddress();

--- a/src/errors/IPCErrors.sol
+++ b/src/errors/IPCErrors.sol
@@ -15,6 +15,7 @@ error EpochNotVotable();
 error GatewayCannotBeZero();
 error InconsistentPrevCheckpoint();
 error InvalidActorAddress();
+error InvalidAmount();
 error InvalidCheckpointEpoch();
 error InvalidCheckpointSource();
 error InvalidCrossMsgDstSubnet();

--- a/src/gateway/GatewayMessengerFacet.sol
+++ b/src/gateway/GatewayMessengerFacet.sol
@@ -12,6 +12,8 @@ import {LibGateway} from "../lib/LibGateway.sol";
 import {StorableMsgHelper} from "../lib/StorableMsgHelper.sol";
 import {FilAddress} from "fevmate/utils/FilAddress.sol";
 
+import "forge-std/console.sol";
+
 contract GatewayMessengerFacet is GatewayActorModifiers {
     using FilAddress for address payable;
     using SubnetIDHelper for SubnetID;
@@ -82,10 +84,13 @@ contract GatewayMessengerFacet is GatewayActorModifiers {
     function _commitCrossMessage(
         CrossMsg memory crossMessage
     ) internal returns (bool shouldBurn, bool shouldDistributeRewards) {
+        console.log(">>>_commitCrossMessage");
         SubnetID memory to = crossMessage.message.to.subnetId;
         if (to.isEmpty()) {
             revert InvalidCrossMsgDstSubnet();
         }
+        console.log(">>>_commitCrossMessage to:", to.toString());
+        console.log(">>>_commitCrossMessage network:", s.networkName.toString());
         // destination is the current network, you are better off with a good old message, no cross needed
         if (to.equals(s.networkName)) {
             revert CannotSendCrossMsgToItself();

--- a/src/gateway/GatewayRouterFacet.sol
+++ b/src/gateway/GatewayRouterFacet.sol
@@ -198,9 +198,9 @@ contract GatewayRouterFacet is GatewayActorModifiers {
         if (crossMsg.message.to.subnetId.isEmpty()) {
             revert InvalidCrossMsgDstSubnet();
         }
-        console.log("_applyMsg");
-        console.log(address(this));
-        console.log(address(this).balance);
+        console.log(">>> _applyMsg");
+        console.log("crossMsg.message.value:", crossMsg.message.value);
+        console.log("msg.value:", msg.value);
         if (crossMsg.message.method == METHOD_SEND) {
             if (crossMsg.message.value > address(this).balance) {
                 revert NotEnoughBalance();

--- a/src/lib/CrossMsgHelper.sol
+++ b/src/lib/CrossMsgHelper.sol
@@ -77,16 +77,19 @@ library CrossMsgHelper {
     function execute(CrossMsg calldata crossMsg) public returns (bytes memory) {
         uint256 value = crossMsg.message.value;
         address recipient = crossMsg.message.to.rawAddress.extractEvmAddress().normalize();
-        console.log("execute");
-        console.log(value);
-        console.log(recipient);
-        console.logBytes4(crossMsg.message.method);
+        console.log(">>>> execute:");
+        console.log("crossMsg.value:", value);
+        console.log("msg.value:", msg.value);
+        console.log("recipient:", recipient);
 
         if (crossMsg.message.method == METHOD_SEND) {
-            console.log("METHOD_SEND");
+            console.log("METHOD_SEND received");
             Address.sendValue(payable(recipient), value);
             return EMPTY_BYTES;
         }
+
+        console.logBytes4(crossMsg.message.method);
+        console.logBytes(crossMsg.message.params);
 
         bytes memory params = crossMsg.message.params;
 
@@ -94,11 +97,18 @@ library CrossMsgHelper {
             params = abi.encode(crossMsg);
         }
 
-        bytes memory data = abi.encodeWithSelector(crossMsg.message.method, params);
+        //bytes memory data = abi.encodeWithSelector(crossMsg.message.method, params);
+        bytes memory data = params;
+        console.logBytes(data);
 
         if (value > 0) {
             return Address.functionCallWithValue({target: recipient, data: data, value: value});
         }
+        console.log("Address.functionCall");
+        console.log("Address this:", address(this));
+        //(address a, uint256 ff) = abi.decode(params, (address,uint256));
+        //console.log("decoded:", a);
+        //console.log("decoded:", ff);
 
         return Address.functionCall(recipient, data);
     }

--- a/src/lib/CrossMsgHelper.sol
+++ b/src/lib/CrossMsgHelper.sol
@@ -10,6 +10,8 @@ import {FvmAddress} from "../structs/FvmAddress.sol";
 import {FilAddress} from "fevmate/utils/FilAddress.sol";
 import {Address} from "openzeppelin-contracts/utils/Address.sol";
 
+import "forge-std/console.sol";
+
 /// @title Helper library for manipulating StorableMsg struct
 /// @author LimeChain team
 library CrossMsgHelper {
@@ -75,8 +77,13 @@ library CrossMsgHelper {
     function execute(CrossMsg calldata crossMsg) public returns (bytes memory) {
         uint256 value = crossMsg.message.value;
         address recipient = crossMsg.message.to.rawAddress.extractEvmAddress().normalize();
+        console.log("execute");
+        console.log(value);
+        console.log(recipient);
+        console.logBytes4(crossMsg.message.method);
 
         if (crossMsg.message.method == METHOD_SEND) {
+            console.log("METHOD_SEND");
             Address.sendValue(payable(recipient), value);
             return EMPTY_BYTES;
         }

--- a/src/lib/CrossMsgHelper.sol
+++ b/src/lib/CrossMsgHelper.sol
@@ -97,8 +97,10 @@ library CrossMsgHelper {
             params = abi.encode(crossMsg);
         }
 
+        bytes memory data = bytes.concat(crossMsg.message.method, params);
+
         //bytes memory data = abi.encodeWithSelector(crossMsg.message.method, params);
-        bytes memory data = params;
+        //bytes memory data = params;
         console.logBytes(data);
 
         if (value > 0) {

--- a/src/lib/LibGateway.sol
+++ b/src/lib/LibGateway.sol
@@ -13,6 +13,8 @@ import {CrossMsgHelper} from "../lib/CrossMsgHelper.sol";
 import {SubnetIDHelper} from "../lib/SubnetIDHelper.sol";
 import {LibVoting} from "../lib/LibVoting.sol";
 
+import "forge-std/console.sol";
+
 library LibGateway {
     using FilAddress for address;
     using FilAddress for address payable;
@@ -38,6 +40,9 @@ library LibGateway {
     /// @notice commit topdown messages for their execution in the subnet. Adds the message to the subnet struct for future execution
     /// @param crossMessage - the cross message to be committed
     function commitTopDownMsg(CrossMsg memory crossMessage) internal {
+        console.log(">>> commitTopDownMsg");
+        console.log("crossMsg.message.value:", crossMessage.message.value);
+        console.log("msg.value:", msg.value);
         GatewayActorStorage storage s = LibGatewayActorStorage.appStorage();
         SubnetID memory subnetId = crossMessage.message.to.subnetId.down(s.networkName);
 

--- a/test/ERC20Helper.sol
+++ b/test/ERC20Helper.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.19;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract DummyERC20 is ERC20, Ownable {
+
+    uint256 public currentSupply = 0;
+
+    constructor(string memory _name, string memory _symbol, uint256 _initialSupply)
+    ERC20(_name, _symbol) {
+        _mint(owner(), _initialSupply);
+    }
+
+    function mint(address _to, uint256 _amount) public onlyOwner {
+        _mint(_to, _amount);
+    }
+}

--- a/test/ERC20Helper.sol
+++ b/test/ERC20Helper.sol
@@ -5,11 +5,9 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract DummyERC20 is ERC20, Ownable {
-
     uint256 public currentSupply = 0;
 
-    constructor(string memory _name, string memory _symbol, uint256 _initialSupply)
-    ERC20(_name, _symbol) {
+    constructor(string memory _name, string memory _symbol, uint256 _initialSupply) ERC20(_name, _symbol) {
         _mint(owner(), _initialSupply);
     }
 

--- a/test/ERC20Helper.sol
+++ b/test/ERC20Helper.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.19;
 import "openzeppelin-contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-contracts/access/Ownable.sol";
 
+import "forge-std/console.sol";
+
 contract DummyERC20 is ERC20, Ownable {
     uint256 public currentSupply = 0;
 
@@ -17,5 +19,13 @@ contract DummyERC20 is ERC20, Ownable {
 
     function mint(address _to, uint256 _amount) public onlyOwner {
         _mint(_to, _amount);
+    }
+    function transfer(address _to,uint256 _amount) override public returns (bool) {
+        console.log(">>>> transfer to:", _to);
+        console.log(">>>> transfer amount:", _amount);
+        if (_amount == 1) {
+            //revert("ddddddd");
+        }
+        return super.transfer(_to, _amount);
     }
 }

--- a/test/ERC20Helper.sol
+++ b/test/ERC20Helper.sol
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "openzeppelin-contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-contracts/access/Ownable.sol";
 
 contract DummyERC20 is ERC20, Ownable {
     uint256 public currentSupply = 0;
 
-    constructor(string memory _name, string memory _symbol, uint256 _initialSupply) ERC20(_name, _symbol) {
+    constructor(
+        string memory _name,
+        string memory _symbol,
+        uint256 _initialSupply
+    ) Ownable(msg.sender) ERC20(_name, _symbol) {
         _mint(owner(), _initialSupply);
     }
 

--- a/test/GatewayDiamond.t.sol
+++ b/test/GatewayDiamond.t.sol
@@ -1479,7 +1479,7 @@ contract GatewayDiamondDeploymentTest is StdInvariant, Test {
 
         Messenger messengerContract = new Messenger(address(gatewayDiamond), gwGetter.getNetworkName());
         vm.deal(address(messengerContract), 10 ether);
-        messengerContract.sendMessage(destinationSubnet, receiver);
+        messengerContract.sendMessage(destinationSubnet, receiver, 10 gwei, 1);
 
         (SubnetID memory id, , uint256 nonce, , uint256 circSupply, ) = getSubnet(address(this));
 

--- a/test/GatewayDiamond.t.sol
+++ b/test/GatewayDiamond.t.sol
@@ -1729,8 +1729,14 @@ contract GatewayDiamondDeploymentTest is StdInvariant, Test {
 
         TokenMessenger tokenMessenger = newTokenMessenger(address(gatewayDiamond));
 
-        //bytes memory payload = abi.encode(user, 1);
-        bytes memory payload = abi.encodeWithSignature("transfer(address,uint256)", user, 1);
+        bytes memory payload = abi.encode(user, 1);
+
+       // bytes memory payload = abi.encodeWithSignature("transfer(address,uint256)", user, 1);
+        //console.log(">>> payload");
+        //console.logBytes(payload);
+        //payload = abi.encode(user, 1);
+        //console.log(">>> payload 2");
+        //console.logBytes(payload);
 
         console.log("!!! user balance before:", dstToken.balanceOf(user));
         vm.startPrank(user);

--- a/test/GatewayDiamond.t.sol
+++ b/test/GatewayDiamond.t.sol
@@ -1464,7 +1464,7 @@ contract GatewayDiamondDeploymentTest is StdInvariant, Test {
     function testGatewayDiamond_SendCrossMessage_MessengerContract() public {
         address caller = vm.addr(100);
         vm.prank(caller);
-        vm.deal(caller, MIN_COLLATERAL_AMOUNT + CROSS_MSG_FEE + 2);
+        vm.deal(caller, MIN_COLLATERAL_AMOUNT + 1 + CROSS_MSG_FEE + 1);
         registerSubnet(MIN_COLLATERAL_AMOUNT, caller);
 
         address receiver = address(this); // callback to reward() method
@@ -1475,11 +1475,10 @@ contract GatewayDiamondDeploymentTest is StdInvariant, Test {
         SubnetID memory destinationSubnet = gwGetter.getNetworkName().createSubnetId(receiver);
         SubnetID memory from = gwGetter.getNetworkName().createSubnetId(caller);
 
-        vm.prank(caller);
-
+        vm.startPrank(caller);
         Messenger messengerContract = new Messenger(address(gatewayDiamond), gwGetter.getNetworkName());
-        vm.deal(address(messengerContract), 10 ether);
-        messengerContract.sendMessage(destinationSubnet, receiver, 10 gwei, 1);
+        messengerContract.sendMessage{value: CROSS_MSG_FEE + 1}(destinationSubnet, receiver, CROSS_MSG_FEE + 1);
+        vm.stopPrank();
 
         (SubnetID memory id, , uint256 nonce, , uint256 circSupply, ) = getSubnet(address(this));
 

--- a/test/GatewayDiamond.t.sol
+++ b/test/GatewayDiamond.t.sol
@@ -1475,27 +1475,14 @@ contract GatewayDiamondDeploymentTest is StdInvariant, Test {
         SubnetID memory destinationSubnet = gwGetter.getNetworkName().createSubnetId(receiver);
         SubnetID memory from = gwGetter.getNetworkName().createSubnetId(caller);
 
-        CrossMsg memory crossMsg = CrossMsg({
-            message: StorableMsg({
-                from: IPCAddress({subnetId: gwGetter.getNetworkName(), rawAddress: FvmAddressHelper.from(caller)}),
-                to: IPCAddress({subnetId: destinationSubnet, rawAddress: FvmAddressHelper.from(receiver)}),
-                value: CROSS_MSG_FEE + 1,
-                nonce: 0,
-                method: METHOD_SEND,
-                params: new bytes(0)
-            }),
-            wrapped: true
-        });
-
         vm.prank(caller);
 
-        Messenger messengerContract = new Messenger(address(gatewayDiamond));
+        Messenger messengerContract = new Messenger(address(gatewayDiamond), gwGetter.getNetworkName());
         vm.deal(address(messengerContract), 10 ether);
-        messengerContract.sendMessage(crossMsg);
+        messengerContract.sendMessage(destinationSubnet, receiver);
 
         (SubnetID memory id, , uint256 nonce, , uint256 circSupply, ) = getSubnet(address(this));
 
-        require(crossMsg.message.applyType(gwGetter.getNetworkName()) == IPCMsgType.TopDown);
         require(id.equals(destinationSubnet));
         require(nonce == 1);
         require(circSupply == CROSS_MSG_FEE + 1);

--- a/test/GatewayDiamond.t.sol
+++ b/test/GatewayDiamond.t.sol
@@ -34,7 +34,7 @@ import {DiamondLoupeFacet} from "../src/diamond/DiamondLoupeFacet.sol";
 import {Messenger} from "../examples/contracts/Messenger.sol";
 import {TokenMessenger} from "../examples/contracts/TokenMessenger.sol";
 import {DummyERC20} from "./ERC20Helper.sol";
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC20} from "openzeppelin-contracts/token/ERC20/ERC20.sol";
 
 contract GatewayDiamondDeploymentTest is StdInvariant, Test {
     using SubnetIDHelper for SubnetID;

--- a/test/TestUtils.sol
+++ b/test/TestUtils.sol
@@ -14,3 +14,4 @@ library TestUtils {
         facetSelectors = abi.decode(res, (bytes4[]));
     }
 }
+

--- a/test/TestUtils.sol
+++ b/test/TestUtils.sol
@@ -14,4 +14,3 @@ library TestUtils {
         facetSelectors = abi.decode(res, (bytes4[]));
     }
 }
-


### PR DESCRIPTION
This PR fixes https://github.com/consensus-shipyard/ipc-solidity-actors/issues/135 by introducing a simple contract that triggers a cross-net message to some subnet when the target function is called. 
