### PR TITLE
Arrange top down messages by height

### DIFF
--- a/.storage-layouts/GatewayActorModifiers.json
+++ b/.storage-layouts/GatewayActorModifiers.json
@@ -1,12 +1,12 @@
 {
   "storage": [
     {
-      "astId": 7924,
+      "astId": 8362,
       "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
       "label": "s",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(GatewayActorStorage)7912_storage"
+      "type": "t_struct(GatewayActorStorage)8350_storage"
     }
   ],
   "types": {
@@ -27,14 +27,14 @@
       "label": "bytes32[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(ChildCheck)9661_storage)dyn_storage": {
-      "base": "t_struct(ChildCheck)9661_storage",
+    "t_array(t_struct(ChildCheck)10008_storage)dyn_storage": {
+      "base": "t_struct(ChildCheck)10008_storage",
       "encoding": "dynamic_array",
       "label": "struct ChildCheck[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(CrossMsg)9667_storage)dyn_storage": {
-      "base": "t_struct(CrossMsg)9667_storage",
+    "t_array(t_struct(CrossMsg)10014_storage)dyn_storage": {
+      "base": "t_struct(CrossMsg)10014_storage",
       "encoding": "dynamic_array",
       "label": "struct CrossMsg[]",
       "numberOfBytes": "32"
@@ -65,7 +65,7 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_enum(Status)3598": {
+    "t_enum(Status)4025": {
       "encoding": "inplace",
       "label": "enum Status",
       "numberOfBytes": "1"
@@ -105,26 +105,33 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_bytes32,t_bool)"
     },
-    "t_mapping(t_bytes32,t_struct(CrossMsg)9667_storage)": {
+    "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)10014_storage)dyn_storage))": {
+      "encoding": "mapping",
+      "key": "t_bytes32",
+      "label": "mapping(bytes32 => mapping(uint256 => struct CrossMsg[]))",
+      "numberOfBytes": "32",
+      "value": "t_mapping(t_uint256,t_array(t_struct(CrossMsg)10014_storage)dyn_storage)"
+    },
+    "t_mapping(t_bytes32,t_struct(CrossMsg)10014_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct CrossMsg)",
       "numberOfBytes": "32",
-      "value": "t_struct(CrossMsg)9667_storage"
+      "value": "t_struct(CrossMsg)10014_storage"
     },
-    "t_mapping(t_bytes32,t_struct(Subnet)9796_storage)": {
+    "t_mapping(t_bytes32,t_struct(Subnet)10139_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct Subnet)",
       "numberOfBytes": "32",
-      "value": "t_struct(Subnet)9796_storage"
+      "value": "t_struct(Subnet)10139_storage"
     },
-    "t_mapping(t_bytes32,t_struct(TopDownCheckpoint)9654_storage)": {
+    "t_mapping(t_bytes32,t_struct(TopDownCheckpoint)10001_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct TopDownCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(TopDownCheckpoint)9654_storage"
+      "value": "t_struct(TopDownCheckpoint)10001_storage"
     },
     "t_mapping(t_bytes32,t_uint256)": {
       "encoding": "mapping",
@@ -132,6 +139,13 @@
       "label": "mapping(bytes32 => uint256)",
       "numberOfBytes": "32",
       "value": "t_uint256"
+    },
+    "t_mapping(t_uint256,t_array(t_struct(CrossMsg)10014_storage)dyn_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint256",
+      "label": "mapping(uint256 => struct CrossMsg[])",
+      "numberOfBytes": "32",
+      "value": "t_array(t_struct(CrossMsg)10014_storage)dyn_storage"
     },
     "t_mapping(t_uint256,t_mapping(t_address,t_bool))": {
       "encoding": "mapping",
@@ -168,34 +182,34 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_bytes32,t_mapping(t_bytes32,t_bool))"
     },
-    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9647_storage)": {
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9994_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)9647_storage"
+      "value": "t_struct(BottomUpCheckpoint)9994_storage"
     },
-    "t_mapping(t_uint64,t_struct(EpochVoteTopDownSubmission)9715_storage)": {
+    "t_mapping(t_uint64,t_struct(EpochVoteTopDownSubmission)10062_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct EpochVoteTopDownSubmission)",
       "numberOfBytes": "32",
-      "value": "t_struct(EpochVoteTopDownSubmission)9715_storage"
+      "value": "t_struct(EpochVoteTopDownSubmission)10062_storage"
     },
