### PR TITLE
Add install eth-abi to make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ build:
 	forge build
 
 test:
-    forge test -vvv --ffi
+	forge test -vvv --ffi
 
 install-dev: install-npm-package install-eth-abi
 
@@ -42,7 +42,7 @@ install-npm-package:
 	npm install --save-dev
 
 install-eth-abi:
-    python -m ensurepip --upgrade && pip install eth_abi
+	python -m ensurepip --upgrade && pip install eth_abi
 
 storage:
 	npx hardhat storage-layout --update

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,13 @@ build:
 	forge build
 
 test:
-	forge test -vvv --ffi
+	install-eth-abi forge-test
+
+forge-test:
+    forge test -vvv --ffi
+
+install-eth-abi:
+    pip install eth_abi
 
 storage:
 	npx hardhat storage-layout --update

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ install-npm-package:
 	npm install --save-dev
 
 install-eth-abi:
-	python -m ensurepip --upgrade && pip install eth_abi
+	curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py && ~/.local/bin/pip install eth_abi
 
 storage:
 	npx hardhat storage-layout --update

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ install-npm-package:
 	npm install --save-dev
 
 install-eth-abi:
-	curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py && ~/.local/bin/pip install eth_abi
+	curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py && pip install eth_abi
 
 storage:
 	npx hardhat storage-layout --update

--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,16 @@ format:
 build:
 	forge build
 
-test: install-eth-abi forge-test
-
-forge-test:
+test:
     forge test -vvv --ffi
 
+install-dev: install-npm-package install-eth-abi
+
+install-npm-package:
+	npm install --save-dev
+
 install-eth-abi:
-    pip install eth_abi
+    python -m ensurepip --upgrade && pip install eth_abi
 
 storage:
 	npx hardhat storage-layout --update

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,7 @@ format:
 build:
 	forge build
 
-test:
-	install-eth-abi forge-test
+test: install-eth-abi forge-test
 
 forge-test:
     forge test -vvv --ffi

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ install-npm-package:
 	npm install --save-dev
 
 install-eth-abi:
-	curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py && pip install eth_abi
+	curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py && python3 -m pip install eth_abi
 
 storage:
 	npx hardhat storage-layout --update

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ forge coverage
 
 # Development
 
+Run `make install-dev` to install all necessary dependencies for development.
+
 Before committing:
 
 ```bash


### PR DESCRIPTION
Some unit tests require `eth-abi` python module to work. Previously `make test` assumes `eth-abi` has already been installed, now we add install `eth-abi` into `make install-dev`. 