### PR TITLE
Update join and leave

### DIFF
--- a/.storage-layouts/GatewayActorModifiers.json
+++ b/.storage-layouts/GatewayActorModifiers.json
@@ -1,12 +1,12 @@
 {
   "storage": [
     {
-      "astId": 7913,
+      "astId": 8362,
       "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
       "label": "s",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(GatewayActorStorage)7901_storage"
+      "type": "t_struct(GatewayActorStorage)8350_storage"
     }
   ],
   "types": {
@@ -27,14 +27,14 @@
       "label": "bytes32[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(ChildCheck)9564_storage)dyn_storage": {
-      "base": "t_struct(ChildCheck)9564_storage",
+    "t_array(t_struct(ChildCheck)10008_storage)dyn_storage": {
+      "base": "t_struct(ChildCheck)10008_storage",
       "encoding": "dynamic_array",
       "label": "struct ChildCheck[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(CrossMsg)9570_storage)dyn_storage": {
-      "base": "t_struct(CrossMsg)9570_storage",
+    "t_array(t_struct(CrossMsg)10014_storage)dyn_storage": {
+      "base": "t_struct(CrossMsg)10014_storage",
       "encoding": "dynamic_array",
       "label": "struct CrossMsg[]",
       "numberOfBytes": "32"
@@ -65,7 +65,7 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_enum(Status)3587": {
+    "t_enum(Status)4025": {
       "encoding": "inplace",
       "label": "enum Status",
       "numberOfBytes": "1"
@@ -76,6 +76,13 @@
       "label": "mapping(address => bool)",
       "numberOfBytes": "32",
       "value": "t_bool"
+    },
+    "t_mapping(t_address,t_uint256)": {
+      "encoding": "mapping",
+      "key": "t_address",
+      "label": "mapping(address => uint256)",
+      "numberOfBytes": "32",
+      "value": "t_uint256"
     },
     "t_mapping(t_bytes32,t_array(t_uint256)2_storage)": {
       "encoding": "mapping",
@@ -98,33 +105,33 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_bytes32,t_bool)"
     },
-    "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)9570_storage)dyn_storage))": {
+    "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)10014_storage)dyn_storage))": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => mapping(uint256 => struct CrossMsg[]))",
       "numberOfBytes": "32",
-      "value": "t_mapping(t_uint256,t_array(t_struct(CrossMsg)9570_storage)dyn_storage)"
+      "value": "t_mapping(t_uint256,t_array(t_struct(CrossMsg)10014_storage)dyn_storage)"
     },
-    "t_mapping(t_bytes32,t_struct(CrossMsg)9570_storage)": {
+    "t_mapping(t_bytes32,t_struct(CrossMsg)10014_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct CrossMsg)",
       "numberOfBytes": "32",
-      "value": "t_struct(CrossMsg)9570_storage"
+      "value": "t_struct(CrossMsg)10014_storage"
     },
-    "t_mapping(t_bytes32,t_struct(Subnet)9695_storage)": {
+    "t_mapping(t_bytes32,t_struct(Subnet)10139_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct Subnet)",
       "numberOfBytes": "32",
-      "value": "t_struct(Subnet)9695_storage"
+      "value": "t_struct(Subnet)10139_storage"
     },
-    "t_mapping(t_bytes32,t_struct(TopDownCheckpoint)9557_storage)": {
+    "t_mapping(t_bytes32,t_struct(TopDownCheckpoint)10001_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct TopDownCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(TopDownCheckpoint)9557_storage"
+      "value": "t_struct(TopDownCheckpoint)10001_storage"
     },
     "t_mapping(t_bytes32,t_uint256)": {
       "encoding": "mapping",
@@ -133,12 +140,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_mapping(t_uint256,t_array(t_struct(CrossMsg)9570_storage)dyn_storage)": {
+    "t_mapping(t_uint256,t_array(t_struct(CrossMsg)10014_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct CrossMsg[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(CrossMsg)9570_storage)dyn_storage"
+      "value": "t_array(t_struct(CrossMsg)10014_storage)dyn_storage"
     },
     "t_mapping(t_uint256,t_mapping(t_address,t_bool))": {
       "encoding": "mapping",
@@ -147,19 +154,19 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_address,t_bool)"
     },
+    "t_mapping(t_uint256,t_mapping(t_address,t_uint256))": {
+      "encoding": "mapping",
+      "key": "t_uint256",
+      "label": "mapping(uint256 => mapping(address => uint256))",
+      "numberOfBytes": "32",
+      "value": "t_mapping(t_address,t_uint256)"
+    },
     "t_mapping(t_uint256,t_mapping(t_bytes32,t_uint256))": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => mapping(bytes32 => uint256))",
       "numberOfBytes": "32",
       "value": "t_mapping(t_bytes32,t_uint256)"
-    },
-    "t_mapping(t_uint256,t_struct(ParentFinality)9530_storage)": {
-      "encoding": "mapping",
-      "key": "t_uint256",
-      "label": "mapping(uint256 => struct ParentFinality)",
-      "numberOfBytes": "32",
-      "value": "t_struct(ParentFinality)9530_storage"
     },
     "t_mapping(t_uint64,t_mapping(t_bytes32,t_array(t_uint256)2_storage))": {
       "encoding": "mapping",
@@ -175,34 +182,34 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_bytes32,t_mapping(t_bytes32,t_bool))"
     },
-    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9550_storage)": {
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9994_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)9550_storage"
+      "value": "t_struct(BottomUpCheckpoint)9994_storage"
     },
-    "t_mapping(t_uint64,t_struct(EpochVoteTopDownSubmission)9618_storage)": {
+    "t_mapping(t_uint64,t_struct(EpochVoteTopDownSubmission)10062_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct EpochVoteTopDownSubmission)",
       "numberOfBytes": "32",
-      "value": "t_struct(EpochVoteTopDownSubmission)9618_storage"
+      "value": "t_struct(EpochVoteTopDownSubmission)10062_storage"
     },