-    "t_struct(BottomUpCheckpoint)9647_storage": {
+    "t_struct(BottomUpCheckpoint)9994_storage": {
       "encoding": "inplace",
       "label": "struct BottomUpCheckpoint",
       "members": [
         {
-          "astId": 9630,
+          "astId": 9977,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "source",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9772_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9632,
+          "astId": 9979,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "epoch",
           "offset": 0,
@@ -203,7 +217,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9634,
+          "astId": 9981,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "fee",
           "offset": 0,
@@ -211,23 +225,23 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9638,
+          "astId": 9985,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "crossMsgs",
           "offset": 0,
           "slot": "4",
-          "type": "t_array(t_struct(CrossMsg)9667_storage)dyn_storage"
+          "type": "t_array(t_struct(CrossMsg)10014_storage)dyn_storage"
         },
         {
-          "astId": 9642,
+          "astId": 9989,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "children",
           "offset": 0,
           "slot": "5",
-          "type": "t_array(t_struct(ChildCheck)9661_storage)dyn_storage"
+          "type": "t_array(t_struct(ChildCheck)10008_storage)dyn_storage"
         },
         {
-          "astId": 9644,
+          "astId": 9991,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "prevHash",
           "offset": 0,
@@ -235,7 +249,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 9646,
+          "astId": 9993,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "proof",
           "offset": 0,
@@ -245,20 +259,20 @@
       ],
       "numberOfBytes": "256"
     },
-    "t_struct(ChildCheck)9661_storage": {
+    "t_struct(ChildCheck)10008_storage": {
       "encoding": "inplace",
       "label": "struct ChildCheck",
       "members": [
         {
-          "astId": 9657,
+          "astId": 10004,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "source",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9772_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9660,
+          "astId": 10007,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "checks",
           "offset": 0,
@@ -268,20 +282,20 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(CrossMsg)9667_storage": {
+    "t_struct(CrossMsg)10014_storage": {
       "encoding": "inplace",
       "label": "struct CrossMsg",
       "members": [
         {
-          "astId": 9664,
+          "astId": 10011,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "message",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(StorableMsg)9682_storage"
+          "type": "t_struct(StorableMsg)10029_storage"
         },
         {
-          "astId": 9666,
+          "astId": 10013,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "wrapped",
           "offset": 0,
@@ -291,12 +305,12 @@
       ],
       "numberOfBytes": "384"
     },
-    "t_struct(EpochVoteSubmission)9706_storage": {
+    "t_struct(EpochVoteSubmission)10053_storage": {
       "encoding": "inplace",
       "label": "struct EpochVoteSubmission",
       "members": [
         {
-          "astId": 9689,
+          "astId": 10036,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "nonce",
           "offset": 0,
@@ -304,7 +318,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9691,
+          "astId": 10038,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "totalSubmissionWeight",
           "offset": 0,
@@ -312,7 +326,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9693,
+          "astId": 10040,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "mostVotedSubmission",
           "offset": 0,
@@ -320,7 +334,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 9699,
+          "astId": 10046,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "submitters",
           "offset": 0,
@@ -328,7 +342,7 @@
           "type": "t_mapping(t_uint256,t_mapping(t_address,t_bool))"
         },
         {
-          "astId": 9705,
+          "astId": 10052,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "submissionWeights",
           "offset": 0,
@@ -338,35 +352,35 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(EpochVoteTopDownSubmission)9715_storage": {
+    "t_struct(EpochVoteTopDownSubmission)10062_storage": {
       "encoding": "inplace",
       "label": "struct EpochVoteTopDownSubmission",
       "members": [
         {
-          "astId": 9709,
+          "astId": 10056,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "vote",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(EpochVoteSubmission)9706_storage"
+          "type": "t_struct(EpochVoteSubmission)10053_storage"
         },
         {
-          "astId": 9714,
+          "astId": 10061,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "submissions",
           "offset": 0,
           "slot": "5",
-          "type": "t_mapping(t_bytes32,t_struct(TopDownCheckpoint)9654_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(TopDownCheckpoint)10001_storage)"
         }
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(FvmAddress)9746_storage": {
+    "t_struct(FvmAddress)10093_storage": {
       "encoding": "inplace",
       "label": "struct FvmAddress",
       "members": [
         {
-          "astId": 9743,
+          "astId": 10090,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "addrType",
           "offset": 0,
@@ -374,7 +388,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 9745,
+          "astId": 10092,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "payload",
           "offset": 0,
@@ -384,210 +398,218 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(GatewayActorStorage)7912_storage": {
+    "t_struct(GatewayActorStorage)8350_storage": {
       "encoding": "inplace",
       "label": "struct GatewayActorStorage",
       "members": [
         {
-          "astId": 7831,
+          "astId": 8260,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "subnets",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_bytes32,t_struct(Subnet)9796_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(Subnet)10139_storage)"
         },
         {
-          "astId": 7837,
+          "astId": 8269,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "topDownMsgs",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)10014_storage)dyn_storage))"
+        },
+        {
+          "astId": 8275,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "postbox",
           "offset": 0,
-          "slot": "1",
-          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)9667_storage)"
+          "slot": "2",
+          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)10014_storage)"
         },
         {
-          "astId": 7843,
+          "astId": 8281,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpCheckpoints",
           "offset": 0,
-          "slot": "2",
-          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9647_storage)"
+          "slot": "3",
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9994_storage)"
         },
         {
-          "astId": 7850,
+          "astId": 8288,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "validatorSet",
           "offset": 0,
-          "slot": "3",
+          "slot": "4",
           "type": "t_mapping(t_uint256,t_mapping(t_address,t_uint256))"
         },
         {
-          "astId": 7859,
+          "astId": 8297,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "children",
           "offset": 0,
-          "slot": "4",
+          "slot": "5",
           "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_array(t_uint256)2_storage))"
         },
         {
-          "astId": 7868,
+          "astId": 8306,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "checks",
           "offset": 0,
-          "slot": "5",
+          "slot": "6",
           "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_mapping(t_bytes32,t_bool)))"
         },
         {
-          "astId": 7874,
+          "astId": 8312,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "epochVoteSubmissions",
           "offset": 0,
-          "slot": "6",
-          "type": "t_mapping(t_uint64,t_struct(EpochVoteTopDownSubmission)9715_storage)"
+          "slot": "7",
+          "type": "t_mapping(t_uint64,t_struct(EpochVoteTopDownSubmission)10062_storage)"
         },
         {
-          "astId": 7878,
+          "astId": 8316,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "subnetKeys",
           "offset": 0,
-          "slot": "7",
+          "slot": "8",
           "type": "t_array(t_bytes32)dyn_storage"
         },
         {
-          "astId": 7882,
+          "astId": 8320,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "networkName",
           "offset": 0,
-          "slot": "8",
-          "type": "t_struct(SubnetID)9772_storage"
+          "slot": "9",
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 7885,
+          "astId": 8323,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "minStake",
-          "offset": 0,
-          "slot": "10",
-          "type": "t_uint256"
-        },
-        {
-          "astId": 7888,
-          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-          "label": "validatorNonce",
           "offset": 0,
           "slot": "11",
           "type": "t_uint256"
         },
         {
-          "astId": 7891,
+          "astId": 8326,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-          "label": "crossMsgFee",
+          "label": "validatorNonce",
           "offset": 0,
           "slot": "12",
           "type": "t_uint256"
         },
         {
-          "astId": 7894,
+          "astId": 8329,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-          "label": "totalWeight",
+          "label": "crossMsgFee",
           "offset": 0,
           "slot": "13",
           "type": "t_uint256"
         },
         {
-          "astId": 7897,
+          "astId": 8332,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "totalWeight",
+          "offset": 0,
+          "slot": "14",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 8335,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpNonce",
           "offset": 0,
-          "slot": "14",
+          "slot": "15",
           "type": "t_uint64"
         },
         {
-          "astId": 7900,
+          "astId": 8338,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "appliedTopDownNonce",
           "offset": 8,
-          "slot": "14",
+          "slot": "15",
           "type": "t_uint64"
         },
         {
-          "astId": 7903,
+          "astId": 8341,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "topDownCheckPeriod",
           "offset": 16,
-          "slot": "14",
+          "slot": "15",
           "type": "t_uint64"
         },
         {
-          "astId": 7906,
+          "astId": 8344,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "totalSubnets",
           "offset": 24,
-          "slot": "14",
+          "slot": "15",
           "type": "t_uint64"
         },
         {
-          "astId": 7908,
+          "astId": 8346,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpCheckPeriod",
           "offset": 0,
-          "slot": "15",
+          "slot": "16",
           "type": "t_uint64"
         },
         {
-          "astId": 7911,
+          "astId": 8349,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "initialized",
           "offset": 8,
-          "slot": "15",
+          "slot": "16",
           "type": "t_bool"
         }
       ],
-      "numberOfBytes": "512"
+      "numberOfBytes": "544"
     },
-    "t_struct(IPCAddress)9803_storage": {
+    "t_struct(IPCAddress)10146_storage": {
       "encoding": "inplace",
       "label": "struct IPCAddress",
       "members": [
         {
-          "astId": 9799,
+          "astId": 10142,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "subnetId",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9772_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9802,
+          "astId": 10145,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "rawAddress",
           "offset": 0,
           "slot": "2",
-          "type": "t_struct(FvmAddress)9746_storage"
+          "type": "t_struct(FvmAddress)10093_storage"
         }
       ],
       "numberOfBytes": "128"
     },
-    "t_struct(StorableMsg)9682_storage": {
+    "t_struct(StorableMsg)10029_storage": {
       "encoding": "inplace",
       "label": "struct StorableMsg",
       "members": [
         {
-          "astId": 9670,
+          "astId": 10017,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "from",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(IPCAddress)9803_storage"
+          "type": "t_struct(IPCAddress)10146_storage"
         },
         {
-          "astId": 9673,
+          "astId": 10020,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "to",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(IPCAddress)9803_storage"
+          "type": "t_struct(IPCAddress)10146_storage"
         },
         {
-          "astId": 9675,
+          "astId": 10022,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "value",
           "offset": 0,
@@ -595,7 +617,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9677,
+          "astId": 10024,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "nonce",
           "offset": 0,
@@ -603,7 +625,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9679,
+          "astId": 10026,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "method",
           "offset": 8,
@@ -611,7 +633,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 9681,
+          "astId": 10028,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "params",
           "offset": 0,
@@ -621,12 +643,12 @@
       ],
       "numberOfBytes": "352"
     },
-    "t_struct(Subnet)9796_storage": {
+    "t_struct(Subnet)10139_storage": {
       "encoding": "inplace",
       "label": "struct Subnet",
       "members": [
         {
-          "astId": 9774,
+          "astId": 10121,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "stake",
           "offset": 0,
@@ -634,7 +656,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9776,
+          "astId": 10123,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "genesisEpoch",
           "offset": 0,
@@ -642,7 +664,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9778,
+          "astId": 10125,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "circSupply",
           "offset": 0,
@@ -650,7 +672,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9780,
+          "astId": 10127,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "topDownNonce",
           "offset": 0,
@@ -658,7 +680,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9782,
+          "astId": 10129,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "appliedBottomUpNonce",
           "offset": 8,
@@ -666,46 +688,38 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9785,
+          "astId": 10132,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "status",
           "offset": 16,
           "slot": "3",
-          "type": "t_enum(Status)3598"
+          "type": "t_enum(Status)4025"
         },
         {
-          "astId": 9788,
+          "astId": 10135,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "id",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(SubnetID)9772_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9791,
+          "astId": 10138,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "prevCheckpoint",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(BottomUpCheckpoint)9647_storage"
-        },
-        {
-          "astId": 9795,
-          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-          "label": "topDownMsgs",
-          "offset": 0,
-          "slot": "14",
-          "type": "t_array(t_struct(CrossMsg)9667_storage)dyn_storage"
+          "type": "t_struct(BottomUpCheckpoint)9994_storage"
         }
       ],
-      "numberOfBytes": "480"
+      "numberOfBytes": "448"
     },
-    "t_struct(SubnetID)9772_storage": {
+    "t_struct(SubnetID)10119_storage": {
       "encoding": "inplace",
       "label": "struct SubnetID",
       "members": [
         {
-          "astId": 9767,
+          "astId": 10114,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "root",
           "offset": 0,
@@ -713,7 +727,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9771,
+          "astId": 10118,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "route",
           "offset": 0,
@@ -723,12 +737,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(TopDownCheckpoint)9654_storage": {
+    "t_struct(TopDownCheckpoint)10001_storage": {
       "encoding": "inplace",
       "label": "struct TopDownCheckpoint",
       "members": [
         {
-          "astId": 9649,
+          "astId": 9996,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "epoch",
           "offset": 0,
@@ -736,12 +750,12 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9653,
+          "astId": 10000,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "topDownMsgs",
           "offset": 0,
           "slot": "1",
-          "type": "t_array(t_struct(CrossMsg)9667_storage)dyn_storage"
+          "type": "t_array(t_struct(CrossMsg)10014_storage)dyn_storage"
         }
       ],
       "numberOfBytes": "64"

--- a/.storage-layouts/GatewayDiamond.json
+++ b/.storage-layouts/GatewayDiamond.json
@@ -1,12 +1,12 @@
 {
   "storage": [
     {
-      "astId": 2790,
+      "astId": 2783,
       "contract": "src/GatewayDiamond.sol:GatewayDiamond",
       "label": "s",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(GatewayActorStorage)7912_storage"
+      "type": "t_struct(GatewayActorStorage)8350_storage"
     }
   ],
   "types": {
@@ -27,14 +27,14 @@
       "label": "bytes32[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(ChildCheck)9661_storage)dyn_storage": {
-      "base": "t_struct(ChildCheck)9661_storage",
+    "t_array(t_struct(ChildCheck)10008_storage)dyn_storage": {
+      "base": "t_struct(ChildCheck)10008_storage",
       "encoding": "dynamic_array",
       "label": "struct ChildCheck[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(CrossMsg)9667_storage)dyn_storage": {
-      "base": "t_struct(CrossMsg)9667_storage",
+    "t_array(t_struct(CrossMsg)10014_storage)dyn_storage": {
+      "base": "t_struct(CrossMsg)10014_storage",
       "encoding": "dynamic_array",
       "label": "struct CrossMsg[]",
       "numberOfBytes": "32"
@@ -65,7 +65,7 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_enum(Status)3598": {
+    "t_enum(Status)4025": {
       "encoding": "inplace",
       "label": "enum Status",
       "numberOfBytes": "1"
@@ -105,26 +105,33 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_bytes32,t_bool)"
     },
-    "t_mapping(t_bytes32,t_struct(CrossMsg)9667_storage)": {
+    "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)10014_storage)dyn_storage))": {
+      "encoding": "mapping",
+      "key": "t_bytes32",
+      "label": "mapping(bytes32 => mapping(uint256 => struct CrossMsg[]))",
+      "numberOfBytes": "32",
+      "value": "t_mapping(t_uint256,t_array(t_struct(CrossMsg)10014_storage)dyn_storage)"
+    },
+    "t_mapping(t_bytes32,t_struct(CrossMsg)10014_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct CrossMsg)",
       "numberOfBytes": "32",
-      "value": "t_struct(CrossMsg)9667_storage"
+      "value": "t_struct(CrossMsg)10014_storage"
     },
-    "t_mapping(t_bytes32,t_struct(Subnet)9796_storage)": {
+    "t_mapping(t_bytes32,t_struct(Subnet)10139_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct Subnet)",
       "numberOfBytes": "32",
-      "value": "t_struct(Subnet)9796_storage"
+      "value": "t_struct(Subnet)10139_storage"
     },
-    "t_mapping(t_bytes32,t_struct(TopDownCheckpoint)9654_storage)": {
+    "t_mapping(t_bytes32,t_struct(TopDownCheckpoint)10001_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct TopDownCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(TopDownCheckpoint)9654_storage"
+      "value": "t_struct(TopDownCheckpoint)10001_storage"
     },
     "t_mapping(t_bytes32,t_uint256)": {
       "encoding": "mapping",
@@ -132,6 +139,13 @@
       "label": "mapping(bytes32 => uint256)",
       "numberOfBytes": "32",
       "value": "t_uint256"
+    },
+    "t_mapping(t_uint256,t_array(t_struct(CrossMsg)10014_storage)dyn_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint256",
+      "label": "mapping(uint256 => struct CrossMsg[])",
+      "numberOfBytes": "32",
+      "value": "t_array(t_struct(CrossMsg)10014_storage)dyn_storage"
     },
     "t_mapping(t_uint256,t_mapping(t_address,t_bool))": {
       "encoding": "mapping",
@@ -168,34 +182,34 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_bytes32,t_mapping(t_bytes32,t_bool))"
     },
-    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9647_storage)": {
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9994_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)9647_storage"
+      "value": "t_struct(BottomUpCheckpoint)9994_storage"
     },
-    "t_mapping(t_uint64,t_struct(EpochVoteTopDownSubmission)9715_storage)": {
+    "t_mapping(t_uint64,t_struct(EpochVoteTopDownSubmission)10062_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct EpochVoteTopDownSubmission)",
       "numberOfBytes": "32",
-      "value": "t_struct(EpochVoteTopDownSubmission)9715_storage"
+      "value": "t_struct(EpochVoteTopDownSubmission)10062_storage"
     },
-    "t_struct(BottomUpCheckpoint)9647_storage": {
+    "t_struct(BottomUpCheckpoint)9994_storage": {
       "encoding": "inplace",
       "label": "struct BottomUpCheckpoint",
       "members": [
         {
-          "astId": 9630,
+          "astId": 9977,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "source",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9772_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9632,
+          "astId": 9979,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "epoch",
           "offset": 0,
@@ -203,7 +217,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9634,
+          "astId": 9981,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "fee",
           "offset": 0,
@@ -211,23 +225,23 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9638,
+          "astId": 9985,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "crossMsgs",
           "offset": 0,
           "slot": "4",
-          "type": "t_array(t_struct(CrossMsg)9667_storage)dyn_storage"
+          "type": "t_array(t_struct(CrossMsg)10014_storage)dyn_storage"
         },
         {
-          "astId": 9642,
+          "astId": 9989,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "children",
           "offset": 0,
           "slot": "5",
-          "type": "t_array(t_struct(ChildCheck)9661_storage)dyn_storage"
+          "type": "t_array(t_struct(ChildCheck)10008_storage)dyn_storage"
         },
         {
-          "astId": 9644,
+          "astId": 9991,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "prevHash",
           "offset": 0,
@@ -235,7 +249,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 9646,
+          "astId": 9993,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "proof",
           "offset": 0,
@@ -245,20 +259,20 @@
       ],
       "numberOfBytes": "256"
     },
-    "t_struct(ChildCheck)9661_storage": {
+    "t_struct(ChildCheck)10008_storage": {
       "encoding": "inplace",
       "label": "struct ChildCheck",
       "members": [
         {
-          "astId": 9657,
+          "astId": 10004,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "source",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9772_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9660,
+          "astId": 10007,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "checks",
           "offset": 0,
@@ -268,20 +282,20 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(CrossMsg)9667_storage": {
+    "t_struct(CrossMsg)10014_storage": {
       "encoding": "inplace",
       "label": "struct CrossMsg",
       "members": [
         {
-          "astId": 9664,
+          "astId": 10011,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "message",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(StorableMsg)9682_storage"
+          "type": "t_struct(StorableMsg)10029_storage"
         },
         {
-          "astId": 9666,
+          "astId": 10013,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "wrapped",
           "offset": 0,
@@ -291,12 +305,12 @@
       ],
       "numberOfBytes": "384"
     },
-    "t_struct(EpochVoteSubmission)9706_storage": {
+    "t_struct(EpochVoteSubmission)10053_storage": {
       "encoding": "inplace",
       "label": "struct EpochVoteSubmission",
       "members": [
         {
-          "astId": 9689,
+          "astId": 10036,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "nonce",
           "offset": 0,
@@ -304,7 +318,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9691,
+          "astId": 10038,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "totalSubmissionWeight",
           "offset": 0,
@@ -312,7 +326,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9693,
+          "astId": 10040,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "mostVotedSubmission",
           "offset": 0,
@@ -320,7 +334,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 9699,
+          "astId": 10046,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "submitters",
           "offset": 0,
@@ -328,7 +342,7 @@
           "type": "t_mapping(t_uint256,t_mapping(t_address,t_bool))"
         },
         {
-          "astId": 9705,
+          "astId": 10052,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "submissionWeights",
           "offset": 0,
@@ -338,35 +352,35 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(EpochVoteTopDownSubmission)9715_storage": {
+    "t_struct(EpochVoteTopDownSubmission)10062_storage": {
       "encoding": "inplace",
       "label": "struct EpochVoteTopDownSubmission",
       "members": [
         {
-          "astId": 9709,
+          "astId": 10056,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "vote",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(EpochVoteSubmission)9706_storage"
+          "type": "t_struct(EpochVoteSubmission)10053_storage"
         },
         {
-          "astId": 9714,
+          "astId": 10061,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "submissions",
           "offset": 0,
           "slot": "5",
-          "type": "t_mapping(t_bytes32,t_struct(TopDownCheckpoint)9654_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(TopDownCheckpoint)10001_storage)"
         }
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(FvmAddress)9746_storage": {
+    "t_struct(FvmAddress)10093_storage": {
       "encoding": "inplace",
       "label": "struct FvmAddress",
       "members": [
         {
-          "astId": 9743,
+          "astId": 10090,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "addrType",
           "offset": 0,
@@ -374,7 +388,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 9745,
+          "astId": 10092,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "payload",
           "offset": 0,
@@ -384,210 +398,218 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(GatewayActorStorage)7912_storage": {
+    "t_struct(GatewayActorStorage)8350_storage": {
       "encoding": "inplace",
       "label": "struct GatewayActorStorage",
       "members": [
         {
-          "astId": 7831,
+          "astId": 8260,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "subnets",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_bytes32,t_struct(Subnet)9796_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(Subnet)10139_storage)"
         },
         {
-          "astId": 7837,
+          "astId": 8269,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "topDownMsgs",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)10014_storage)dyn_storage))"
+        },
+        {
+          "astId": 8275,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "postbox",
           "offset": 0,
-          "slot": "1",
-          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)9667_storage)"
+          "slot": "2",
+          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)10014_storage)"
         },
         {
-          "astId": 7843,
+          "astId": 8281,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpCheckpoints",
           "offset": 0,
-          "slot": "2",
-          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9647_storage)"
+          "slot": "3",
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9994_storage)"
         },
         {
-          "astId": 7850,
+          "astId": 8288,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "validatorSet",
           "offset": 0,
-          "slot": "3",
+          "slot": "4",
           "type": "t_mapping(t_uint256,t_mapping(t_address,t_uint256))"
         },
         {
-          "astId": 7859,
+          "astId": 8297,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "children",
           "offset": 0,
-          "slot": "4",
+          "slot": "5",
           "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_array(t_uint256)2_storage))"
         },
         {
-          "astId": 7868,
+          "astId": 8306,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "checks",
           "offset": 0,
-          "slot": "5",
+          "slot": "6",
           "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_mapping(t_bytes32,t_bool)))"
         },
         {
-          "astId": 7874,
+          "astId": 8312,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "epochVoteSubmissions",
           "offset": 0,
-          "slot": "6",
-          "type": "t_mapping(t_uint64,t_struct(EpochVoteTopDownSubmission)9715_storage)"
+          "slot": "7",
+          "type": "t_mapping(t_uint64,t_struct(EpochVoteTopDownSubmission)10062_storage)"
         },
         {
-          "astId": 7878,
+          "astId": 8316,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "subnetKeys",
           "offset": 0,
-          "slot": "7",
+          "slot": "8",
           "type": "t_array(t_bytes32)dyn_storage"
         },
         {
-          "astId": 7882,
+          "astId": 8320,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "networkName",
           "offset": 0,
-          "slot": "8",
-          "type": "t_struct(SubnetID)9772_storage"
+          "slot": "9",
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 7885,
+          "astId": 8323,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "minStake",
-          "offset": 0,
-          "slot": "10",
-          "type": "t_uint256"
-        },
-        {
-          "astId": 7888,
-          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-          "label": "validatorNonce",
           "offset": 0,
           "slot": "11",
           "type": "t_uint256"
         },
         {
-          "astId": 7891,
+          "astId": 8326,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-          "label": "crossMsgFee",
+          "label": "validatorNonce",
           "offset": 0,
           "slot": "12",
           "type": "t_uint256"
         },
         {
-          "astId": 7894,
+          "astId": 8329,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-          "label": "totalWeight",
+          "label": "crossMsgFee",
           "offset": 0,
           "slot": "13",
           "type": "t_uint256"
         },
         {
-          "astId": 7897,
+          "astId": 8332,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "totalWeight",
+          "offset": 0,
+          "slot": "14",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 8335,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpNonce",
           "offset": 0,
-          "slot": "14",
+          "slot": "15",
           "type": "t_uint64"
         },
         {
-          "astId": 7900,
+          "astId": 8338,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "appliedTopDownNonce",
           "offset": 8,
-          "slot": "14",
+          "slot": "15",
           "type": "t_uint64"
         },
         {
-          "astId": 7903,
+          "astId": 8341,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "topDownCheckPeriod",
           "offset": 16,
-          "slot": "14",
+          "slot": "15",
           "type": "t_uint64"
         },
         {
-          "astId": 7906,
+          "astId": 8344,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "totalSubnets",
           "offset": 24,
-          "slot": "14",
+          "slot": "15",
           "type": "t_uint64"
         },
         {
-          "astId": 7908,
+          "astId": 8346,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpCheckPeriod",
           "offset": 0,
-          "slot": "15",
+          "slot": "16",
           "type": "t_uint64"
         },
         {
-          "astId": 7911,
+          "astId": 8349,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "initialized",
           "offset": 8,
-          "slot": "15",
+          "slot": "16",
           "type": "t_bool"
         }
       ],
-      "numberOfBytes": "512"
+      "numberOfBytes": "544"
     },
-    "t_struct(IPCAddress)9803_storage": {
+    "t_struct(IPCAddress)10146_storage": {
       "encoding": "inplace",
       "label": "struct IPCAddress",
       "members": [
         {
-          "astId": 9799,
+          "astId": 10142,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "subnetId",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9772_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9802,
+          "astId": 10145,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "rawAddress",
           "offset": 0,
           "slot": "2",
-          "type": "t_struct(FvmAddress)9746_storage"
+          "type": "t_struct(FvmAddress)10093_storage"
         }
       ],
       "numberOfBytes": "128"
     },
-    "t_struct(StorableMsg)9682_storage": {
+    "t_struct(StorableMsg)10029_storage": {
       "encoding": "inplace",
       "label": "struct StorableMsg",
       "members": [
         {
-          "astId": 9670,
+          "astId": 10017,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "from",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(IPCAddress)9803_storage"
+          "type": "t_struct(IPCAddress)10146_storage"
         },
         {
-          "astId": 9673,
+          "astId": 10020,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "to",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(IPCAddress)9803_storage"
+          "type": "t_struct(IPCAddress)10146_storage"
         },
         {
-          "astId": 9675,
+          "astId": 10022,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "value",
           "offset": 0,
@@ -595,7 +617,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9677,
+          "astId": 10024,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "nonce",
           "offset": 0,
@@ -603,7 +625,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9679,
+          "astId": 10026,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "method",
           "offset": 8,
@@ -611,7 +633,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 9681,
+          "astId": 10028,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "params",
           "offset": 0,
@@ -621,12 +643,12 @@
       ],
       "numberOfBytes": "352"
     },
-    "t_struct(Subnet)9796_storage": {
+    "t_struct(Subnet)10139_storage": {
       "encoding": "inplace",
       "label": "struct Subnet",
       "members": [
         {
-          "astId": 9774,
+          "astId": 10121,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "stake",
           "offset": 0,
@@ -634,7 +656,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9776,
+          "astId": 10123,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "genesisEpoch",
           "offset": 0,
@@ -642,7 +664,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9778,
+          "astId": 10125,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "circSupply",
           "offset": 0,
@@ -650,7 +672,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9780,
+          "astId": 10127,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "topDownNonce",
           "offset": 0,
@@ -658,7 +680,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9782,
+          "astId": 10129,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "appliedBottomUpNonce",
           "offset": 8,
@@ -666,46 +688,38 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9785,
+          "astId": 10132,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "status",
           "offset": 16,
           "slot": "3",
-          "type": "t_enum(Status)3598"
+          "type": "t_enum(Status)4025"
         },
         {
-          "astId": 9788,
+          "astId": 10135,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "id",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(SubnetID)9772_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9791,
+          "astId": 10138,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "prevCheckpoint",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(BottomUpCheckpoint)9647_storage"
-        },
-        {
-          "astId": 9795,
-          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-          "label": "topDownMsgs",
-          "offset": 0,
-          "slot": "14",
-          "type": "t_array(t_struct(CrossMsg)9667_storage)dyn_storage"
+          "type": "t_struct(BottomUpCheckpoint)9994_storage"
         }
       ],
-      "numberOfBytes": "480"
+      "numberOfBytes": "448"
     },
-    "t_struct(SubnetID)9772_storage": {
+    "t_struct(SubnetID)10119_storage": {
       "encoding": "inplace",
       "label": "struct SubnetID",
       "members": [
         {
-          "astId": 9767,
+          "astId": 10114,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "root",
           "offset": 0,
@@ -713,7 +727,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9771,
+          "astId": 10118,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "route",
           "offset": 0,
@@ -723,12 +737,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(TopDownCheckpoint)9654_storage": {
+    "t_struct(TopDownCheckpoint)10001_storage": {
       "encoding": "inplace",
       "label": "struct TopDownCheckpoint",
       "members": [
         {
-          "astId": 9649,
+          "astId": 9996,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "epoch",
           "offset": 0,
@@ -736,12 +750,12 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9653,
+          "astId": 10000,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "topDownMsgs",
           "offset": 0,
           "slot": "1",
-          "type": "t_array(t_struct(CrossMsg)9667_storage)dyn_storage"
+          "type": "t_array(t_struct(CrossMsg)10014_storage)dyn_storage"
         }
       ],
       "numberOfBytes": "64"

--- a/.storage-layouts/SubnetActorDiamond.json
+++ b/.storage-layouts/SubnetActorDiamond.json
@@ -1,12 +1,12 @@
 {
   "storage": [
     {
-      "astId": 3000,
+      "astId": 2989,
       "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
       "label": "s",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(SubnetActorStorage)8196_storage"
+      "type": "t_struct(SubnetActorStorage)8580_storage"
     }
   ],
   "types": {
@@ -27,14 +27,14 @@
       "label": "bytes32[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(ChildCheck)9661_storage)dyn_storage": {
-      "base": "t_struct(ChildCheck)9661_storage",
+    "t_array(t_struct(ChildCheck)10008_storage)dyn_storage": {
+      "base": "t_struct(ChildCheck)10008_storage",
       "encoding": "dynamic_array",
       "label": "struct ChildCheck[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(CrossMsg)9667_storage)dyn_storage": {
-      "base": "t_struct(CrossMsg)9667_storage",
+    "t_array(t_struct(CrossMsg)10014_storage)dyn_storage": {
+      "base": "t_struct(CrossMsg)10014_storage",
       "encoding": "dynamic_array",
       "label": "struct CrossMsg[]",
       "numberOfBytes": "32"
@@ -59,12 +59,12 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_enum(ConsensusType)3584": {
+    "t_enum(ConsensusType)4011": {
       "encoding": "inplace",
       "label": "enum ConsensusType",
       "numberOfBytes": "1"
     },
-    "t_enum(Status)3598": {
+    "t_enum(Status)4025": {
       "encoding": "inplace",
       "label": "enum Status",
       "numberOfBytes": "1"
@@ -83,12 +83,12 @@
       "numberOfBytes": "32",
       "value": "t_string_storage"
     },
-    "t_mapping(t_address,t_struct(FvmAddress)9746_storage)": {
+    "t_mapping(t_address,t_struct(FvmAddress)10093_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct FvmAddress)",
       "numberOfBytes": "32",
-      "value": "t_struct(FvmAddress)9746_storage"
+      "value": "t_struct(FvmAddress)10093_storage"
     },
     "t_mapping(t_address,t_uint256)": {
       "encoding": "mapping",
@@ -97,12 +97,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_mapping(t_bytes32,t_struct(BottomUpCheckpoint)9647_storage)": {
+    "t_mapping(t_bytes32,t_struct(BottomUpCheckpoint)9994_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)9647_storage"
+      "value": "t_struct(BottomUpCheckpoint)9994_storage"
     },
     "t_mapping(t_bytes32,t_uint256)": {
       "encoding": "mapping",
@@ -125,19 +125,19 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_bytes32,t_uint256)"
     },
-    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9647_storage)": {
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9994_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)9647_storage"
+      "value": "t_struct(BottomUpCheckpoint)9994_storage"
     },
-    "t_mapping(t_uint64,t_struct(EpochVoteBottomUpSubmission)9724_storage)": {
+    "t_mapping(t_uint64,t_struct(EpochVoteBottomUpSubmission)10071_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct EpochVoteBottomUpSubmission)",
       "numberOfBytes": "32",
-      "value": "t_struct(EpochVoteBottomUpSubmission)9724_storage"
+      "value": "t_struct(EpochVoteBottomUpSubmission)10071_storage"
     },
     "t_string_storage": {
       "encoding": "bytes",
@@ -159,20 +159,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(BottomUpCheckpoint)9647_storage": {
+    "t_struct(BottomUpCheckpoint)9994_storage": {
       "encoding": "inplace",
       "label": "struct BottomUpCheckpoint",
       "members": [
         {
-          "astId": 9630,
+          "astId": 9977,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "source",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9772_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9632,
+          "astId": 9979,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "epoch",
           "offset": 0,
@@ -180,7 +180,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9634,
+          "astId": 9981,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "fee",
           "offset": 0,
@@ -188,23 +188,23 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9638,
+          "astId": 9985,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "crossMsgs",
           "offset": 0,
           "slot": "4",
-          "type": "t_array(t_struct(CrossMsg)9667_storage)dyn_storage"
+          "type": "t_array(t_struct(CrossMsg)10014_storage)dyn_storage"
         },
         {
-          "astId": 9642,
+          "astId": 9989,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "children",
           "offset": 0,
           "slot": "5",
-          "type": "t_array(t_struct(ChildCheck)9661_storage)dyn_storage"
+          "type": "t_array(t_struct(ChildCheck)10008_storage)dyn_storage"
         },
         {
-          "astId": 9644,
+          "astId": 9991,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "prevHash",
           "offset": 0,
@@ -212,7 +212,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 9646,
+          "astId": 9993,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "proof",
           "offset": 0,
@@ -222,20 +222,20 @@
       ],
       "numberOfBytes": "256"
     },
-    "t_struct(ChildCheck)9661_storage": {
+    "t_struct(ChildCheck)10008_storage": {
       "encoding": "inplace",
       "label": "struct ChildCheck",
       "members": [
         {
-          "astId": 9657,
+          "astId": 10004,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "source",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9772_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9660,
+          "astId": 10007,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "checks",
           "offset": 0,
@@ -245,20 +245,20 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(CrossMsg)9667_storage": {
+    "t_struct(CrossMsg)10014_storage": {
       "encoding": "inplace",
       "label": "struct CrossMsg",
       "members": [
         {
-          "astId": 9664,
+          "astId": 10011,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "message",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(StorableMsg)9682_storage"
+          "type": "t_struct(StorableMsg)10029_storage"
         },
         {
-          "astId": 9666,
+          "astId": 10013,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "wrapped",
           "offset": 0,
@@ -268,35 +268,35 @@
       ],
       "numberOfBytes": "384"
     },
-    "t_struct(EpochVoteBottomUpSubmission)9724_storage": {
+    "t_struct(EpochVoteBottomUpSubmission)10071_storage": {
       "encoding": "inplace",
       "label": "struct EpochVoteBottomUpSubmission",
       "members": [
         {
-          "astId": 9718,
+          "astId": 10065,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "vote",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(EpochVoteSubmission)9706_storage"
+          "type": "t_struct(EpochVoteSubmission)10053_storage"
         },
         {
-          "astId": 9723,
+          "astId": 10070,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "submissions",
           "offset": 0,
           "slot": "5",
-          "type": "t_mapping(t_bytes32,t_struct(BottomUpCheckpoint)9647_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(BottomUpCheckpoint)9994_storage)"
         }
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(EpochVoteSubmission)9706_storage": {
+    "t_struct(EpochVoteSubmission)10053_storage": {
       "encoding": "inplace",
       "label": "struct EpochVoteSubmission",
       "members": [
         {
-          "astId": 9689,
+          "astId": 10036,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "nonce",
           "offset": 0,
@@ -304,7 +304,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9691,
+          "astId": 10038,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "totalSubmissionWeight",
           "offset": 0,
@@ -312,7 +312,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9693,
+          "astId": 10040,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "mostVotedSubmission",
           "offset": 0,
@@ -320,7 +320,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 9699,
+          "astId": 10046,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "submitters",
           "offset": 0,
@@ -328,7 +328,7 @@
           "type": "t_mapping(t_uint256,t_mapping(t_address,t_bool))"
         },
         {
-          "astId": 9705,
+          "astId": 10052,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "submissionWeights",
           "offset": 0,
@@ -338,12 +338,12 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(FvmAddress)9746_storage": {
+    "t_struct(FvmAddress)10093_storage": {
       "encoding": "inplace",
       "label": "struct FvmAddress",
       "members": [
         {
-          "astId": 9743,
+          "astId": 10090,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "addrType",
           "offset": 0,
@@ -351,7 +351,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 9745,
+          "astId": 10092,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "payload",
           "offset": 0,
@@ -361,25 +361,25 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(IPCAddress)9803_storage": {
+    "t_struct(IPCAddress)10146_storage": {
       "encoding": "inplace",
       "label": "struct IPCAddress",
       "members": [
         {
-          "astId": 9799,
+          "astId": 10142,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "subnetId",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9772_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9802,
+          "astId": 10145,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "rawAddress",
           "offset": 0,
           "slot": "2",
-          "type": "t_struct(FvmAddress)9746_storage"
+          "type": "t_struct(FvmAddress)10093_storage"
         }
       ],
       "numberOfBytes": "128"
@@ -407,28 +407,28 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StorableMsg)9682_storage": {
+    "t_struct(StorableMsg)10029_storage": {
       "encoding": "inplace",
       "label": "struct StorableMsg",
       "members": [
         {
-          "astId": 9670,
+          "astId": 10017,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "from",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(IPCAddress)9803_storage"
+          "type": "t_struct(IPCAddress)10146_storage"
         },
         {
-          "astId": 9673,
+          "astId": 10020,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "to",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(IPCAddress)9803_storage"
+          "type": "t_struct(IPCAddress)10146_storage"
         },
         {
-          "astId": 9675,
+          "astId": 10022,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "value",
           "offset": 0,
@@ -436,7 +436,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9677,
+          "astId": 10024,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "nonce",
           "offset": 0,
@@ -444,7 +444,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9679,
+          "astId": 10026,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "method",
           "offset": 8,
@@ -452,7 +452,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 9681,
+          "astId": 10028,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "params",
           "offset": 0,
@@ -462,20 +462,20 @@
       ],
       "numberOfBytes": "352"
     },
-    "t_struct(SubnetActorStorage)8196_storage": {
+    "t_struct(SubnetActorStorage)8580_storage": {
       "encoding": "inplace",
       "label": "struct SubnetActorStorage",
       "members": [
         {
-          "astId": 8120,
+          "astId": 8504,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "epochVoteSubmissions",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_uint64,t_struct(EpochVoteBottomUpSubmission)9724_storage)"
+          "type": "t_mapping(t_uint64,t_struct(EpochVoteBottomUpSubmission)10071_storage)"
         },
         {
-          "astId": 8125,
+          "astId": 8509,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "stake",
           "offset": 0,
@@ -483,7 +483,7 @@
           "type": "t_mapping(t_address,t_uint256)"
         },
         {
-          "astId": 8130,
+          "astId": 8514,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "accumulatedRewards",
           "offset": 0,
@@ -491,7 +491,7 @@
           "type": "t_mapping(t_address,t_uint256)"
         },
         {
-          "astId": 8135,
+          "astId": 8519,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "validatorNetAddresses",
           "offset": 0,
@@ -499,23 +499,23 @@
           "type": "t_mapping(t_address,t_string_storage)"
         },
         {
-          "astId": 8141,
+          "astId": 8525,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "validatorWorkerAddresses",
           "offset": 0,
           "slot": "4",
-          "type": "t_mapping(t_address,t_struct(FvmAddress)9746_storage)"
+          "type": "t_mapping(t_address,t_struct(FvmAddress)10093_storage)"
         },
         {
-          "astId": 8147,
+          "astId": 8531,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "committedCheckpoints",
           "offset": 0,
           "slot": "5",
-          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9647_storage)"
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9994_storage)"
         },
         {
-          "astId": 8150,
+          "astId": 8534,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "genesis",
           "offset": 0,
@@ -523,7 +523,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 8153,
+          "astId": 8537,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "totalStake",
           "offset": 0,
@@ -531,7 +531,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 8156,
+          "astId": 8540,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "minActivationCollateral",
           "offset": 0,
@@ -539,7 +539,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 8159,
+          "astId": 8543,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "configurationNumber",
           "offset": 0,
@@ -547,7 +547,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 8162,
+          "astId": 8546,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "topDownCheckPeriod",
           "offset": 8,
@@ -555,7 +555,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 8165,
+          "astId": 8549,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "bottomUpCheckPeriod",
           "offset": 16,
@@ -563,7 +563,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 8168,
+          "astId": 8552,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "minValidators",
           "offset": 24,
@@ -571,7 +571,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 8171,
+          "astId": 8555,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "name",
           "offset": 0,
@@ -579,7 +579,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 8173,
+          "astId": 8557,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "currentSubnetHash",
           "offset": 0,
@@ -587,7 +587,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 8176,
+          "astId": 8560,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "prevExecutedCheckpointHash",
           "offset": 0,
@@ -595,7 +595,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 8179,
+          "astId": 8563,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "ipcGatewayAddr",
           "offset": 0,
@@ -603,15 +603,15 @@
           "type": "t_address"
         },
         {
-          "astId": 8183,
+          "astId": 8567,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "status",
           "offset": 20,
           "slot": "13",
-          "type": "t_enum(Status)3598"
+          "type": "t_enum(Status)4025"
         },
         {
-          "astId": 8187,
+          "astId": 8571,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "validators",
           "offset": 0,
@@ -619,30 +619,30 @@
           "type": "t_struct(AddressSet)2473_storage"
         },
         {
-          "astId": 8191,
+          "astId": 8575,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "parentId",
           "offset": 0,
           "slot": "16",
-          "type": "t_struct(SubnetID)9772_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 8195,
+          "astId": 8579,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "consensus",
           "offset": 0,
           "slot": "18",
-          "type": "t_enum(ConsensusType)3584"
+          "type": "t_enum(ConsensusType)4011"
         }
       ],
       "numberOfBytes": "608"
     },
-    "t_struct(SubnetID)9772_storage": {
+    "t_struct(SubnetID)10119_storage": {
       "encoding": "inplace",
       "label": "struct SubnetID",
       "members": [
         {
-          "astId": 9767,
+          "astId": 10114,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "root",
           "offset": 0,
@@ -650,7 +650,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9771,
+          "astId": 10118,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "route",
           "offset": 0,

--- a/.storage-layouts/SubnetActorModifiers.json
+++ b/.storage-layouts/SubnetActorModifiers.json
@@ -1,12 +1,12 @@
 {
   "storage": [
     {
-      "astId": 8208,
+      "astId": 8592,
       "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
       "label": "s",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(SubnetActorStorage)8196_storage"
+      "type": "t_struct(SubnetActorStorage)8580_storage"
     }
   ],
   "types": {
@@ -27,14 +27,14 @@
       "label": "bytes32[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(ChildCheck)9661_storage)dyn_storage": {
-      "base": "t_struct(ChildCheck)9661_storage",
+    "t_array(t_struct(ChildCheck)10008_storage)dyn_storage": {
+      "base": "t_struct(ChildCheck)10008_storage",
       "encoding": "dynamic_array",
       "label": "struct ChildCheck[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(CrossMsg)9667_storage)dyn_storage": {
-      "base": "t_struct(CrossMsg)9667_storage",
+    "t_array(t_struct(CrossMsg)10014_storage)dyn_storage": {
+      "base": "t_struct(CrossMsg)10014_storage",
       "encoding": "dynamic_array",
       "label": "struct CrossMsg[]",
       "numberOfBytes": "32"
@@ -59,12 +59,12 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_enum(ConsensusType)3584": {
+    "t_enum(ConsensusType)4011": {
       "encoding": "inplace",
       "label": "enum ConsensusType",
       "numberOfBytes": "1"
     },
-    "t_enum(Status)3598": {
+    "t_enum(Status)4025": {
       "encoding": "inplace",
       "label": "enum Status",
       "numberOfBytes": "1"
@@ -83,12 +83,12 @@
       "numberOfBytes": "32",
       "value": "t_string_storage"
     },
-    "t_mapping(t_address,t_struct(FvmAddress)9746_storage)": {
+    "t_mapping(t_address,t_struct(FvmAddress)10093_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct FvmAddress)",
       "numberOfBytes": "32",
-      "value": "t_struct(FvmAddress)9746_storage"
+      "value": "t_struct(FvmAddress)10093_storage"
     },
     "t_mapping(t_address,t_uint256)": {
       "encoding": "mapping",
@@ -97,12 +97,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_mapping(t_bytes32,t_struct(BottomUpCheckpoint)9647_storage)": {
+    "t_mapping(t_bytes32,t_struct(BottomUpCheckpoint)9994_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)9647_storage"
+      "value": "t_struct(BottomUpCheckpoint)9994_storage"
     },
     "t_mapping(t_bytes32,t_uint256)": {
       "encoding": "mapping",
@@ -125,19 +125,19 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_bytes32,t_uint256)"
     },
-    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9647_storage)": {
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9994_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)9647_storage"
+      "value": "t_struct(BottomUpCheckpoint)9994_storage"
     },
-    "t_mapping(t_uint64,t_struct(EpochVoteBottomUpSubmission)9724_storage)": {
+    "t_mapping(t_uint64,t_struct(EpochVoteBottomUpSubmission)10071_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct EpochVoteBottomUpSubmission)",
       "numberOfBytes": "32",
-      "value": "t_struct(EpochVoteBottomUpSubmission)9724_storage"
+      "value": "t_struct(EpochVoteBottomUpSubmission)10071_storage"
     },
     "t_string_storage": {
       "encoding": "bytes",
@@ -159,20 +159,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(BottomUpCheckpoint)9647_storage": {
+    "t_struct(BottomUpCheckpoint)9994_storage": {
       "encoding": "inplace",
       "label": "struct BottomUpCheckpoint",
       "members": [
         {
-          "astId": 9630,
+          "astId": 9977,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "source",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9772_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9632,
+          "astId": 9979,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "epoch",
           "offset": 0,
@@ -180,7 +180,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9634,
+          "astId": 9981,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "fee",
           "offset": 0,
@@ -188,23 +188,23 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9638,
+          "astId": 9985,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "crossMsgs",
           "offset": 0,
           "slot": "4",
-          "type": "t_array(t_struct(CrossMsg)9667_storage)dyn_storage"
+          "type": "t_array(t_struct(CrossMsg)10014_storage)dyn_storage"
         },
         {
-          "astId": 9642,
+          "astId": 9989,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "children",
           "offset": 0,
           "slot": "5",
-          "type": "t_array(t_struct(ChildCheck)9661_storage)dyn_storage"
+          "type": "t_array(t_struct(ChildCheck)10008_storage)dyn_storage"
         },
         {
-          "astId": 9644,
+          "astId": 9991,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "prevHash",
           "offset": 0,
@@ -212,7 +212,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 9646,
+          "astId": 9993,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "proof",
           "offset": 0,
@@ -222,20 +222,20 @@
       ],
       "numberOfBytes": "256"
     },
-    "t_struct(ChildCheck)9661_storage": {
+    "t_struct(ChildCheck)10008_storage": {
       "encoding": "inplace",
       "label": "struct ChildCheck",
       "members": [
         {
-          "astId": 9657,
+          "astId": 10004,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "source",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9772_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9660,
+          "astId": 10007,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "checks",
           "offset": 0,
@@ -245,20 +245,20 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(CrossMsg)9667_storage": {
+    "t_struct(CrossMsg)10014_storage": {
       "encoding": "inplace",
       "label": "struct CrossMsg",
       "members": [
         {
-          "astId": 9664,
+          "astId": 10011,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "message",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(StorableMsg)9682_storage"
+          "type": "t_struct(StorableMsg)10029_storage"
         },
         {
-          "astId": 9666,
+          "astId": 10013,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "wrapped",
           "offset": 0,
@@ -268,35 +268,35 @@
       ],
       "numberOfBytes": "384"
     },
-    "t_struct(EpochVoteBottomUpSubmission)9724_storage": {
+    "t_struct(EpochVoteBottomUpSubmission)10071_storage": {
       "encoding": "inplace",
       "label": "struct EpochVoteBottomUpSubmission",
       "members": [
         {
-          "astId": 9718,
+          "astId": 10065,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "vote",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(EpochVoteSubmission)9706_storage"
+          "type": "t_struct(EpochVoteSubmission)10053_storage"
         },
         {
-          "astId": 9723,
+          "astId": 10070,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "submissions",
           "offset": 0,
           "slot": "5",
-          "type": "t_mapping(t_bytes32,t_struct(BottomUpCheckpoint)9647_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(BottomUpCheckpoint)9994_storage)"
         }
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(EpochVoteSubmission)9706_storage": {
+    "t_struct(EpochVoteSubmission)10053_storage": {
       "encoding": "inplace",
       "label": "struct EpochVoteSubmission",
       "members": [
         {
-          "astId": 9689,
+          "astId": 10036,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "nonce",
           "offset": 0,
@@ -304,7 +304,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9691,
+          "astId": 10038,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "totalSubmissionWeight",
           "offset": 0,
@@ -312,7 +312,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9693,
+          "astId": 10040,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "mostVotedSubmission",
           "offset": 0,
@@ -320,7 +320,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 9699,
+          "astId": 10046,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "submitters",
           "offset": 0,
@@ -328,7 +328,7 @@
           "type": "t_mapping(t_uint256,t_mapping(t_address,t_bool))"
         },
         {
-          "astId": 9705,
+          "astId": 10052,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "submissionWeights",
           "offset": 0,
@@ -338,12 +338,12 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(FvmAddress)9746_storage": {
+    "t_struct(FvmAddress)10093_storage": {
       "encoding": "inplace",
       "label": "struct FvmAddress",
       "members": [
         {
-          "astId": 9743,
+          "astId": 10090,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "addrType",
           "offset": 0,
@@ -351,7 +351,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 9745,
+          "astId": 10092,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "payload",
           "offset": 0,
@@ -361,25 +361,25 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(IPCAddress)9803_storage": {
+    "t_struct(IPCAddress)10146_storage": {
       "encoding": "inplace",
       "label": "struct IPCAddress",
       "members": [
         {
-          "astId": 9799,
+          "astId": 10142,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "subnetId",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9772_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9802,
+          "astId": 10145,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "rawAddress",
           "offset": 0,
           "slot": "2",
-          "type": "t_struct(FvmAddress)9746_storage"
+          "type": "t_struct(FvmAddress)10093_storage"
         }
       ],
       "numberOfBytes": "128"
@@ -407,28 +407,28 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StorableMsg)9682_storage": {
+    "t_struct(StorableMsg)10029_storage": {
       "encoding": "inplace",
       "label": "struct StorableMsg",
       "members": [
         {
-          "astId": 9670,
+          "astId": 10017,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "from",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(IPCAddress)9803_storage"
+          "type": "t_struct(IPCAddress)10146_storage"
         },
         {
-          "astId": 9673,
+          "astId": 10020,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "to",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(IPCAddress)9803_storage"
+          "type": "t_struct(IPCAddress)10146_storage"
         },
         {
-          "astId": 9675,
+          "astId": 10022,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "value",
           "offset": 0,
@@ -436,7 +436,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9677,
+          "astId": 10024,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "nonce",
           "offset": 0,
@@ -444,7 +444,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9679,
+          "astId": 10026,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "method",
           "offset": 8,
@@ -452,7 +452,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 9681,
+          "astId": 10028,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "params",
           "offset": 0,
@@ -462,20 +462,20 @@
       ],
       "numberOfBytes": "352"
     },
-    "t_struct(SubnetActorStorage)8196_storage": {
+    "t_struct(SubnetActorStorage)8580_storage": {
       "encoding": "inplace",
       "label": "struct SubnetActorStorage",
       "members": [
         {
-          "astId": 8120,
+          "astId": 8504,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "epochVoteSubmissions",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_uint64,t_struct(EpochVoteBottomUpSubmission)9724_storage)"
+          "type": "t_mapping(t_uint64,t_struct(EpochVoteBottomUpSubmission)10071_storage)"
         },
         {
-          "astId": 8125,
+          "astId": 8509,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "stake",
           "offset": 0,
@@ -483,7 +483,7 @@
           "type": "t_mapping(t_address,t_uint256)"
         },
         {
-          "astId": 8130,
+          "astId": 8514,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "accumulatedRewards",
           "offset": 0,
@@ -491,7 +491,7 @@
           "type": "t_mapping(t_address,t_uint256)"
         },
         {
-          "astId": 8135,
+          "astId": 8519,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "validatorNetAddresses",
           "offset": 0,
@@ -499,23 +499,23 @@
           "type": "t_mapping(t_address,t_string_storage)"
         },
         {
-          "astId": 8141,
+          "astId": 8525,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "validatorWorkerAddresses",
           "offset": 0,
           "slot": "4",
-          "type": "t_mapping(t_address,t_struct(FvmAddress)9746_storage)"
+          "type": "t_mapping(t_address,t_struct(FvmAddress)10093_storage)"
         },
         {
-          "astId": 8147,
+          "astId": 8531,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "committedCheckpoints",
           "offset": 0,
           "slot": "5",
-          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9647_storage)"
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9994_storage)"
         },
         {
-          "astId": 8150,
+          "astId": 8534,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "genesis",
           "offset": 0,
@@ -523,7 +523,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 8153,
+          "astId": 8537,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "totalStake",
           "offset": 0,
@@ -531,7 +531,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 8156,
+          "astId": 8540,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "minActivationCollateral",
           "offset": 0,
@@ -539,7 +539,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 8159,
+          "astId": 8543,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "configurationNumber",
           "offset": 0,
@@ -547,7 +547,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 8162,
+          "astId": 8546,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "topDownCheckPeriod",
           "offset": 8,
@@ -555,7 +555,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 8165,
+          "astId": 8549,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "bottomUpCheckPeriod",
           "offset": 16,
@@ -563,7 +563,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 8168,
+          "astId": 8552,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "minValidators",
           "offset": 24,
@@ -571,7 +571,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 8171,
+          "astId": 8555,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "name",
           "offset": 0,
@@ -579,7 +579,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 8173,
+          "astId": 8557,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "currentSubnetHash",
           "offset": 0,
@@ -587,7 +587,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 8176,
+          "astId": 8560,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "prevExecutedCheckpointHash",
           "offset": 0,
@@ -595,7 +595,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 8179,
+          "astId": 8563,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "ipcGatewayAddr",
           "offset": 0,
@@ -603,15 +603,15 @@
           "type": "t_address"
         },
         {
-          "astId": 8183,
+          "astId": 8567,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "status",
           "offset": 20,
           "slot": "13",
-          "type": "t_enum(Status)3598"
+          "type": "t_enum(Status)4025"
         },
         {
-          "astId": 8187,
+          "astId": 8571,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "validators",
           "offset": 0,
@@ -619,30 +619,30 @@
           "type": "t_struct(AddressSet)2473_storage"
         },
         {
-          "astId": 8191,
+          "astId": 8575,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "parentId",
           "offset": 0,
           "slot": "16",
-          "type": "t_struct(SubnetID)9772_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 8195,
+          "astId": 8579,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "consensus",
           "offset": 0,
           "slot": "18",
-          "type": "t_enum(ConsensusType)3584"
+          "type": "t_enum(ConsensusType)4011"
         }
       ],
       "numberOfBytes": "608"
     },
-    "t_struct(SubnetID)9772_storage": {
+    "t_struct(SubnetID)10119_storage": {
       "encoding": "inplace",
       "label": "struct SubnetID",
       "members": [
         {
-          "astId": 9767,
+          "astId": 10114,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "root",
           "offset": 0,
@@ -650,7 +650,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9771,
+          "astId": 10118,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "route",
           "offset": 0,

--- a/src/gateway/GatewayGetterFacet.sol
+++ b/src/gateway/GatewayGetterFacet.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.19;
 
 import {CrossMsg, BottomUpCheckpoint, StorableMsg} from "../structs/Checkpoint.sol";
 import {EpochVoteTopDownSubmission} from "../structs/EpochVoteSubmission.sol";
-import {SubnetID, Subnet} from "../structs/Subnet.sol";
+import {SubnetID, Subnet, SubnetDTO} from "../structs/Subnet.sol";
 import {CheckpointHelper} from "../lib/CheckpointHelper.sol";
 import {LibGateway} from "../lib/LibGateway.sol";
 import {GatewayActorStorage} from "../lib/LibGatewayActorStorage.sol";
@@ -57,7 +57,7 @@ contract GatewayGetterFacet {
     /// @param subnetId the id of the subnet
     /// @return found whether the subnet exists
     /// @return subnet -  the subnet struct
-    function getSubnet(SubnetID calldata subnetId) external view returns (bool, Subnet memory) {
+    function getSubnet(SubnetID calldata subnetId) external view returns (bool, SubnetDTO memory) {
         // slither-disable-next-line unused-return
         return LibGateway.getSubnet(subnetId);
     }

--- a/src/gateway/GatewayGetterFacet.sol
+++ b/src/gateway/GatewayGetterFacet.sol
@@ -70,6 +70,7 @@ contract GatewayGetterFacet {
     function getSubnetTopDownMsgsLength(SubnetID memory subnetId) external view returns (uint256) {
         // slither-disable-next-line unused-return
         (, Subnet storage subnet) = LibGateway.getSubnet(subnetId);
+        // With every new message, the nonce is added by one, the current nonce should be equal to the top down message length.
         return subnet.topDownNonce;
     }
 

--- a/src/gateway/GatewayGetterFacet.sol
+++ b/src/gateway/GatewayGetterFacet.sol
@@ -82,7 +82,7 @@ contract GatewayGetterFacet {
         uint256 fromBlock,
         uint256 toBlock
     ) external view returns (CrossMsg[] memory) {
-        return LibGateway.getTopDownMsgs(subnetId, fromBlock, toBlock);
+        return LibGateway.getTopDownMsgs({subnetId: subnetId, fromBlock: fromBlock, toBlock: toBlock});
     }
 
     /// @notice Get the latest applied top down nonce

--- a/src/lib/LibGateway.sol
+++ b/src/lib/LibGateway.sol
@@ -50,7 +50,7 @@ library LibGateway {
         crossMessage.message.nonce = subnet.topDownNonce;
         subnet.topDownNonce += 1;
         subnet.circSupply += crossMessage.message.value;
-        subnet.topDownMsgs.push(crossMessage);
+        subnet.topDownMsgs[block.number].push(crossMessage);
     }
 
     /// @notice commit bottomup messages for their execution in the subnet. Adds the message to the checkpoint for future execution

--- a/src/lib/LibGateway.sol
+++ b/src/lib/LibGateway.sol
@@ -50,7 +50,8 @@ library LibGateway {
         crossMessage.message.nonce = subnet.topDownNonce;
         subnet.topDownNonce += 1;
         subnet.circSupply += crossMessage.message.value;
-        subnet.topDownMsgs[block.number].push(crossMessage);
+
+        s.topDownMsgs[block.number].push(crossMessage);
     }
 
     /// @notice commit bottomup messages for their execution in the subnet. Adds the message to the checkpoint for future execution
@@ -75,6 +76,50 @@ library LibGateway {
         }
         // slither-disable-next-line unused-return
         Address.functionCall(to.normalize(), abi.encodeCall(ISubnetActor.reward, amount));
+    }
+
+    /// @notice get the list of top down messages from block number, we may also consider introducing pagination.
+    /// @param subnetId - The subnet id to fetch messages from
+    /// @param fromBlock - The starting block to get top down messages, inclusive.
+    /// @param toBlock - The ending block to get top down messages, inclusive.
+    function getTopDownMsgs(
+        SubnetID calldata subnetId,
+        uint256 fromBlock,
+        uint256 toBlock
+    ) external view returns (CrossMsg[] memory) {
+        GatewayActorStorage storage s = LibGatewayActorStorage.appStorage();
+
+        // invalid from block number
+        if (fromBlock > toBlock) {
+            return new CrossMsg[](0);
+        }
+
+        uint256 msgLength = 0;
+        for (uint256 i = fromBlock; i <= toBlock; ) {
+            msgLength += s.topDownMsgs[subnetId][i].length;
+            unchecked {
+                i++;
+            }
+        }
+
+        CrossMsg[] memory messages = new CrossMsg[](msgLength);
+        uint256 index = 0;
+        for (uint256 i = fromBlock; i <= toBlock; ) {
+            // perform copy
+            for (uint256 j = 0; j < s.topDownMsgs[subnetId][i].length; ) {
+                messages[index] = s.topDownMsgs[subnetId][i][j];
+                unchecked {
+                    j++;
+                    index++;
+                }
+            }
+
+            unchecked {
+                i++;
+            }
+        }
+
+        return messages;
     }
 
     /// @notice returns the subnet created by a validator

--- a/src/lib/LibGateway.sol
+++ b/src/lib/LibGateway.sol
@@ -51,7 +51,7 @@ library LibGateway {
         subnet.topDownNonce += 1;
         subnet.circSupply += crossMessage.message.value;
 
-        s.topDownMsgs[block.number].push(crossMessage);
+        s.topDownMsgs[subnetId.toHash()][block.number].push(crossMessage);
     }
 
     /// @notice commit bottomup messages for their execution in the subnet. Adds the message to the checkpoint for future execution
@@ -94,9 +94,10 @@ library LibGateway {
             return new CrossMsg[](0);
         }
 
+        bytes32 subnetHash = subnetId.toHash();
         uint256 msgLength = 0;
         for (uint256 i = fromBlock; i <= toBlock; ) {
-            msgLength += s.topDownMsgs[subnetId][i].length;
+            msgLength += s.topDownMsgs[subnetHash][i].length;
             unchecked {
                 i++;
             }
@@ -106,8 +107,8 @@ library LibGateway {
         uint256 index = 0;
         for (uint256 i = fromBlock; i <= toBlock; ) {
             // perform copy
-            for (uint256 j = 0; j < s.topDownMsgs[subnetId][i].length; ) {
-                messages[index] = s.topDownMsgs[subnetId][i][j];
+            for (uint256 j = 0; j < s.topDownMsgs[subnetHash][i].length; ) {
+                messages[index] = s.topDownMsgs[subnetHash][i][j];
                 unchecked {
                     j++;
                     index++;

--- a/src/lib/LibGateway.sol
+++ b/src/lib/LibGateway.sol
@@ -86,7 +86,7 @@ library LibGateway {
         SubnetID calldata subnetId,
         uint256 fromBlock,
         uint256 toBlock
-    ) external view returns (CrossMsg[] memory) {
+    ) internal view returns (CrossMsg[] memory) {
         GatewayActorStorage storage s = LibGatewayActorStorage.appStorage();
 
         // invalid from block number

--- a/src/lib/LibGatewayActorStorage.sol
+++ b/src/lib/LibGatewayActorStorage.sol
@@ -12,6 +12,9 @@ struct GatewayActorStorage {
     /// @notice List of subnets
     /// SubnetID => Subnet
     mapping(bytes32 => Subnet) subnets;
+    /// @notice a mapping of block number to cross messages
+    /// SubnetID => blockNumber => messages
+    mapping(bytes32 => mapping(uint256 => CrossMsg[])) topDownMsgs;
     /// @notice Postbox keeps track of all the cross-net messages triggered by
     /// an actor that need to be propagated further through the hierarchy.
     /// cross-net message id => CrossMsg

--- a/src/structs/Subnet.sol
+++ b/src/structs/Subnet.sol
@@ -24,7 +24,8 @@ struct Subnet {
     Status status;
     SubnetID id;
     BottomUpCheckpoint prevCheckpoint;
-    CrossMsg[] topDownMsgs;
+    /// @notice a mapping of block number to cross messages
+    mapping(uint256 => CrossMsg[]) topDownMsgs;
 }
 
 struct IPCAddress {

--- a/src/structs/Subnet.sol
+++ b/src/structs/Subnet.sol
@@ -15,17 +15,6 @@ struct SubnetID {
     address[] route;
 }
 
-struct SubnetDTO {
-    uint256 stake;
-    uint256 genesisEpoch;
-    uint256 circSupply;
-    uint64 topDownNonce;
-    uint64 appliedBottomUpNonce;
-    Status status;
-    SubnetID id;
-    BottomUpCheckpoint prevCheckpoint;
-}
-
 struct Subnet {
     uint256 stake;
     uint256 genesisEpoch;
@@ -35,8 +24,6 @@ struct Subnet {
     Status status;
     SubnetID id;
     BottomUpCheckpoint prevCheckpoint;
-    /// @notice a mapping of block number to cross messages
-    mapping(uint256 => CrossMsg[]) topDownMsgs;
 }
 
 struct IPCAddress {

--- a/src/structs/Subnet.sol
+++ b/src/structs/Subnet.sol
@@ -15,6 +15,17 @@ struct SubnetID {
     address[] route;
 }
 
+struct SubnetDTO {
+    uint256 stake;
+    uint256 genesisEpoch;
+    uint256 circSupply;
+    uint64 topDownNonce;
+    uint64 appliedBottomUpNonce;
+    Status status;
+    SubnetID id;
+    BottomUpCheckpoint prevCheckpoint;
+}
+
 struct Subnet {
     uint256 stake;
     uint256 genesisEpoch;

--- a/test/GatewayDiamond.t.sol
+++ b/test/GatewayDiamond.t.sol
@@ -264,12 +264,10 @@ contract GatewayDiamondDeploymentTest is StdInvariant, Test {
         saDiamond = new SubnetActorDiamond(saDiamondCut, saConstructorParams);
         saManager = SubnetActorManagerFacet(address(saDiamond));
         saGetter = SubnetActorGetterFacet(address(saDiamond));
-
-        targetContract(address(gatewayDiamond));
     }
 
     function invariant_CrossMsgFee() public view {
-        require(gwGetter.crossMsgFee() == CROSS_MSG_FEE);
+        require(gwGetter.crossMsgFee() == CROSS_MSG_FEE, "gw.crossMsgFee == CROSS_MSG_FEE");
     }
 
     function testGatewayDiamond_Constructor() public view {

--- a/test/GatewayDiamond.t.sol
+++ b/test/GatewayDiamond.t.sol
@@ -2263,22 +2263,25 @@ contract GatewayDiamondDeploymentTest is StdInvariant, Test {
 
         (SubnetID memory subnetId, , uint256 nonceBefore, , uint256 circSupplyBefore, ) = getSubnet(address(saManager));
 
-        uint256 expectedTopDownMsgsLength = gwGetter.getSubnetTopDownMsgsLength(subnetId) + 1;
-        uint256 expectedNonce = nonceBefore + 1;
-        uint256 expectedCircSupply = circSupplyBefore + fundAmountWithSubtractedFee;
+        uint256 expectedTopDownMsgsLength = 0;
+        {
+            expectedTopDownMsgsLength = gwGetter.getSubnetTopDownMsgsLength(subnetId) + 1;
+            uint256 expectedNonce = nonceBefore + 1;
+            uint256 expectedCircSupply = circSupplyBefore + fundAmountWithSubtractedFee;
 
-        require(gwGetter.crossMsgFee() > 0, "crossMsgFee is 0");
+            require(gwGetter.crossMsgFee() > 0, "crossMsgFee is 0");
 
-        // vm.expectCall(address(sa), gwGetter.crossMsgFee(), abi.encodeWithSelector(sa.reward.selector), 1);
+            // vm.expectCall(address(sa), gwGetter.crossMsgFee(), abi.encodeWithSelector(sa.reward.selector), 1);
 
-        gwManager.fund{value: fundAmount}(subnetId, FvmAddressHelper.from(funderAddress));
+            gwManager.fund{value: fundAmount}(subnetId, FvmAddressHelper.from(funderAddress));
 
-        (, , uint256 nonce, , uint256 circSupply, ) = getSubnet(address(saManager));
+            (, , uint256 nonce, , uint256 circSupply, ) = getSubnet(address(saManager));
 
-        require(gwGetter.getSubnetTopDownMsgsLength(subnetId) == expectedTopDownMsgsLength);
+            require(gwGetter.getSubnetTopDownMsgsLength(subnetId) == expectedTopDownMsgsLength);
 
-        require(nonce == expectedNonce);
-        require(circSupply == expectedCircSupply);
+            require(nonce == expectedNonce);
+            require(circSupply == expectedCircSupply);
+        }
 
         CrossMsg[] memory topDownMsgs = gwGetter.getTopDownMsgs(subnetId, block.number, block.number);
         for (uint256 msgIndex = 0; msgIndex < expectedTopDownMsgsLength; msgIndex++) {

--- a/test/GatewayDiamond.t.sol
+++ b/test/GatewayDiamond.t.sol
@@ -1453,7 +1453,7 @@ contract GatewayDiamondDeploymentTest is StdInvariant, Test {
         require(gwGetter.getNetworkName().equals(destinationSubnet.commonParent(from)));
         require(gwGetter.appliedTopDownNonce() == 1);
 
-        CrossMsg[] memory msgs = gwGetter.getTopDownMsgs(id, 0);
+        CrossMsg[] memory msgs = gwGetter.getTopDownMsgs(id, block.number, block.number);
         require(msgs.length == 1);
         (bool exists, uint64 n) = gwGetter.getAppliedTopDownNonce(id);
         require(exists);
@@ -2280,8 +2280,9 @@ contract GatewayDiamondDeploymentTest is StdInvariant, Test {
         require(nonce == expectedNonce);
         require(circSupply == expectedCircSupply);
 
+        CrossMsg[] memory topDownMsgs = gwGetter.getTopDownMsgs(subnetId, block.number, block.number);
         for (uint256 msgIndex = 0; msgIndex < expectedTopDownMsgsLength; msgIndex++) {
-            CrossMsg memory topDownMsg = gwGetter.getSubnetTopDownMsg(subnetId, msgIndex);
+            CrossMsg memory topDownMsg = topDownMsgs[msgIndex];
 
             require(topDownMsg.message.nonce == msgIndex);
             require(topDownMsg.message.value == fundAmountWithSubtractedFee);


### PR DESCRIPTION
To integrate with Fendermint, we are arranging the top down checkpoint by height. Key changes:
- Changing `topDownMsgs` from array to `mapping(uint256 =>array)` with block height as key.
- Update all the getter functions, removed unused ones.