### PR TITLE
Log event

### DIFF
--- a/src/subnet/SubnetActorManagerFacet.sol
+++ b/src/subnet/SubnetActorManagerFacet.sol
@@ -124,6 +124,8 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Reentran
 
         EpochVoteBottomUpSubmission storage voteSubmission = s.epochVoteSubmissions[checkpoint.epoch];
 
+        emit BottomUpCheckpointSubmitted(checkpoint, msg.sender);
+
         // submit the vote
         bool shouldExecuteVote = _submitBottomUpVote({
             voteSubmission: voteSubmission,
@@ -132,11 +134,9 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Reentran
             submitterWeight: s.stake[msg.sender]
         });
 
-        emit BottomUpCheckpointSubmitted(checkpoint, msg.sender);
-
         if (shouldExecuteVote) {
-            _commitCheckpoint(voteSubmission);
             emit BottomUpCheckpointExecuted(checkpoint.epoch, msg.sender);
+            _commitCheckpoint(voteSubmission);
         } else {
             // try to get the next executable epoch from the queue
             (uint64 nextExecutableEpoch, bool isExecutableEpoch) = LibVoting.getNextExecutableEpoch();
@@ -144,8 +144,8 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Reentran
             if (isExecutableEpoch) {
                 EpochVoteBottomUpSubmission storage nextVoteSubmission = s.epochVoteSubmissions[nextExecutableEpoch];
 
-                _commitCheckpoint(nextVoteSubmission);
                 emit NextBottomUpCheckpointExecuted(nextExecutableEpoch, msg.sender);
+                _commitCheckpoint(nextVoteSubmission);
             }
         }
     }

--- a/src/subnet/SubnetActorManagerFacet.sol
+++ b/src/subnet/SubnetActorManagerFacet.sol
@@ -30,8 +30,9 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Reentran
     using EpochVoteSubmissionHelper for EpochVoteSubmission;
     using FvmAddressHelper for FvmAddress;
 
-    event BottomUpCheckpointSubmitted(BottomUpCheckpoint checkpoint, address submitter, bool shouldExecute);
+    event BottomUpCheckpointSubmitted(BottomUpCheckpoint checkpoint, address submitter);
     event BottomUpCheckpointExecuted(uint64 epoch, address submitter);
+    event NextBottomUpCheckpointExecuted(uint64 epoch, address submitter);
 
     /// @notice method that allows a validator to join the subnet
     /// @param netAddr - the network address of the validator
@@ -131,7 +132,7 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Reentran
             submitterWeight: s.stake[msg.sender]
         });
 
-        emit BottomUpCheckpointSubmitted(checkpoint, msg.sender, shouldExecuteVote);
+        emit BottomUpCheckpointSubmitted(checkpoint, msg.sender);
 
         if (shouldExecuteVote) {
             _commitCheckpoint(voteSubmission);
@@ -144,7 +145,7 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Reentran
                 EpochVoteBottomUpSubmission storage nextVoteSubmission = s.epochVoteSubmissions[nextExecutableEpoch];
 
                 _commitCheckpoint(nextVoteSubmission);
-                emit BottomUpCheckpointExecuted(checkpoint.epoch, msg.sender);
+                emit NextBottomUpCheckpointExecuted(nextExecutableEpoch, msg.sender);
             }
         }
     }

--- a/src/subnet/SubnetActorManagerFacet.sol
+++ b/src/subnet/SubnetActorManagerFacet.sol
@@ -30,15 +30,8 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Reentran
     using EpochVoteSubmissionHelper for EpochVoteSubmission;
     using FvmAddressHelper for FvmAddress;
 
-    event BottomUpCheckpointSubmitted(
-        BottomUpCheckpoint checkpoint,
-        address submitter,
-        bool shouldExecute
-    );
-    event BottomUpCheckpointExecuted(
-        uint64 epoch,
-        address submitter
-    );
+    event BottomUpCheckpointSubmitted(BottomUpCheckpoint checkpoint, address submitter, bool shouldExecute);
+    event BottomUpCheckpointExecuted(uint64 epoch, address submitter);
 
     /// @notice method that allows a validator to join the subnet
     /// @param netAddr - the network address of the validator
@@ -143,7 +136,6 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Reentran
         if (shouldExecuteVote) {
             _commitCheckpoint(voteSubmission);
             emit BottomUpCheckpointExecuted(checkpoint.epoch, msg.sender);
-
         } else {
             // try to get the next executable epoch from the queue
             (uint64 nextExecutableEpoch, bool isExecutableEpoch) = LibVoting.getNextExecutableEpoch();


### PR DESCRIPTION
# Motivation
Currently, the manager is quite difficult to debug as it does not expose intermediate states nor exposes events. Whenever the voting goes wrong, it is almost impossible to debug where goes wrong. This PR attempts to expose internal events so that we can track what is going on.

# Solution
Adding `BottomUpCheckpointSubmitted` and `BottomUpCheckpointExecuted` events to expose the internal process.