-    "t_struct(BottomUpCheckpoint)9550_storage": {
+    "t_struct(BottomUpCheckpoint)9994_storage": {
       "encoding": "inplace",
       "label": "struct BottomUpCheckpoint",
       "members": [
         {
-          "astId": 9533,
+          "astId": 9977,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "source",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9675_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9535,
+          "astId": 9979,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "epoch",
           "offset": 0,
@@ -210,7 +217,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9537,
+          "astId": 9981,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "fee",
           "offset": 0,
@@ -218,23 +225,23 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9541,
+          "astId": 9985,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "crossMsgs",
           "offset": 0,
           "slot": "4",
-          "type": "t_array(t_struct(CrossMsg)9570_storage)dyn_storage"
+          "type": "t_array(t_struct(CrossMsg)10014_storage)dyn_storage"
         },
         {
-          "astId": 9545,
+          "astId": 9989,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "children",
           "offset": 0,
           "slot": "5",
-          "type": "t_array(t_struct(ChildCheck)9564_storage)dyn_storage"
+          "type": "t_array(t_struct(ChildCheck)10008_storage)dyn_storage"
         },
         {
-          "astId": 9547,
+          "astId": 9991,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "prevHash",
           "offset": 0,
@@ -242,7 +249,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 9549,
+          "astId": 9993,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "proof",
           "offset": 0,
@@ -252,20 +259,20 @@
       ],
       "numberOfBytes": "256"
     },
-    "t_struct(ChildCheck)9564_storage": {
+    "t_struct(ChildCheck)10008_storage": {
       "encoding": "inplace",
       "label": "struct ChildCheck",
       "members": [
         {
-          "astId": 9560,
+          "astId": 10004,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "source",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9675_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9563,
+          "astId": 10007,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "checks",
           "offset": 0,
@@ -275,20 +282,20 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(CrossMsg)9570_storage": {
+    "t_struct(CrossMsg)10014_storage": {
       "encoding": "inplace",
       "label": "struct CrossMsg",
       "members": [
         {
-          "astId": 9567,
+          "astId": 10011,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "message",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(StorableMsg)9585_storage"
+          "type": "t_struct(StorableMsg)10029_storage"
         },
         {
-          "astId": 9569,
+          "astId": 10013,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "wrapped",
           "offset": 0,
@@ -298,12 +305,12 @@
       ],
       "numberOfBytes": "384"
     },
-    "t_struct(EpochVoteSubmission)9609_storage": {
+    "t_struct(EpochVoteSubmission)10053_storage": {
       "encoding": "inplace",
       "label": "struct EpochVoteSubmission",
       "members": [
         {
-          "astId": 9592,
+          "astId": 10036,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "nonce",
           "offset": 0,
@@ -311,7 +318,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9594,
+          "astId": 10038,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "totalSubmissionWeight",
           "offset": 0,
@@ -319,7 +326,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9596,
+          "astId": 10040,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "mostVotedSubmission",
           "offset": 0,
@@ -327,7 +334,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 9602,
+          "astId": 10046,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "submitters",
           "offset": 0,
@@ -335,7 +342,7 @@
           "type": "t_mapping(t_uint256,t_mapping(t_address,t_bool))"
         },
         {
-          "astId": 9608,
+          "astId": 10052,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "submissionWeights",
           "offset": 0,
@@ -345,35 +352,35 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(EpochVoteTopDownSubmission)9618_storage": {
+    "t_struct(EpochVoteTopDownSubmission)10062_storage": {
       "encoding": "inplace",
       "label": "struct EpochVoteTopDownSubmission",
       "members": [
         {
-          "astId": 9612,
+          "astId": 10056,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "vote",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(EpochVoteSubmission)9609_storage"
+          "type": "t_struct(EpochVoteSubmission)10053_storage"
         },
         {
-          "astId": 9617,
+          "astId": 10061,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "submissions",
           "offset": 0,
           "slot": "5",
-          "type": "t_mapping(t_bytes32,t_struct(TopDownCheckpoint)9557_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(TopDownCheckpoint)10001_storage)"
         }
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(FvmAddress)9649_storage": {
+    "t_struct(FvmAddress)10093_storage": {
       "encoding": "inplace",
       "label": "struct FvmAddress",
       "members": [
         {
-          "astId": 9646,
+          "astId": 10090,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "addrType",
           "offset": 0,
@@ -381,7 +388,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 9648,
+          "astId": 10092,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "payload",
           "offset": 0,
@@ -391,257 +398,218 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(GatewayActorStorage)7901_storage": {
+    "t_struct(GatewayActorStorage)8350_storage": {
       "encoding": "inplace",
       "label": "struct GatewayActorStorage",
       "members": [
         {
-          "astId": 7802,
+          "astId": 8260,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "subnets",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_bytes32,t_struct(Subnet)9695_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(Subnet)10139_storage)"
         },
         {
-          "astId": 7811,
+          "astId": 8269,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "topDownMsgs",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)9570_storage)dyn_storage))"
+          "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)10014_storage)dyn_storage))"
         },
         {
-          "astId": 7817,
-          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-          "label": "finalitiesMap",
-          "offset": 0,
-          "slot": "2",
-          "type": "t_mapping(t_uint256,t_struct(ParentFinality)9530_storage)"
-        },
-        {
-          "astId": 7820,
-          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-          "label": "latestParentHeight",
-          "offset": 0,
-          "slot": "3",
-          "type": "t_uint256"
-        },
-        {
-          "astId": 7826,
+          "astId": 8275,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "postbox",
           "offset": 0,
-          "slot": "4",
-          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)9570_storage)"
+          "slot": "2",
+          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)10014_storage)"
         },
         {
-          "astId": 7832,
+          "astId": 8281,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpCheckpoints",
           "offset": 0,
-          "slot": "5",
-          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9550_storage)"
+          "slot": "3",
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9994_storage)"
         },
         {
-          "astId": 7839,
+          "astId": 8288,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "validatorSet",
           "offset": 0,
-          "slot": "6",
-          "type": "t_mapping(t_uint256,t_mapping(t_bytes32,t_uint256))"
+          "slot": "4",
+          "type": "t_mapping(t_uint256,t_mapping(t_address,t_uint256))"
         },
         {
-          "astId": 7848,
+          "astId": 8297,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "children",
           "offset": 0,
-          "slot": "7",
+          "slot": "5",
           "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_array(t_uint256)2_storage))"
         },
         {
-          "astId": 7857,
+          "astId": 8306,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "checks",
           "offset": 0,
-          "slot": "8",
+          "slot": "6",
           "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_mapping(t_bytes32,t_bool)))"
         },
         {
-          "astId": 7863,
+          "astId": 8312,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "epochVoteSubmissions",
           "offset": 0,
-          "slot": "9",
-          "type": "t_mapping(t_uint64,t_struct(EpochVoteTopDownSubmission)9618_storage)"
+          "slot": "7",
+          "type": "t_mapping(t_uint64,t_struct(EpochVoteTopDownSubmission)10062_storage)"
         },
         {
-          "astId": 7867,
+          "astId": 8316,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "subnetKeys",
           "offset": 0,
-          "slot": "10",
+          "slot": "8",
           "type": "t_array(t_bytes32)dyn_storage"
         },
         {
-          "astId": 7871,
+          "astId": 8320,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "networkName",
           "offset": 0,
-          "slot": "11",
-          "type": "t_struct(SubnetID)9675_storage"
+          "slot": "9",
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 7874,
+          "astId": 8323,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "minStake",
+          "offset": 0,
+          "slot": "11",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 8326,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "validatorNonce",
+          "offset": 0,
+          "slot": "12",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 8329,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "crossMsgFee",
           "offset": 0,
           "slot": "13",
           "type": "t_uint256"
         },
         {
-          "astId": 7877,
+          "astId": 8332,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-          "label": "validatorNonce",
+          "label": "totalWeight",
           "offset": 0,
           "slot": "14",
           "type": "t_uint256"
         },
         {
-          "astId": 7880,
-          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-          "label": "crossMsgFee",
-          "offset": 0,
-          "slot": "15",
-          "type": "t_uint256"
-        },
-        {
-          "astId": 7883,
-          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-          "label": "totalWeight",
-          "offset": 0,
-          "slot": "16",
-          "type": "t_uint256"
-        },
-        {
-          "astId": 7886,
+          "astId": 8335,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpNonce",
           "offset": 0,
-          "slot": "17",
+          "slot": "15",
           "type": "t_uint64"
         },
         {
-          "astId": 7889,
+          "astId": 8338,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "appliedTopDownNonce",
           "offset": 8,
-          "slot": "17",
+          "slot": "15",
           "type": "t_uint64"
         },
         {
-          "astId": 7892,
+          "astId": 8341,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "topDownCheckPeriod",
           "offset": 16,
-          "slot": "17",
+          "slot": "15",
           "type": "t_uint64"
         },
         {
-          "astId": 7895,
+          "astId": 8344,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "totalSubnets",
           "offset": 24,
-          "slot": "17",
+          "slot": "15",
           "type": "t_uint64"
         },
         {
-          "astId": 7897,
+          "astId": 8346,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpCheckPeriod",
           "offset": 0,
-          "slot": "18",
+          "slot": "16",
           "type": "t_uint64"
         },
         {
-          "astId": 7900,
+          "astId": 8349,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "initialized",
           "offset": 8,
-          "slot": "18",
+          "slot": "16",
           "type": "t_bool"
         }
       ],
-      "numberOfBytes": "608"
+      "numberOfBytes": "544"
     },
-    "t_struct(IPCAddress)9702_storage": {
+    "t_struct(IPCAddress)10146_storage": {
       "encoding": "inplace",
       "label": "struct IPCAddress",
       "members": [
         {
-          "astId": 9698,
+          "astId": 10142,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "subnetId",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9675_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9701,
+          "astId": 10145,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "rawAddress",
           "offset": 0,
           "slot": "2",
-          "type": "t_struct(FvmAddress)9649_storage"
+          "type": "t_struct(FvmAddress)10093_storage"
         }
       ],
       "numberOfBytes": "128"
     },
-    "t_struct(ParentFinality)9530_storage": {
-      "encoding": "inplace",
-      "label": "struct ParentFinality",
-      "members": [
-        {
-          "astId": 9527,
-          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-          "label": "height",
-          "offset": 0,
-          "slot": "0",
-          "type": "t_uint256"
-        },
-        {
-          "astId": 9529,
-          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-          "label": "blockHash",
-          "offset": 0,
-          "slot": "1",
-          "type": "t_bytes32"
-        }
-      ],
-      "numberOfBytes": "64"
-    },
-    "t_struct(StorableMsg)9585_storage": {
+    "t_struct(StorableMsg)10029_storage": {
       "encoding": "inplace",
       "label": "struct StorableMsg",
       "members": [
         {
-          "astId": 9573,
+          "astId": 10017,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "from",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(IPCAddress)9702_storage"
+          "type": "t_struct(IPCAddress)10146_storage"
         },
         {
-          "astId": 9576,
+          "astId": 10020,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "to",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(IPCAddress)9702_storage"
+          "type": "t_struct(IPCAddress)10146_storage"
         },
         {
-          "astId": 9578,
+          "astId": 10022,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "value",
           "offset": 0,
@@ -649,7 +617,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9580,
+          "astId": 10024,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "nonce",
           "offset": 0,
@@ -657,7 +625,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9582,
+          "astId": 10026,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "method",
           "offset": 8,
@@ -665,7 +633,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 9584,
+          "astId": 10028,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "params",
           "offset": 0,
@@ -675,12 +643,12 @@
       ],
       "numberOfBytes": "352"
     },
-    "t_struct(Subnet)9695_storage": {
+    "t_struct(Subnet)10139_storage": {
       "encoding": "inplace",
       "label": "struct Subnet",
       "members": [
         {
-          "astId": 9677,
+          "astId": 10121,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "stake",
           "offset": 0,
@@ -688,7 +656,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9679,
+          "astId": 10123,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "genesisEpoch",
           "offset": 0,
@@ -696,7 +664,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9681,
+          "astId": 10125,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "circSupply",
           "offset": 0,
@@ -704,7 +672,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9683,
+          "astId": 10127,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "topDownNonce",
           "offset": 0,
@@ -712,7 +680,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9685,
+          "astId": 10129,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "appliedBottomUpNonce",
           "offset": 8,
@@ -720,38 +688,38 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9688,
+          "astId": 10132,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "status",
           "offset": 16,
           "slot": "3",
-          "type": "t_enum(Status)3587"
+          "type": "t_enum(Status)4025"
         },
         {
-          "astId": 9691,
+          "astId": 10135,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "id",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(SubnetID)9675_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9694,
+          "astId": 10138,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "prevCheckpoint",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(BottomUpCheckpoint)9550_storage"
+          "type": "t_struct(BottomUpCheckpoint)9994_storage"
         }
       ],
       "numberOfBytes": "448"
     },
-    "t_struct(SubnetID)9675_storage": {
+    "t_struct(SubnetID)10119_storage": {
       "encoding": "inplace",
       "label": "struct SubnetID",
       "members": [
         {
-          "astId": 9670,
+          "astId": 10114,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "root",
           "offset": 0,
@@ -759,7 +727,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9674,
+          "astId": 10118,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "route",
           "offset": 0,
@@ -769,12 +737,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(TopDownCheckpoint)9557_storage": {
+    "t_struct(TopDownCheckpoint)10001_storage": {
       "encoding": "inplace",
       "label": "struct TopDownCheckpoint",
       "members": [
         {
-          "astId": 9552,
+          "astId": 9996,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "epoch",
           "offset": 0,
@@ -782,12 +750,12 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9556,
+          "astId": 10000,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "topDownMsgs",
           "offset": 0,
           "slot": "1",
-          "type": "t_array(t_struct(CrossMsg)9570_storage)dyn_storage"
+          "type": "t_array(t_struct(CrossMsg)10014_storage)dyn_storage"
         }
       ],
       "numberOfBytes": "64"

--- a/.storage-layouts/GatewayDiamond.json
+++ b/.storage-layouts/GatewayDiamond.json
@@ -6,7 +6,7 @@
       "label": "s",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(GatewayActorStorage)7901_storage"
+      "type": "t_struct(GatewayActorStorage)8350_storage"
     }
   ],
   "types": {
@@ -27,14 +27,14 @@
       "label": "bytes32[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(ChildCheck)9564_storage)dyn_storage": {
-      "base": "t_struct(ChildCheck)9564_storage",
+    "t_array(t_struct(ChildCheck)10008_storage)dyn_storage": {
+      "base": "t_struct(ChildCheck)10008_storage",
       "encoding": "dynamic_array",
       "label": "struct ChildCheck[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(CrossMsg)9570_storage)dyn_storage": {
-      "base": "t_struct(CrossMsg)9570_storage",
+    "t_array(t_struct(CrossMsg)10014_storage)dyn_storage": {
+      "base": "t_struct(CrossMsg)10014_storage",
       "encoding": "dynamic_array",
       "label": "struct CrossMsg[]",
       "numberOfBytes": "32"
@@ -65,7 +65,7 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_enum(Status)3587": {
+    "t_enum(Status)4025": {
       "encoding": "inplace",
       "label": "enum Status",
       "numberOfBytes": "1"
@@ -76,6 +76,13 @@
       "label": "mapping(address => bool)",
       "numberOfBytes": "32",
       "value": "t_bool"
+    },
+    "t_mapping(t_address,t_uint256)": {
+      "encoding": "mapping",
+      "key": "t_address",
+      "label": "mapping(address => uint256)",
+      "numberOfBytes": "32",
+      "value": "t_uint256"
     },
     "t_mapping(t_bytes32,t_array(t_uint256)2_storage)": {
       "encoding": "mapping",
@@ -98,33 +105,33 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_bytes32,t_bool)"
     },
-    "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)9570_storage)dyn_storage))": {
+    "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)10014_storage)dyn_storage))": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => mapping(uint256 => struct CrossMsg[]))",
       "numberOfBytes": "32",
-      "value": "t_mapping(t_uint256,t_array(t_struct(CrossMsg)9570_storage)dyn_storage)"
+      "value": "t_mapping(t_uint256,t_array(t_struct(CrossMsg)10014_storage)dyn_storage)"
     },
-    "t_mapping(t_bytes32,t_struct(CrossMsg)9570_storage)": {
+    "t_mapping(t_bytes32,t_struct(CrossMsg)10014_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct CrossMsg)",
       "numberOfBytes": "32",
-      "value": "t_struct(CrossMsg)9570_storage"
+      "value": "t_struct(CrossMsg)10014_storage"
     },
-    "t_mapping(t_bytes32,t_struct(Subnet)9695_storage)": {
+    "t_mapping(t_bytes32,t_struct(Subnet)10139_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct Subnet)",
       "numberOfBytes": "32",
-      "value": "t_struct(Subnet)9695_storage"
+      "value": "t_struct(Subnet)10139_storage"
     },
-    "t_mapping(t_bytes32,t_struct(TopDownCheckpoint)9557_storage)": {
+    "t_mapping(t_bytes32,t_struct(TopDownCheckpoint)10001_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct TopDownCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(TopDownCheckpoint)9557_storage"
+      "value": "t_struct(TopDownCheckpoint)10001_storage"
     },
     "t_mapping(t_bytes32,t_uint256)": {
       "encoding": "mapping",
@@ -133,12 +140,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_mapping(t_uint256,t_array(t_struct(CrossMsg)9570_storage)dyn_storage)": {
+    "t_mapping(t_uint256,t_array(t_struct(CrossMsg)10014_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct CrossMsg[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(CrossMsg)9570_storage)dyn_storage"
+      "value": "t_array(t_struct(CrossMsg)10014_storage)dyn_storage"
     },
     "t_mapping(t_uint256,t_mapping(t_address,t_bool))": {
       "encoding": "mapping",
@@ -147,19 +154,19 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_address,t_bool)"
     },
+    "t_mapping(t_uint256,t_mapping(t_address,t_uint256))": {
+      "encoding": "mapping",
+      "key": "t_uint256",
+      "label": "mapping(uint256 => mapping(address => uint256))",
+      "numberOfBytes": "32",
+      "value": "t_mapping(t_address,t_uint256)"
+    },
     "t_mapping(t_uint256,t_mapping(t_bytes32,t_uint256))": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => mapping(bytes32 => uint256))",
       "numberOfBytes": "32",
       "value": "t_mapping(t_bytes32,t_uint256)"
-    },
-    "t_mapping(t_uint256,t_struct(ParentFinality)9530_storage)": {
-      "encoding": "mapping",
-      "key": "t_uint256",
-      "label": "mapping(uint256 => struct ParentFinality)",
-      "numberOfBytes": "32",
-      "value": "t_struct(ParentFinality)9530_storage"
     },
     "t_mapping(t_uint64,t_mapping(t_bytes32,t_array(t_uint256)2_storage))": {
       "encoding": "mapping",
@@ -175,34 +182,34 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_bytes32,t_mapping(t_bytes32,t_bool))"
     },
-    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9550_storage)": {
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9994_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)9550_storage"
+      "value": "t_struct(BottomUpCheckpoint)9994_storage"
     },
-    "t_mapping(t_uint64,t_struct(EpochVoteTopDownSubmission)9618_storage)": {
+    "t_mapping(t_uint64,t_struct(EpochVoteTopDownSubmission)10062_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct EpochVoteTopDownSubmission)",
       "numberOfBytes": "32",
-      "value": "t_struct(EpochVoteTopDownSubmission)9618_storage"
+      "value": "t_struct(EpochVoteTopDownSubmission)10062_storage"
     },
-    "t_struct(BottomUpCheckpoint)9550_storage": {
+    "t_struct(BottomUpCheckpoint)9994_storage": {
       "encoding": "inplace",
       "label": "struct BottomUpCheckpoint",
       "members": [
         {
-          "astId": 9533,
+          "astId": 9977,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "source",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9675_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9535,
+          "astId": 9979,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "epoch",
           "offset": 0,
@@ -210,7 +217,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9537,
+          "astId": 9981,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "fee",
           "offset": 0,
@@ -218,23 +225,23 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9541,
+          "astId": 9985,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "crossMsgs",
           "offset": 0,
           "slot": "4",
-          "type": "t_array(t_struct(CrossMsg)9570_storage)dyn_storage"
+          "type": "t_array(t_struct(CrossMsg)10014_storage)dyn_storage"
         },
         {
-          "astId": 9545,
+          "astId": 9989,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "children",
           "offset": 0,
           "slot": "5",
-          "type": "t_array(t_struct(ChildCheck)9564_storage)dyn_storage"
+          "type": "t_array(t_struct(ChildCheck)10008_storage)dyn_storage"
         },
         {
-          "astId": 9547,
+          "astId": 9991,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "prevHash",
           "offset": 0,
@@ -242,7 +249,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 9549,
+          "astId": 9993,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "proof",
           "offset": 0,
@@ -252,20 +259,20 @@
       ],
       "numberOfBytes": "256"
     },
-    "t_struct(ChildCheck)9564_storage": {
+    "t_struct(ChildCheck)10008_storage": {
       "encoding": "inplace",
       "label": "struct ChildCheck",
       "members": [
         {
-          "astId": 9560,
+          "astId": 10004,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "source",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9675_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9563,
+          "astId": 10007,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "checks",
           "offset": 0,
@@ -275,20 +282,20 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(CrossMsg)9570_storage": {
+    "t_struct(CrossMsg)10014_storage": {
       "encoding": "inplace",
       "label": "struct CrossMsg",
       "members": [
         {
-          "astId": 9567,
+          "astId": 10011,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "message",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(StorableMsg)9585_storage"
+          "type": "t_struct(StorableMsg)10029_storage"
         },
         {
-          "astId": 9569,
+          "astId": 10013,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "wrapped",
           "offset": 0,
@@ -298,12 +305,12 @@
       ],
       "numberOfBytes": "384"
     },
-    "t_struct(EpochVoteSubmission)9609_storage": {
+    "t_struct(EpochVoteSubmission)10053_storage": {
       "encoding": "inplace",
       "label": "struct EpochVoteSubmission",
       "members": [
         {
-          "astId": 9592,
+          "astId": 10036,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "nonce",
           "offset": 0,
@@ -311,7 +318,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9594,
+          "astId": 10038,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "totalSubmissionWeight",
           "offset": 0,
@@ -319,7 +326,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9596,
+          "astId": 10040,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "mostVotedSubmission",
           "offset": 0,
@@ -327,7 +334,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 9602,
+          "astId": 10046,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "submitters",
           "offset": 0,
@@ -335,7 +342,7 @@
           "type": "t_mapping(t_uint256,t_mapping(t_address,t_bool))"
         },
         {
-          "astId": 9608,
+          "astId": 10052,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "submissionWeights",
           "offset": 0,
@@ -345,35 +352,35 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(EpochVoteTopDownSubmission)9618_storage": {
+    "t_struct(EpochVoteTopDownSubmission)10062_storage": {
       "encoding": "inplace",
       "label": "struct EpochVoteTopDownSubmission",
       "members": [
         {
-          "astId": 9612,
+          "astId": 10056,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "vote",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(EpochVoteSubmission)9609_storage"
+          "type": "t_struct(EpochVoteSubmission)10053_storage"
         },
         {
-          "astId": 9617,
+          "astId": 10061,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "submissions",
           "offset": 0,
           "slot": "5",
-          "type": "t_mapping(t_bytes32,t_struct(TopDownCheckpoint)9557_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(TopDownCheckpoint)10001_storage)"
         }
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(FvmAddress)9649_storage": {
+    "t_struct(FvmAddress)10093_storage": {
       "encoding": "inplace",
       "label": "struct FvmAddress",
       "members": [
         {
-          "astId": 9646,
+          "astId": 10090,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "addrType",
           "offset": 0,
@@ -381,7 +388,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 9648,
+          "astId": 10092,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "payload",
           "offset": 0,
@@ -391,257 +398,218 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(GatewayActorStorage)7901_storage": {
+    "t_struct(GatewayActorStorage)8350_storage": {
       "encoding": "inplace",
       "label": "struct GatewayActorStorage",
       "members": [
         {
-          "astId": 7802,
+          "astId": 8260,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "subnets",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_bytes32,t_struct(Subnet)9695_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(Subnet)10139_storage)"
         },
         {
-          "astId": 7811,
+          "astId": 8269,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "topDownMsgs",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)9570_storage)dyn_storage))"
+          "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)10014_storage)dyn_storage))"
         },
         {
-          "astId": 7817,
-          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-          "label": "finalitiesMap",
-          "offset": 0,
-          "slot": "2",
-          "type": "t_mapping(t_uint256,t_struct(ParentFinality)9530_storage)"
-        },
-        {
-          "astId": 7820,
-          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-          "label": "latestParentHeight",
-          "offset": 0,
-          "slot": "3",
-          "type": "t_uint256"
-        },
-        {
-          "astId": 7826,
+          "astId": 8275,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "postbox",
           "offset": 0,
-          "slot": "4",
-          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)9570_storage)"
+          "slot": "2",
+          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)10014_storage)"
         },
         {
-          "astId": 7832,
+          "astId": 8281,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpCheckpoints",
           "offset": 0,
-          "slot": "5",
-          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9550_storage)"
+          "slot": "3",
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9994_storage)"
         },
         {
-          "astId": 7839,
+          "astId": 8288,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "validatorSet",
           "offset": 0,
-          "slot": "6",
-          "type": "t_mapping(t_uint256,t_mapping(t_bytes32,t_uint256))"
+          "slot": "4",
+          "type": "t_mapping(t_uint256,t_mapping(t_address,t_uint256))"
         },
         {
-          "astId": 7848,
+          "astId": 8297,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "children",
           "offset": 0,
-          "slot": "7",
+          "slot": "5",
           "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_array(t_uint256)2_storage))"
         },
         {
-          "astId": 7857,
+          "astId": 8306,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "checks",
           "offset": 0,
-          "slot": "8",
+          "slot": "6",
           "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_mapping(t_bytes32,t_bool)))"
         },
         {
-          "astId": 7863,
+          "astId": 8312,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "epochVoteSubmissions",
           "offset": 0,
-          "slot": "9",
-          "type": "t_mapping(t_uint64,t_struct(EpochVoteTopDownSubmission)9618_storage)"
+          "slot": "7",
+          "type": "t_mapping(t_uint64,t_struct(EpochVoteTopDownSubmission)10062_storage)"
         },
         {
-          "astId": 7867,
+          "astId": 8316,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "subnetKeys",
           "offset": 0,
-          "slot": "10",
+          "slot": "8",
           "type": "t_array(t_bytes32)dyn_storage"
         },
         {
-          "astId": 7871,
+          "astId": 8320,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "networkName",
           "offset": 0,
-          "slot": "11",
-          "type": "t_struct(SubnetID)9675_storage"
+          "slot": "9",
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 7874,
+          "astId": 8323,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "minStake",
+          "offset": 0,
+          "slot": "11",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 8326,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "validatorNonce",
+          "offset": 0,
+          "slot": "12",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 8329,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "crossMsgFee",
           "offset": 0,
           "slot": "13",
           "type": "t_uint256"
         },
         {
-          "astId": 7877,
+          "astId": 8332,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-          "label": "validatorNonce",
+          "label": "totalWeight",
           "offset": 0,
           "slot": "14",
           "type": "t_uint256"
         },
         {
-          "astId": 7880,
-          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-          "label": "crossMsgFee",
-          "offset": 0,
-          "slot": "15",
-          "type": "t_uint256"
-        },
-        {
-          "astId": 7883,
-          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-          "label": "totalWeight",
-          "offset": 0,
-          "slot": "16",
-          "type": "t_uint256"
-        },
-        {
-          "astId": 7886,
+          "astId": 8335,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpNonce",
           "offset": 0,
-          "slot": "17",
+          "slot": "15",
           "type": "t_uint64"
         },
         {
-          "astId": 7889,
+          "astId": 8338,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "appliedTopDownNonce",
           "offset": 8,
-          "slot": "17",
+          "slot": "15",
           "type": "t_uint64"
         },
         {
-          "astId": 7892,
+          "astId": 8341,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "topDownCheckPeriod",
           "offset": 16,
-          "slot": "17",
+          "slot": "15",
           "type": "t_uint64"
         },
         {
-          "astId": 7895,
+          "astId": 8344,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "totalSubnets",
           "offset": 24,
-          "slot": "17",
+          "slot": "15",
           "type": "t_uint64"
         },
         {
-          "astId": 7897,
+          "astId": 8346,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpCheckPeriod",
           "offset": 0,
-          "slot": "18",
+          "slot": "16",
           "type": "t_uint64"
         },
         {
-          "astId": 7900,
+          "astId": 8349,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "initialized",
           "offset": 8,
-          "slot": "18",
+          "slot": "16",
           "type": "t_bool"
         }
       ],
-      "numberOfBytes": "608"
+      "numberOfBytes": "544"
     },
-    "t_struct(IPCAddress)9702_storage": {
+    "t_struct(IPCAddress)10146_storage": {
       "encoding": "inplace",
       "label": "struct IPCAddress",
       "members": [
         {
-          "astId": 9698,
+          "astId": 10142,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "subnetId",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9675_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9701,
+          "astId": 10145,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "rawAddress",
           "offset": 0,
           "slot": "2",
-          "type": "t_struct(FvmAddress)9649_storage"
+          "type": "t_struct(FvmAddress)10093_storage"
         }
       ],
       "numberOfBytes": "128"
     },
-    "t_struct(ParentFinality)9530_storage": {
-      "encoding": "inplace",
-      "label": "struct ParentFinality",
-      "members": [
-        {
-          "astId": 9527,
-          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-          "label": "height",
-          "offset": 0,
-          "slot": "0",
-          "type": "t_uint256"
-        },
-        {
-          "astId": 9529,
-          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-          "label": "blockHash",
-          "offset": 0,
-          "slot": "1",
-          "type": "t_bytes32"
-        }
-      ],
-      "numberOfBytes": "64"
-    },
-    "t_struct(StorableMsg)9585_storage": {
+    "t_struct(StorableMsg)10029_storage": {
       "encoding": "inplace",
       "label": "struct StorableMsg",
       "members": [
         {
-          "astId": 9573,
+          "astId": 10017,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "from",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(IPCAddress)9702_storage"
+          "type": "t_struct(IPCAddress)10146_storage"
         },
         {
-          "astId": 9576,
+          "astId": 10020,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "to",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(IPCAddress)9702_storage"
+          "type": "t_struct(IPCAddress)10146_storage"
         },
         {
-          "astId": 9578,
+          "astId": 10022,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "value",
           "offset": 0,
@@ -649,7 +617,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9580,
+          "astId": 10024,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "nonce",
           "offset": 0,
@@ -657,7 +625,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9582,
+          "astId": 10026,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "method",
           "offset": 8,
@@ -665,7 +633,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 9584,
+          "astId": 10028,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "params",
           "offset": 0,
@@ -675,12 +643,12 @@
       ],
       "numberOfBytes": "352"
     },
-    "t_struct(Subnet)9695_storage": {
+    "t_struct(Subnet)10139_storage": {
       "encoding": "inplace",
       "label": "struct Subnet",
       "members": [
         {
-          "astId": 9677,
+          "astId": 10121,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "stake",
           "offset": 0,
@@ -688,7 +656,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9679,
+          "astId": 10123,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "genesisEpoch",
           "offset": 0,
@@ -696,7 +664,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9681,
+          "astId": 10125,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "circSupply",
           "offset": 0,
@@ -704,7 +672,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9683,
+          "astId": 10127,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "topDownNonce",
           "offset": 0,
@@ -712,7 +680,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9685,
+          "astId": 10129,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "appliedBottomUpNonce",
           "offset": 8,
@@ -720,38 +688,38 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9688,
+          "astId": 10132,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "status",
           "offset": 16,
           "slot": "3",
-          "type": "t_enum(Status)3587"
+          "type": "t_enum(Status)4025"
         },
         {
-          "astId": 9691,
+          "astId": 10135,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "id",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(SubnetID)9675_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9694,
+          "astId": 10138,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "prevCheckpoint",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(BottomUpCheckpoint)9550_storage"
+          "type": "t_struct(BottomUpCheckpoint)9994_storage"
         }
       ],
       "numberOfBytes": "448"
     },
-    "t_struct(SubnetID)9675_storage": {
+    "t_struct(SubnetID)10119_storage": {
       "encoding": "inplace",
       "label": "struct SubnetID",
       "members": [
         {
-          "astId": 9670,
+          "astId": 10114,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "root",
           "offset": 0,
@@ -759,7 +727,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9674,
+          "astId": 10118,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "route",
           "offset": 0,
@@ -769,12 +737,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(TopDownCheckpoint)9557_storage": {
+    "t_struct(TopDownCheckpoint)10001_storage": {
       "encoding": "inplace",
       "label": "struct TopDownCheckpoint",
       "members": [
         {
-          "astId": 9552,
+          "astId": 9996,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "epoch",
           "offset": 0,
@@ -782,12 +750,12 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9556,
+          "astId": 10000,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "topDownMsgs",
           "offset": 0,
           "slot": "1",
-          "type": "t_array(t_struct(CrossMsg)9570_storage)dyn_storage"
+          "type": "t_array(t_struct(CrossMsg)10014_storage)dyn_storage"
         }
       ],
       "numberOfBytes": "64"

--- a/.storage-layouts/SubnetActorDiamond.json
+++ b/.storage-layouts/SubnetActorDiamond.json
@@ -6,7 +6,7 @@
       "label": "s",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(SubnetActorStorage)8131_storage"
+      "type": "t_struct(SubnetActorStorage)8580_storage"
     }
   ],
   "types": {
@@ -27,14 +27,14 @@
       "label": "bytes32[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(ChildCheck)9564_storage)dyn_storage": {
-      "base": "t_struct(ChildCheck)9564_storage",
+    "t_array(t_struct(ChildCheck)10008_storage)dyn_storage": {
+      "base": "t_struct(ChildCheck)10008_storage",
       "encoding": "dynamic_array",
       "label": "struct ChildCheck[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(CrossMsg)9570_storage)dyn_storage": {
-      "base": "t_struct(CrossMsg)9570_storage",
+    "t_array(t_struct(CrossMsg)10014_storage)dyn_storage": {
+      "base": "t_struct(CrossMsg)10014_storage",
       "encoding": "dynamic_array",
       "label": "struct CrossMsg[]",
       "numberOfBytes": "32"
@@ -59,12 +59,12 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_enum(ConsensusType)3573": {
+    "t_enum(ConsensusType)4011": {
       "encoding": "inplace",
       "label": "enum ConsensusType",
       "numberOfBytes": "1"
     },
-    "t_enum(Status)3587": {
+    "t_enum(Status)4025": {
       "encoding": "inplace",
       "label": "enum Status",
       "numberOfBytes": "1"
@@ -83,12 +83,12 @@
       "numberOfBytes": "32",
       "value": "t_string_storage"
     },
-    "t_mapping(t_address,t_struct(FvmAddress)9649_storage)": {
+    "t_mapping(t_address,t_struct(FvmAddress)10093_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct FvmAddress)",
       "numberOfBytes": "32",
-      "value": "t_struct(FvmAddress)9649_storage"
+      "value": "t_struct(FvmAddress)10093_storage"
     },
     "t_mapping(t_address,t_uint256)": {
       "encoding": "mapping",
@@ -97,12 +97,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_mapping(t_bytes32,t_struct(BottomUpCheckpoint)9550_storage)": {
+    "t_mapping(t_bytes32,t_struct(BottomUpCheckpoint)9994_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)9550_storage"
+      "value": "t_struct(BottomUpCheckpoint)9994_storage"
     },
     "t_mapping(t_bytes32,t_uint256)": {
       "encoding": "mapping",
@@ -125,19 +125,19 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_bytes32,t_uint256)"
     },
-    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9550_storage)": {
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9994_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)9550_storage"
+      "value": "t_struct(BottomUpCheckpoint)9994_storage"
     },
-    "t_mapping(t_uint64,t_struct(EpochVoteBottomUpSubmission)9627_storage)": {
+    "t_mapping(t_uint64,t_struct(EpochVoteBottomUpSubmission)10071_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct EpochVoteBottomUpSubmission)",
       "numberOfBytes": "32",
-      "value": "t_struct(EpochVoteBottomUpSubmission)9627_storage"
+      "value": "t_struct(EpochVoteBottomUpSubmission)10071_storage"
     },
     "t_string_storage": {
       "encoding": "bytes",
@@ -159,20 +159,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(BottomUpCheckpoint)9550_storage": {
+    "t_struct(BottomUpCheckpoint)9994_storage": {
       "encoding": "inplace",
       "label": "struct BottomUpCheckpoint",
       "members": [
         {
-          "astId": 9533,
+          "astId": 9977,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "source",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9675_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9535,
+          "astId": 9979,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "epoch",
           "offset": 0,
@@ -180,7 +180,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9537,
+          "astId": 9981,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "fee",
           "offset": 0,
@@ -188,23 +188,23 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9541,
+          "astId": 9985,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "crossMsgs",
           "offset": 0,
           "slot": "4",
-          "type": "t_array(t_struct(CrossMsg)9570_storage)dyn_storage"
+          "type": "t_array(t_struct(CrossMsg)10014_storage)dyn_storage"
         },
         {
-          "astId": 9545,
+          "astId": 9989,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "children",
           "offset": 0,
           "slot": "5",
-          "type": "t_array(t_struct(ChildCheck)9564_storage)dyn_storage"
+          "type": "t_array(t_struct(ChildCheck)10008_storage)dyn_storage"
         },
         {
-          "astId": 9547,
+          "astId": 9991,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "prevHash",
           "offset": 0,
@@ -212,7 +212,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 9549,
+          "astId": 9993,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "proof",
           "offset": 0,
@@ -222,20 +222,20 @@
       ],
       "numberOfBytes": "256"
     },
-    "t_struct(ChildCheck)9564_storage": {
+    "t_struct(ChildCheck)10008_storage": {
       "encoding": "inplace",
       "label": "struct ChildCheck",
       "members": [
         {
-          "astId": 9560,
+          "astId": 10004,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "source",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9675_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9563,
+          "astId": 10007,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "checks",
           "offset": 0,
@@ -245,20 +245,20 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(CrossMsg)9570_storage": {
+    "t_struct(CrossMsg)10014_storage": {
       "encoding": "inplace",
       "label": "struct CrossMsg",
       "members": [
         {
-          "astId": 9567,
+          "astId": 10011,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "message",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(StorableMsg)9585_storage"
+          "type": "t_struct(StorableMsg)10029_storage"
         },
         {
-          "astId": 9569,
+          "astId": 10013,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "wrapped",
           "offset": 0,
@@ -268,35 +268,35 @@
       ],
       "numberOfBytes": "384"
     },
-    "t_struct(EpochVoteBottomUpSubmission)9627_storage": {
+    "t_struct(EpochVoteBottomUpSubmission)10071_storage": {
       "encoding": "inplace",
       "label": "struct EpochVoteBottomUpSubmission",
       "members": [
         {
-          "astId": 9621,
+          "astId": 10065,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "vote",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(EpochVoteSubmission)9609_storage"
+          "type": "t_struct(EpochVoteSubmission)10053_storage"
         },
         {
-          "astId": 9626,
+          "astId": 10070,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "submissions",
           "offset": 0,
           "slot": "5",
-          "type": "t_mapping(t_bytes32,t_struct(BottomUpCheckpoint)9550_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(BottomUpCheckpoint)9994_storage)"
         }
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(EpochVoteSubmission)9609_storage": {
+    "t_struct(EpochVoteSubmission)10053_storage": {
       "encoding": "inplace",
       "label": "struct EpochVoteSubmission",
       "members": [
         {
-          "astId": 9592,
+          "astId": 10036,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "nonce",
           "offset": 0,
@@ -304,7 +304,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9594,
+          "astId": 10038,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "totalSubmissionWeight",
           "offset": 0,
@@ -312,7 +312,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9596,
+          "astId": 10040,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "mostVotedSubmission",
           "offset": 0,
@@ -320,7 +320,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 9602,
+          "astId": 10046,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "submitters",
           "offset": 0,
@@ -328,7 +328,7 @@
           "type": "t_mapping(t_uint256,t_mapping(t_address,t_bool))"
         },
         {
-          "astId": 9608,
+          "astId": 10052,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "submissionWeights",
           "offset": 0,
@@ -338,12 +338,12 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(FvmAddress)9649_storage": {
+    "t_struct(FvmAddress)10093_storage": {
       "encoding": "inplace",
       "label": "struct FvmAddress",
       "members": [
         {
-          "astId": 9646,
+          "astId": 10090,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "addrType",
           "offset": 0,
@@ -351,7 +351,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 9648,
+          "astId": 10092,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "payload",
           "offset": 0,
@@ -361,25 +361,25 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(IPCAddress)9702_storage": {
+    "t_struct(IPCAddress)10146_storage": {
       "encoding": "inplace",
       "label": "struct IPCAddress",
       "members": [
         {
-          "astId": 9698,
+          "astId": 10142,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "subnetId",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9675_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9701,
+          "astId": 10145,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "rawAddress",
           "offset": 0,
           "slot": "2",
-          "type": "t_struct(FvmAddress)9649_storage"
+          "type": "t_struct(FvmAddress)10093_storage"
         }
       ],
       "numberOfBytes": "128"
@@ -407,28 +407,28 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StorableMsg)9585_storage": {
+    "t_struct(StorableMsg)10029_storage": {
       "encoding": "inplace",
       "label": "struct StorableMsg",
       "members": [
         {
-          "astId": 9573,
+          "astId": 10017,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "from",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(IPCAddress)9702_storage"
+          "type": "t_struct(IPCAddress)10146_storage"
         },
         {
-          "astId": 9576,
+          "astId": 10020,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "to",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(IPCAddress)9702_storage"
+          "type": "t_struct(IPCAddress)10146_storage"
         },
         {
-          "astId": 9578,
+          "astId": 10022,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "value",
           "offset": 0,
@@ -436,7 +436,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9580,
+          "astId": 10024,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "nonce",
           "offset": 0,
@@ -444,7 +444,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9582,
+          "astId": 10026,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "method",
           "offset": 8,
@@ -452,7 +452,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 9584,
+          "astId": 10028,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "params",
           "offset": 0,
@@ -462,20 +462,20 @@
       ],
       "numberOfBytes": "352"
     },
-    "t_struct(SubnetActorStorage)8131_storage": {
+    "t_struct(SubnetActorStorage)8580_storage": {
       "encoding": "inplace",
       "label": "struct SubnetActorStorage",
       "members": [
         {
-          "astId": 8055,
+          "astId": 8504,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "epochVoteSubmissions",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_uint64,t_struct(EpochVoteBottomUpSubmission)9627_storage)"
+          "type": "t_mapping(t_uint64,t_struct(EpochVoteBottomUpSubmission)10071_storage)"
         },
         {
-          "astId": 8060,
+          "astId": 8509,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "stake",
           "offset": 0,
@@ -483,7 +483,7 @@
           "type": "t_mapping(t_address,t_uint256)"
         },
         {
-          "astId": 8065,
+          "astId": 8514,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "accumulatedRewards",
           "offset": 0,
@@ -491,7 +491,7 @@
           "type": "t_mapping(t_address,t_uint256)"
         },
         {
-          "astId": 8070,
+          "astId": 8519,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "validatorNetAddresses",
           "offset": 0,
@@ -499,23 +499,23 @@
           "type": "t_mapping(t_address,t_string_storage)"
         },
         {
-          "astId": 8076,
+          "astId": 8525,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "validatorWorkerAddresses",
           "offset": 0,
           "slot": "4",
-          "type": "t_mapping(t_address,t_struct(FvmAddress)9649_storage)"
+          "type": "t_mapping(t_address,t_struct(FvmAddress)10093_storage)"
         },
         {
-          "astId": 8082,
+          "astId": 8531,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "committedCheckpoints",
           "offset": 0,
           "slot": "5",
-          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9550_storage)"
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9994_storage)"
         },
         {
-          "astId": 8085,
+          "astId": 8534,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "genesis",
           "offset": 0,
@@ -523,7 +523,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 8088,
+          "astId": 8537,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "totalStake",
           "offset": 0,
@@ -531,7 +531,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 8091,
+          "astId": 8540,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "minActivationCollateral",
           "offset": 0,
@@ -539,7 +539,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 8094,
+          "astId": 8543,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "configurationNumber",
           "offset": 0,
@@ -547,7 +547,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 8097,
+          "astId": 8546,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "topDownCheckPeriod",
           "offset": 8,
@@ -555,7 +555,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 8100,
+          "astId": 8549,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "bottomUpCheckPeriod",
           "offset": 16,
@@ -563,7 +563,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 8103,
+          "astId": 8552,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "minValidators",
           "offset": 24,
@@ -571,7 +571,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 8106,
+          "astId": 8555,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "name",
           "offset": 0,
@@ -579,7 +579,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 8108,
+          "astId": 8557,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "currentSubnetHash",
           "offset": 0,
@@ -587,7 +587,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 8111,
+          "astId": 8560,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "prevExecutedCheckpointHash",
           "offset": 0,
@@ -595,7 +595,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 8114,
+          "astId": 8563,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "ipcGatewayAddr",
           "offset": 0,
@@ -603,15 +603,15 @@
           "type": "t_address"
         },
         {
-          "astId": 8118,
+          "astId": 8567,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "status",
           "offset": 20,
           "slot": "13",
-          "type": "t_enum(Status)3587"
+          "type": "t_enum(Status)4025"
         },
         {
-          "astId": 8122,
+          "astId": 8571,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "validators",
           "offset": 0,
@@ -619,30 +619,30 @@
           "type": "t_struct(AddressSet)2473_storage"
         },
         {
-          "astId": 8126,
+          "astId": 8575,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "parentId",
           "offset": 0,
           "slot": "16",
-          "type": "t_struct(SubnetID)9675_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 8130,
+          "astId": 8579,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "consensus",
           "offset": 0,
           "slot": "18",
-          "type": "t_enum(ConsensusType)3573"
+          "type": "t_enum(ConsensusType)4011"
         }
       ],
       "numberOfBytes": "608"
     },
-    "t_struct(SubnetID)9675_storage": {
+    "t_struct(SubnetID)10119_storage": {
       "encoding": "inplace",
       "label": "struct SubnetID",
       "members": [
         {
-          "astId": 9670,
+          "astId": 10114,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "root",
           "offset": 0,
@@ -650,7 +650,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9674,
+          "astId": 10118,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "route",
           "offset": 0,

--- a/.storage-layouts/SubnetActorModifiers.json
+++ b/.storage-layouts/SubnetActorModifiers.json
@@ -1,12 +1,12 @@
 {
   "storage": [
     {
-      "astId": 8143,
+      "astId": 8592,
       "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
       "label": "s",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(SubnetActorStorage)8131_storage"
+      "type": "t_struct(SubnetActorStorage)8580_storage"
     }
   ],
   "types": {
@@ -27,14 +27,14 @@
       "label": "bytes32[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(ChildCheck)9564_storage)dyn_storage": {
-      "base": "t_struct(ChildCheck)9564_storage",
+    "t_array(t_struct(ChildCheck)10008_storage)dyn_storage": {
+      "base": "t_struct(ChildCheck)10008_storage",
       "encoding": "dynamic_array",
       "label": "struct ChildCheck[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(CrossMsg)9570_storage)dyn_storage": {
-      "base": "t_struct(CrossMsg)9570_storage",
+    "t_array(t_struct(CrossMsg)10014_storage)dyn_storage": {
+      "base": "t_struct(CrossMsg)10014_storage",
       "encoding": "dynamic_array",
       "label": "struct CrossMsg[]",
       "numberOfBytes": "32"
@@ -59,12 +59,12 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_enum(ConsensusType)3573": {
+    "t_enum(ConsensusType)4011": {
       "encoding": "inplace",
       "label": "enum ConsensusType",
       "numberOfBytes": "1"
     },
-    "t_enum(Status)3587": {
+    "t_enum(Status)4025": {
       "encoding": "inplace",
       "label": "enum Status",
       "numberOfBytes": "1"
@@ -83,12 +83,12 @@
       "numberOfBytes": "32",
       "value": "t_string_storage"
     },
-    "t_mapping(t_address,t_struct(FvmAddress)9649_storage)": {
+    "t_mapping(t_address,t_struct(FvmAddress)10093_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct FvmAddress)",
       "numberOfBytes": "32",
-      "value": "t_struct(FvmAddress)9649_storage"
+      "value": "t_struct(FvmAddress)10093_storage"
     },
     "t_mapping(t_address,t_uint256)": {
       "encoding": "mapping",
@@ -97,12 +97,12 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_mapping(t_bytes32,t_struct(BottomUpCheckpoint)9550_storage)": {
+    "t_mapping(t_bytes32,t_struct(BottomUpCheckpoint)9994_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)9550_storage"
+      "value": "t_struct(BottomUpCheckpoint)9994_storage"
     },
     "t_mapping(t_bytes32,t_uint256)": {
       "encoding": "mapping",
@@ -125,19 +125,19 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_bytes32,t_uint256)"
     },
-    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9550_storage)": {
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9994_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)9550_storage"
+      "value": "t_struct(BottomUpCheckpoint)9994_storage"
     },
-    "t_mapping(t_uint64,t_struct(EpochVoteBottomUpSubmission)9627_storage)": {
+    "t_mapping(t_uint64,t_struct(EpochVoteBottomUpSubmission)10071_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct EpochVoteBottomUpSubmission)",
       "numberOfBytes": "32",
-      "value": "t_struct(EpochVoteBottomUpSubmission)9627_storage"
+      "value": "t_struct(EpochVoteBottomUpSubmission)10071_storage"
     },
     "t_string_storage": {
       "encoding": "bytes",
@@ -159,20 +159,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(BottomUpCheckpoint)9550_storage": {
+    "t_struct(BottomUpCheckpoint)9994_storage": {
       "encoding": "inplace",
       "label": "struct BottomUpCheckpoint",
       "members": [
         {
-          "astId": 9533,
+          "astId": 9977,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "source",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9675_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9535,
+          "astId": 9979,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "epoch",
           "offset": 0,
@@ -180,7 +180,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9537,
+          "astId": 9981,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "fee",
           "offset": 0,
@@ -188,23 +188,23 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9541,
+          "astId": 9985,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "crossMsgs",
           "offset": 0,
           "slot": "4",
-          "type": "t_array(t_struct(CrossMsg)9570_storage)dyn_storage"
+          "type": "t_array(t_struct(CrossMsg)10014_storage)dyn_storage"
         },
         {
-          "astId": 9545,
+          "astId": 9989,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "children",
           "offset": 0,
           "slot": "5",
-          "type": "t_array(t_struct(ChildCheck)9564_storage)dyn_storage"
+          "type": "t_array(t_struct(ChildCheck)10008_storage)dyn_storage"
         },
         {
-          "astId": 9547,
+          "astId": 9991,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "prevHash",
           "offset": 0,
@@ -212,7 +212,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 9549,
+          "astId": 9993,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "proof",
           "offset": 0,
@@ -222,20 +222,20 @@
       ],
       "numberOfBytes": "256"
     },
-    "t_struct(ChildCheck)9564_storage": {
+    "t_struct(ChildCheck)10008_storage": {
       "encoding": "inplace",
       "label": "struct ChildCheck",
       "members": [
         {
-          "astId": 9560,
+          "astId": 10004,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "source",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9675_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9563,
+          "astId": 10007,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "checks",
           "offset": 0,
@@ -245,20 +245,20 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(CrossMsg)9570_storage": {
+    "t_struct(CrossMsg)10014_storage": {
       "encoding": "inplace",
       "label": "struct CrossMsg",
       "members": [
         {
-          "astId": 9567,
+          "astId": 10011,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "message",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(StorableMsg)9585_storage"
+          "type": "t_struct(StorableMsg)10029_storage"
         },
         {
-          "astId": 9569,
+          "astId": 10013,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "wrapped",
           "offset": 0,
@@ -268,35 +268,35 @@
       ],
       "numberOfBytes": "384"
     },
-    "t_struct(EpochVoteBottomUpSubmission)9627_storage": {
+    "t_struct(EpochVoteBottomUpSubmission)10071_storage": {
       "encoding": "inplace",
       "label": "struct EpochVoteBottomUpSubmission",
       "members": [
         {
-          "astId": 9621,
+          "astId": 10065,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "vote",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(EpochVoteSubmission)9609_storage"
+          "type": "t_struct(EpochVoteSubmission)10053_storage"
         },
         {
-          "astId": 9626,
+          "astId": 10070,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "submissions",
           "offset": 0,
           "slot": "5",
-          "type": "t_mapping(t_bytes32,t_struct(BottomUpCheckpoint)9550_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(BottomUpCheckpoint)9994_storage)"
         }
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(EpochVoteSubmission)9609_storage": {
+    "t_struct(EpochVoteSubmission)10053_storage": {
       "encoding": "inplace",
       "label": "struct EpochVoteSubmission",
       "members": [
         {
-          "astId": 9592,
+          "astId": 10036,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "nonce",
           "offset": 0,
@@ -304,7 +304,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9594,
+          "astId": 10038,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "totalSubmissionWeight",
           "offset": 0,
@@ -312,7 +312,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9596,
+          "astId": 10040,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "mostVotedSubmission",
           "offset": 0,
@@ -320,7 +320,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 9602,
+          "astId": 10046,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "submitters",
           "offset": 0,
@@ -328,7 +328,7 @@
           "type": "t_mapping(t_uint256,t_mapping(t_address,t_bool))"
         },
         {
-          "astId": 9608,
+          "astId": 10052,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "submissionWeights",
           "offset": 0,
@@ -338,12 +338,12 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(FvmAddress)9649_storage": {
+    "t_struct(FvmAddress)10093_storage": {
       "encoding": "inplace",
       "label": "struct FvmAddress",
       "members": [
         {
-          "astId": 9646,
+          "astId": 10090,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "addrType",
           "offset": 0,
@@ -351,7 +351,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 9648,
+          "astId": 10092,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "payload",
           "offset": 0,
@@ -361,25 +361,25 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(IPCAddress)9702_storage": {
+    "t_struct(IPCAddress)10146_storage": {
       "encoding": "inplace",
       "label": "struct IPCAddress",
       "members": [
         {
-          "astId": 9698,
+          "astId": 10142,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "subnetId",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)9675_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 9701,
+          "astId": 10145,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "rawAddress",
           "offset": 0,
           "slot": "2",
-          "type": "t_struct(FvmAddress)9649_storage"
+          "type": "t_struct(FvmAddress)10093_storage"
         }
       ],
       "numberOfBytes": "128"
@@ -407,28 +407,28 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StorableMsg)9585_storage": {
+    "t_struct(StorableMsg)10029_storage": {
       "encoding": "inplace",
       "label": "struct StorableMsg",
       "members": [
         {
-          "astId": 9573,
+          "astId": 10017,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "from",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(IPCAddress)9702_storage"
+          "type": "t_struct(IPCAddress)10146_storage"
         },
         {
-          "astId": 9576,
+          "astId": 10020,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "to",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(IPCAddress)9702_storage"
+          "type": "t_struct(IPCAddress)10146_storage"
         },
         {
-          "astId": 9578,
+          "astId": 10022,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "value",
           "offset": 0,
@@ -436,7 +436,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9580,
+          "astId": 10024,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "nonce",
           "offset": 0,
@@ -444,7 +444,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9582,
+          "astId": 10026,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "method",
           "offset": 8,
@@ -452,7 +452,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 9584,
+          "astId": 10028,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "params",
           "offset": 0,
@@ -462,20 +462,20 @@
       ],
       "numberOfBytes": "352"
     },
-    "t_struct(SubnetActorStorage)8131_storage": {
+    "t_struct(SubnetActorStorage)8580_storage": {
       "encoding": "inplace",
       "label": "struct SubnetActorStorage",
       "members": [
         {
-          "astId": 8055,
+          "astId": 8504,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "epochVoteSubmissions",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_uint64,t_struct(EpochVoteBottomUpSubmission)9627_storage)"
+          "type": "t_mapping(t_uint64,t_struct(EpochVoteBottomUpSubmission)10071_storage)"
         },
         {
-          "astId": 8060,
+          "astId": 8509,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "stake",
           "offset": 0,
@@ -483,7 +483,7 @@
           "type": "t_mapping(t_address,t_uint256)"
         },
         {
-          "astId": 8065,
+          "astId": 8514,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "accumulatedRewards",
           "offset": 0,
@@ -491,7 +491,7 @@
           "type": "t_mapping(t_address,t_uint256)"
         },
         {
-          "astId": 8070,
+          "astId": 8519,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "validatorNetAddresses",
           "offset": 0,
@@ -499,23 +499,23 @@
           "type": "t_mapping(t_address,t_string_storage)"
         },
         {
-          "astId": 8076,
+          "astId": 8525,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "validatorWorkerAddresses",
           "offset": 0,
           "slot": "4",
-          "type": "t_mapping(t_address,t_struct(FvmAddress)9649_storage)"
+          "type": "t_mapping(t_address,t_struct(FvmAddress)10093_storage)"
         },
         {
-          "astId": 8082,
+          "astId": 8531,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "committedCheckpoints",
           "offset": 0,
           "slot": "5",
-          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9550_storage)"
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)9994_storage)"
         },
         {
-          "astId": 8085,
+          "astId": 8534,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "genesis",
           "offset": 0,
@@ -523,7 +523,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 8088,
+          "astId": 8537,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "totalStake",
           "offset": 0,
@@ -531,7 +531,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 8091,
+          "astId": 8540,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "minActivationCollateral",
           "offset": 0,
@@ -539,7 +539,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 8094,
+          "astId": 8543,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "configurationNumber",
           "offset": 0,
@@ -547,7 +547,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 8097,
+          "astId": 8546,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "topDownCheckPeriod",
           "offset": 8,
@@ -555,7 +555,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 8100,
+          "astId": 8549,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "bottomUpCheckPeriod",
           "offset": 16,
@@ -563,7 +563,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 8103,
+          "astId": 8552,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "minValidators",
           "offset": 24,
@@ -571,7 +571,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 8106,
+          "astId": 8555,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "name",
           "offset": 0,
@@ -579,7 +579,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 8108,
+          "astId": 8557,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "currentSubnetHash",
           "offset": 0,
@@ -587,7 +587,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 8111,
+          "astId": 8560,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "prevExecutedCheckpointHash",
           "offset": 0,
@@ -595,7 +595,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 8114,
+          "astId": 8563,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "ipcGatewayAddr",
           "offset": 0,
@@ -603,15 +603,15 @@
           "type": "t_address"
         },
         {
-          "astId": 8118,
+          "astId": 8567,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "status",
           "offset": 20,
           "slot": "13",
-          "type": "t_enum(Status)3587"
+          "type": "t_enum(Status)4025"
         },
         {
-          "astId": 8122,
+          "astId": 8571,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "validators",
           "offset": 0,
@@ -619,30 +619,30 @@
           "type": "t_struct(AddressSet)2473_storage"
         },
         {
-          "astId": 8126,
+          "astId": 8575,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "parentId",
           "offset": 0,
           "slot": "16",
-          "type": "t_struct(SubnetID)9675_storage"
+          "type": "t_struct(SubnetID)10119_storage"
         },
         {
-          "astId": 8130,
+          "astId": 8579,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "consensus",
           "offset": 0,
           "slot": "18",
-          "type": "t_enum(ConsensusType)3573"
+          "type": "t_enum(ConsensusType)4011"
         }
       ],
       "numberOfBytes": "608"
     },
-    "t_struct(SubnetID)9675_storage": {
+    "t_struct(SubnetID)10119_storage": {
       "encoding": "inplace",
       "label": "struct SubnetID",
       "members": [
         {
-          "astId": 9670,
+          "astId": 10114,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "root",
           "offset": 0,
@@ -650,7 +650,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9674,
+          "astId": 10118,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "route",
           "offset": 0,

--- a/src/errors/IPCErrors.sol
+++ b/src/errors/IPCErrors.sol
@@ -50,3 +50,4 @@ error WorkerAddressInvalid();
 error WrongCheckpointSource();
 error ParentFinalityAlreadyCommitted();
 error InvalidCrossMsgValue();
+error InvalidConfigurationNumber();

--- a/src/lib/LibSubnetActorStorage.sol
+++ b/src/lib/LibSubnetActorStorage.sol
@@ -56,11 +56,11 @@ struct SubnetActorStorage {
     // ============ Validator Related ===========
     /// @notice Sequence number that uniquely identifies a validator set.
     uint64 configurationNumber;
-    /// @notice The set of validators changes to be committed
+    /// @notice The set of validators changes to be committed.
     ValidatorChange[] validatorSetChanges;
-    /// @notice List of validators in the subnet that are currently
+    /// @notice List of validators in the subnet that are currently active.
     EnumerableSet.AddressSet validators;
-    /// @notice address to validator information
+    /// @notice address to validator information.
     mapping(address => Validator) validatorInfo;
 }
 

--- a/src/lib/LibSubnetActorStorage.sol
+++ b/src/lib/LibSubnetActorStorage.sol
@@ -7,7 +7,7 @@ import {BottomUpCheckpoint} from "../structs/Checkpoint.sol";
 import {NotGateway, SubnetAlreadyKilled} from "../errors/IPCErrors.sol";
 import {EpochVoteBottomUpSubmission} from "../structs/EpochVoteSubmission.sol";
 import {FvmAddress} from "../structs/FvmAddress.sol";
-import {SubnetID} from "../structs/Subnet.sol";
+import {SubnetID, Validator, ValidatorChange} from "../structs/Subnet.sol";
 import {Address} from "openzeppelin-contracts/utils/Address.sol";
 import {EnumerableSet} from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
 
@@ -31,8 +31,6 @@ struct SubnetActorStorage {
     uint256 totalStake;
     /// @notice Minimal activation collateral
     uint256 minActivationCollateral;
-    /// @notice Sequence number that uniquely identifies a validator set.
-    uint64 configurationNumber;
     /// @notice number of blocks in a top-down epoch
     uint64 topDownCheckPeriod;
     /// @notice number of blocks in a bottom-up epoch
@@ -50,12 +48,20 @@ struct SubnetActorStorage {
     /// @notice Type of consensus algorithm.
     /// @notice current status of the subnet
     Status status;
-    /// @notice List of validators in the subnet
-    EnumerableSet.AddressSet validators;
     /// @notice ID of the parent subnet
     SubnetID parentId;
     /// immutable params
     ConsensusType consensus;
+
+    // ============ Validator Related ===========
+    /// @notice Sequence number that uniquely identifies a validator set.
+    uint64 configurationNumber;
+    /// @notice The set of validators changes to be committed
+    ValidatorChange[] validatorSetChanges;
+    /// @notice List of validators in the subnet that are currently
+    EnumerableSet.AddressSet validators;
+    /// @notice address to validator information
+    mapping(address => Validator) validatorInfo;
 }
 
 library LibSubnetActorStorage {

--- a/src/structs/Subnet.sol
+++ b/src/structs/Subnet.sol
@@ -13,6 +13,30 @@ struct SubnetID {
     address[] route;
 }
 
+/// @notice All the information about a validator
+struct Validator {
+    address validator;
+    uint256 weight;
+    /// @notice The extra info about the validator. This information is not
+    /// @notice important for the contract, but useful for offchain computation.
+    /// @dev Offchain should know how to decode these bytes, contract does not
+    /// @dev need to know about the details.
+    bytes info;
+}
+
+/// @notice All the information about a validator
+struct ValidatorChange {
+    Validator validator;
+    uint64 configurationNumber;
+    SubnetOpt operation;
+}
+
+/// The operations that validators can perform for the subnet lifecycle
+enum SubnetOpt {
+    Join,
+    Leave
+}
+
 struct Subnet {
     uint256 stake;
     uint256 genesisEpoch;

--- a/src/subnet/SubnetActorManagerFacet.sol
+++ b/src/subnet/SubnetActorManagerFacet.sol
@@ -258,7 +258,7 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Reentran
         uint256 length = s.validatorSetChanges.length;
 
         if (length != 0) {
-            // ensure the configuration number is consequential
+            // ensure the configuration number is sequential
             uint64 nextConfigurationNumber = s.validatorSetChanges[length-1].configurationNumber + 1;
             if (nextConfigurationNumber != change.configurationNumber) {
                 // this should rarely happen


### PR DESCRIPTION
This PR updates the `join` and `leave` function call in the subnet manager. So that we can track the changes instead for the checkpointing to apply the changes.

It is implemented as described in: https://github.com/consensus-shipyard/ipc-solidity-actors/issues/203