### PR TITLE
Return previous finality

### DIFF
--- a/.storage-layouts/GatewayActorModifiers.json
+++ b/.storage-layouts/GatewayActorModifiers.json
@@ -1,12 +1,12 @@
 {
   "storage": [
     {
-      "astId": 9916,
+      "astId": 9945,
       "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
       "label": "s",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(GatewayActorStorage)9902_storage"
+      "type": "t_struct(GatewayActorStorage)9931_storage"
     }
   ],
   "types": {
@@ -27,14 +27,14 @@
       "label": "bytes32[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(CrossMsg)14758_storage)dyn_storage": {
-      "base": "t_struct(CrossMsg)14758_storage",
+    "t_array(t_struct(CrossMsg)14787_storage)dyn_storage": {
+      "base": "t_struct(CrossMsg)14787_storage",
       "encoding": "dynamic_array",
       "label": "struct CrossMsg[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(Validator)14937_storage)dyn_storage": {
-      "base": "t_struct(Validator)14937_storage",
+    "t_array(t_struct(Validator)14966_storage)dyn_storage": {
+      "base": "t_struct(Validator)14966_storage",
       "encoding": "dynamic_array",
       "label": "struct Validator[]",
       "numberOfBytes": "32"
@@ -59,7 +59,7 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_enum(StakingOperation)14833": {
+    "t_enum(StakingOperation)14862": {
       "encoding": "inplace",
       "label": "enum StakingOperation",
       "numberOfBytes": "1"
@@ -76,12 +76,12 @@
       "numberOfBytes": "32",
       "value": "t_bytes_storage"
     },
-    "t_mapping(t_address,t_struct(ValidatorInfo)14895_storage)": {
+    "t_mapping(t_address,t_struct(ValidatorInfo)14924_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ValidatorInfo)",
       "numberOfBytes": "32",
-      "value": "t_struct(ValidatorInfo)14895_storage"
+      "value": "t_struct(ValidatorInfo)14924_storage"
     },
     "t_mapping(t_address,t_uint16)": {
       "encoding": "mapping",
@@ -90,26 +90,26 @@
       "numberOfBytes": "32",
       "value": "t_uint16"
     },
-    "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)14758_storage)dyn_storage))": {
+    "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)14787_storage)dyn_storage))": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => mapping(uint256 => struct CrossMsg[]))",
       "numberOfBytes": "32",
-      "value": "t_mapping(t_uint256,t_array(t_struct(CrossMsg)14758_storage)dyn_storage)"
+      "value": "t_mapping(t_uint256,t_array(t_struct(CrossMsg)14787_storage)dyn_storage)"
     },
-    "t_mapping(t_bytes32,t_struct(CrossMsg)14758_storage)": {
+    "t_mapping(t_bytes32,t_struct(CrossMsg)14787_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct CrossMsg)",
       "numberOfBytes": "32",
-      "value": "t_struct(CrossMsg)14758_storage"
+      "value": "t_struct(CrossMsg)14787_storage"
     },
-    "t_mapping(t_bytes32,t_struct(Subnet)14829_storage)": {
+    "t_mapping(t_bytes32,t_struct(Subnet)14858_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct Subnet)",
       "numberOfBytes": "32",
-      "value": "t_struct(Subnet)14829_storage"
+      "value": "t_struct(Subnet)14858_storage"
     },
     "t_mapping(t_bytes32,t_uint256)": {
       "encoding": "mapping",
@@ -125,26 +125,26 @@
       "numberOfBytes": "32",
       "value": "t_address"
     },
-    "t_mapping(t_uint256,t_array(t_struct(CrossMsg)14758_storage)dyn_storage)": {
+    "t_mapping(t_uint256,t_array(t_struct(CrossMsg)14787_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct CrossMsg[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(CrossMsg)14758_storage)dyn_storage"
+      "value": "t_array(t_struct(CrossMsg)14787_storage)dyn_storage"
     },
-    "t_mapping(t_uint256,t_struct(ParentFinality)14719_storage)": {
+    "t_mapping(t_uint256,t_struct(ParentFinality)14748_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct ParentFinality)",
       "numberOfBytes": "32",
-      "value": "t_struct(ParentFinality)14719_storage"
+      "value": "t_struct(ParentFinality)14748_storage"
     },
-    "t_mapping(t_uint64,t_array(t_struct(CrossMsg)14758_storage)dyn_storage)": {
+    "t_mapping(t_uint64,t_array(t_struct(CrossMsg)14787_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct CrossMsg[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(CrossMsg)14758_storage)dyn_storage"
+      "value": "t_array(t_struct(CrossMsg)14787_storage)dyn_storage"
     },
     "t_mapping(t_uint64,t_mapping(t_address,t_bytes_storage))": {
       "encoding": "mapping",
@@ -167,26 +167,26 @@
       "numberOfBytes": "32",
       "value": "t_struct(AddressSet)3420_storage"
     },
-    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)14736_storage)": {
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)14765_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)14736_storage"
+      "value": "t_struct(BottomUpCheckpoint)14765_storage"
     },
-    "t_mapping(t_uint64,t_struct(CheckpointInfo)14752_storage)": {
+    "t_mapping(t_uint64,t_struct(CheckpointInfo)14781_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct CheckpointInfo)",
       "numberOfBytes": "32",
-      "value": "t_struct(CheckpointInfo)14752_storage"
+      "value": "t_struct(CheckpointInfo)14781_storage"
     },
-    "t_mapping(t_uint64,t_struct(StakingChange)14841_storage)": {
+    "t_mapping(t_uint64,t_struct(StakingChange)14870_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct StakingChange)",
       "numberOfBytes": "32",
-      "value": "t_struct(StakingChange)14841_storage"
+      "value": "t_struct(StakingChange)14870_storage"
     },
     "t_struct(AddressSet)3420_storage": {
       "encoding": "inplace",
@@ -203,20 +203,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(BottomUpCheckpoint)14736_storage": {
+    "t_struct(BottomUpCheckpoint)14765_storage": {
       "encoding": "inplace",
       "label": "struct BottomUpCheckpoint",
       "members": [
         {
-          "astId": 14723,
+          "astId": 14752,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "subnetID",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)14812_storage"
+          "type": "t_struct(SubnetID)14841_storage"
         },
         {
-          "astId": 14726,
+          "astId": 14755,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "blockHeight",
           "offset": 0,
@@ -224,7 +224,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14729,
+          "astId": 14758,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "blockHash",
           "offset": 0,
@@ -232,7 +232,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14732,
+          "astId": 14761,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -240,7 +240,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14735,
+          "astId": 14764,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "crossMessagesHash",
           "offset": 0,
@@ -250,12 +250,12 @@
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(CheckpointInfo)14752_storage": {
+    "t_struct(CheckpointInfo)14781_storage": {
       "encoding": "inplace",
       "label": "struct CheckpointInfo",
       "members": [
         {
-          "astId": 14739,
+          "astId": 14768,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "hash",
           "offset": 0,
@@ -263,7 +263,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14742,
+          "astId": 14771,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "rootHash",
           "offset": 0,
@@ -271,7 +271,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14745,
+          "astId": 14774,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "threshold",
           "offset": 0,
@@ -279,7 +279,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14748,
+          "astId": 14777,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "currentWeight",
           "offset": 0,
@@ -287,7 +287,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14751,
+          "astId": 14780,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "reached",
           "offset": 0,
@@ -297,20 +297,20 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(CrossMsg)14758_storage": {
+    "t_struct(CrossMsg)14787_storage": {
       "encoding": "inplace",
       "label": "struct CrossMsg",
       "members": [
         {
-          "astId": 14755,
+          "astId": 14784,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "message",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(StorableMsg)14775_storage"
+          "type": "t_struct(StorableMsg)14804_storage"
         },
         {
-          "astId": 14757,
+          "astId": 14786,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "wrapped",
           "offset": 0,
@@ -320,12 +320,12 @@
       ],
       "numberOfBytes": "416"
     },
-    "t_struct(FvmAddress)14782_storage": {
+    "t_struct(FvmAddress)14811_storage": {
       "encoding": "inplace",
       "label": "struct FvmAddress",
       "members": [
         {
-          "astId": 14779,
+          "astId": 14808,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "addrType",
           "offset": 0,
@@ -333,7 +333,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 14781,
+          "astId": 14810,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "payload",
           "offset": 0,
@@ -343,36 +343,36 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(GatewayActorStorage)9902_storage": {
+    "t_struct(GatewayActorStorage)9931_storage": {
       "encoding": "inplace",
       "label": "struct GatewayActorStorage",
       "members": [
         {
-          "astId": 9788,
+          "astId": 9817,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "subnets",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_bytes32,t_struct(Subnet)14829_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(Subnet)14858_storage)"
         },
         {
-          "astId": 9797,
+          "astId": 9826,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "topDownMsgs",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)14758_storage)dyn_storage))"
+          "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)14787_storage)dyn_storage))"
         },
         {
-          "astId": 9803,
+          "astId": 9832,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "finalitiesMap",
           "offset": 0,
           "slot": "2",
-          "type": "t_mapping(t_uint256,t_struct(ParentFinality)14719_storage)"
+          "type": "t_mapping(t_uint256,t_struct(ParentFinality)14748_storage)"
         },
         {
-          "astId": 9806,
+          "astId": 9835,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "latestParentHeight",
           "offset": 0,
@@ -380,15 +380,15 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9812,
+          "astId": 9841,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "postbox",
           "offset": 0,
           "slot": "4",
-          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)14758_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)14787_storage)"
         },
         {
-          "astId": 9819,
+          "astId": 9848,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "validatorSetWeights",
           "offset": 0,
@@ -396,47 +396,47 @@
           "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_uint256))"
         },
         {
-          "astId": 9823,
+          "astId": 9852,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "currentMembership",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(Membership)14944_storage"
+          "type": "t_struct(Membership)14973_storage"
         },
         {
-          "astId": 9827,
+          "astId": 9856,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "lastMembership",
           "offset": 0,
           "slot": "8",
-          "type": "t_struct(Membership)14944_storage"
+          "type": "t_struct(Membership)14973_storage"
         },
         {
-          "astId": 9833,
+          "astId": 9862,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpCheckpoints",
           "offset": 0,
           "slot": "10",
-          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)14736_storage)"
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)14765_storage)"
         },
         {
-          "astId": 9839,
+          "astId": 9868,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpCheckpointInfo",
           "offset": 0,
           "slot": "11",
-          "type": "t_mapping(t_uint64,t_struct(CheckpointInfo)14752_storage)"
+          "type": "t_mapping(t_uint64,t_struct(CheckpointInfo)14781_storage)"
         },
         {
-          "astId": 9846,
+          "astId": 9875,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpMessages",
           "offset": 0,
           "slot": "12",
-          "type": "t_mapping(t_uint64,t_array(t_struct(CrossMsg)14758_storage)dyn_storage)"
+          "type": "t_mapping(t_uint64,t_array(t_struct(CrossMsg)14787_storage)dyn_storage)"
         },
         {
-          "astId": 9849,
+          "astId": 9878,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpCheckpointRetentionHeight",
           "offset": 0,
@@ -444,7 +444,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9853,
+          "astId": 9882,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "incompleteCheckpoints",
           "offset": 0,
@@ -452,7 +452,7 @@
           "type": "t_struct(UintSet)3577_storage"
         },
         {
-          "astId": 9859,
+          "astId": 9888,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpSignatureSenders",
           "offset": 0,
@@ -460,7 +460,7 @@
           "type": "t_mapping(t_uint64,t_struct(AddressSet)3420_storage)"
         },
         {
-          "astId": 9866,
+          "astId": 9895,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpSignatures",
           "offset": 0,
@@ -468,7 +468,7 @@
           "type": "t_mapping(t_uint64,t_mapping(t_address,t_bytes_storage))"
         },
         {
-          "astId": 9870,
+          "astId": 9899,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "subnetKeys",
           "offset": 0,
@@ -476,15 +476,15 @@
           "type": "t_array(t_bytes32)dyn_storage"
         },
         {
-          "astId": 9874,
+          "astId": 9903,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "networkName",
           "offset": 0,
           "slot": "19",
-          "type": "t_struct(SubnetID)14812_storage"
+          "type": "t_struct(SubnetID)14841_storage"
         },
         {
-          "astId": 9877,
+          "astId": 9906,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "minStake",
           "offset": 0,
@@ -492,7 +492,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9880,
+          "astId": 9909,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "minCrossMsgFee",
           "offset": 0,
@@ -500,7 +500,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9883,
+          "astId": 9912,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "majorityPercentage",
           "offset": 0,
@@ -508,7 +508,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 9886,
+          "astId": 9915,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpNonce",
           "offset": 1,
@@ -516,7 +516,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9889,
+          "astId": 9918,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "appliedTopDownNonce",
           "offset": 9,
@@ -524,7 +524,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9892,
+          "astId": 9921,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "totalSubnets",
           "offset": 17,
@@ -532,7 +532,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9894,
+          "astId": 9923,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpCheckPeriod",
           "offset": 0,
@@ -540,15 +540,15 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9898,
+          "astId": 9927,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "validatorsTracker",
           "offset": 0,
           "slot": "25",
-          "type": "t_struct(ParentValidatorsTracker)14923_storage"
+          "type": "t_struct(ParentValidatorsTracker)14952_storage"
         },
         {
-          "astId": 9901,
+          "astId": 9930,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "lastBottomUpExecutedCheckpointHeight",
           "offset": 0,
@@ -558,58 +558,58 @@
       ],
       "numberOfBytes": "1184"
     },
-    "t_struct(IPCAddress)14930_storage": {
+    "t_struct(IPCAddress)14959_storage": {
       "encoding": "inplace",
       "label": "struct IPCAddress",
       "members": [
         {
-          "astId": 14926,
+          "astId": 14955,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "subnetId",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)14812_storage"
+          "type": "t_struct(SubnetID)14841_storage"
         },
         {
-          "astId": 14929,
+          "astId": 14958,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "rawAddress",
           "offset": 0,
           "slot": "2",
-          "type": "t_struct(FvmAddress)14782_storage"
+          "type": "t_struct(FvmAddress)14811_storage"
         }
       ],
       "numberOfBytes": "128"
     },
-    "t_struct(MaxPQ)13270_storage": {
+    "t_struct(MaxPQ)13299_storage": {
       "encoding": "inplace",
       "label": "struct MaxPQ",
       "members": [
         {
-          "astId": 13269,
+          "astId": 13298,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)14507_storage"
+          "type": "t_struct(PQ)14536_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(Membership)14944_storage": {
+    "t_struct(Membership)14973_storage": {
       "encoding": "inplace",
       "label": "struct Membership",
       "members": [
         {
-          "astId": 14941,
+          "astId": 14970,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "validators",
           "offset": 0,
           "slot": "0",
-          "type": "t_array(t_struct(Validator)14937_storage)dyn_storage"
+          "type": "t_array(t_struct(Validator)14966_storage)dyn_storage"
         },
         {
-          "astId": 14943,
+          "astId": 14972,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "configurationNumber",
           "offset": 0,
@@ -619,27 +619,27 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(MinPQ)13883_storage": {
+    "t_struct(MinPQ)13912_storage": {
       "encoding": "inplace",
       "label": "struct MinPQ",
       "members": [
         {
-          "astId": 13882,
+          "astId": 13911,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)14507_storage"
+          "type": "t_struct(PQ)14536_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(PQ)14507_storage": {
+    "t_struct(PQ)14536_storage": {
       "encoding": "inplace",
       "label": "struct PQ",
       "members": [
         {
-          "astId": 14496,
+          "astId": 14525,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "size",
           "offset": 0,
@@ -647,7 +647,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 14501,
+          "astId": 14530,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "addressToPos",
           "offset": 0,
@@ -655,7 +655,7 @@
           "type": "t_mapping(t_address,t_uint16)"
         },
         {
-          "astId": 14506,
+          "astId": 14535,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "posToAddress",
           "offset": 0,
@@ -665,12 +665,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ParentFinality)14719_storage": {
+    "t_struct(ParentFinality)14748_storage": {
       "encoding": "inplace",
       "label": "struct ParentFinality",
       "members": [
         {
-          "astId": 14716,
+          "astId": 14745,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "height",
           "offset": 0,
@@ -678,7 +678,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14718,
+          "astId": 14747,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "blockHash",
           "offset": 0,
@@ -688,25 +688,25 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(ParentValidatorsTracker)14923_storage": {
+    "t_struct(ParentValidatorsTracker)14952_storage": {
       "encoding": "inplace",
       "label": "struct ParentValidatorsTracker",
       "members": [
         {
-          "astId": 14919,
+          "astId": 14948,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "validators",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(ValidatorSet)14916_storage"
+          "type": "t_struct(ValidatorSet)14945_storage"
         },
         {
-          "astId": 14922,
+          "astId": 14951,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "changes",
           "offset": 0,
           "slot": "9",
-          "type": "t_struct(StakingChangeLog)14860_storage"
+          "type": "t_struct(StakingChangeLog)14889_storage"
         }
       ],
       "numberOfBytes": "352"
@@ -734,20 +734,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingChange)14841_storage": {
+    "t_struct(StakingChange)14870_storage": {
       "encoding": "inplace",
       "label": "struct StakingChange",
       "members": [
         {
-          "astId": 14836,
+          "astId": 14865,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "op",
           "offset": 0,
           "slot": "0",
-          "type": "t_enum(StakingOperation)14833"
+          "type": "t_enum(StakingOperation)14862"
         },
         {
-          "astId": 14838,
+          "astId": 14867,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "payload",
           "offset": 0,
@@ -755,7 +755,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 14840,
+          "astId": 14869,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "validator",
           "offset": 0,
@@ -765,12 +765,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(StakingChangeLog)14860_storage": {
+    "t_struct(StakingChangeLog)14889_storage": {
       "encoding": "inplace",
       "label": "struct StakingChangeLog",
       "members": [
         {
-          "astId": 14850,
+          "astId": 14879,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -778,7 +778,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14853,
+          "astId": 14882,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "startConfigurationNumber",
           "offset": 8,
@@ -786,38 +786,38 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14859,
+          "astId": 14888,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "changes",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_uint64,t_struct(StakingChange)14841_storage)"
+          "type": "t_mapping(t_uint64,t_struct(StakingChange)14870_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StorableMsg)14775_storage": {
+    "t_struct(StorableMsg)14804_storage": {
       "encoding": "inplace",
       "label": "struct StorableMsg",
       "members": [
         {
-          "astId": 14761,
+          "astId": 14790,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "from",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(IPCAddress)14930_storage"
+          "type": "t_struct(IPCAddress)14959_storage"
         },
         {
-          "astId": 14764,
+          "astId": 14793,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "to",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(IPCAddress)14930_storage"
+          "type": "t_struct(IPCAddress)14959_storage"
         },
         {
-          "astId": 14766,
+          "astId": 14795,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "value",
           "offset": 0,
@@ -825,7 +825,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14768,
+          "astId": 14797,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "nonce",
           "offset": 0,
@@ -833,7 +833,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14770,
+          "astId": 14799,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "method",
           "offset": 8,
@@ -841,7 +841,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 14772,
+          "astId": 14801,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "params",
           "offset": 0,
@@ -849,7 +849,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 14774,
+          "astId": 14803,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "fee",
           "offset": 0,
@@ -859,12 +859,12 @@
       ],
       "numberOfBytes": "384"
     },
-    "t_struct(Subnet)14829_storage": {
+    "t_struct(Subnet)14858_storage": {
       "encoding": "inplace",
       "label": "struct Subnet",
       "members": [
         {
-          "astId": 14814,
+          "astId": 14843,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "stake",
           "offset": 0,
@@ -872,7 +872,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14816,
+          "astId": 14845,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "genesisEpoch",
           "offset": 0,
@@ -880,7 +880,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14818,
+          "astId": 14847,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "circSupply",
           "offset": 0,
@@ -888,7 +888,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14820,
+          "astId": 14849,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "topDownNonce",
           "offset": 0,
@@ -896,7 +896,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14822,
+          "astId": 14851,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "appliedBottomUpNonce",
           "offset": 8,
@@ -904,7 +904,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14825,
+          "astId": 14854,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "status",
           "offset": 16,
@@ -912,22 +912,22 @@
           "type": "t_enum(Status)5033"
         },
         {
-          "astId": 14828,
+          "astId": 14857,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "id",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(SubnetID)14812_storage"
+          "type": "t_struct(SubnetID)14841_storage"
         }
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(SubnetID)14812_storage": {
+    "t_struct(SubnetID)14841_storage": {
       "encoding": "inplace",
       "label": "struct SubnetID",
       "members": [
         {
-          "astId": 14807,
+          "astId": 14836,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "root",
           "offset": 0,
@@ -935,7 +935,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14811,
+          "astId": 14840,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "route",
           "offset": 0,
@@ -960,12 +960,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(Validator)14937_storage": {
+    "t_struct(Validator)14966_storage": {
       "encoding": "inplace",
       "label": "struct Validator",
       "members": [
         {
-          "astId": 14932,
+          "astId": 14961,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "weight",
           "offset": 0,
@@ -973,7 +973,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14934,
+          "astId": 14963,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "addr",
           "offset": 0,
@@ -981,7 +981,7 @@
           "type": "t_address"
         },
         {
-          "astId": 14936,
+          "astId": 14965,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "metadata",
           "offset": 0,
@@ -991,12 +991,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorInfo)14895_storage": {
+    "t_struct(ValidatorInfo)14924_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorInfo",
       "members": [
         {
-          "astId": 14889,
+          "astId": 14918,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "confirmedCollateral",
           "offset": 0,
@@ -1004,7 +1004,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14891,
+          "astId": 14920,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "totalCollateral",
           "offset": 0,
@@ -1012,7 +1012,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14894,
+          "astId": 14923,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "metadata",
           "offset": 0,
@@ -1022,12 +1022,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorSet)14916_storage": {
+    "t_struct(ValidatorSet)14945_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorSet",
       "members": [
         {
-          "astId": 14898,
+          "astId": 14927,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "activeLimit",
           "offset": 0,
@@ -1035,7 +1035,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 14901,
+          "astId": 14930,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "totalConfirmedCollateral",
           "offset": 0,
@@ -1043,28 +1043,28 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14907,
+          "astId": 14936,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "validators",
           "offset": 0,
           "slot": "2",
-          "type": "t_mapping(t_address,t_struct(ValidatorInfo)14895_storage)"
+          "type": "t_mapping(t_address,t_struct(ValidatorInfo)14924_storage)"
         },
         {
-          "astId": 14911,
+          "astId": 14940,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "activeValidators",
           "offset": 0,
           "slot": "3",
-          "type": "t_struct(MinPQ)13883_storage"
+          "type": "t_struct(MinPQ)13912_storage"
         },
         {
-          "astId": 14915,
+          "astId": 14944,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "waitingValidators",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(MaxPQ)13270_storage"
+          "type": "t_struct(MaxPQ)13299_storage"
         }
       ],
       "numberOfBytes": "288"

--- a/.storage-layouts/GatewayDiamond.json
+++ b/.storage-layouts/GatewayDiamond.json
@@ -6,7 +6,7 @@
       "label": "s",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(GatewayActorStorage)9902_storage"
+      "type": "t_struct(GatewayActorStorage)9931_storage"
     }
   ],
   "types": {
@@ -27,14 +27,14 @@
       "label": "bytes32[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(CrossMsg)14758_storage)dyn_storage": {
-      "base": "t_struct(CrossMsg)14758_storage",
+    "t_array(t_struct(CrossMsg)14787_storage)dyn_storage": {
+      "base": "t_struct(CrossMsg)14787_storage",
       "encoding": "dynamic_array",
       "label": "struct CrossMsg[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(Validator)14937_storage)dyn_storage": {
-      "base": "t_struct(Validator)14937_storage",
+    "t_array(t_struct(Validator)14966_storage)dyn_storage": {
+      "base": "t_struct(Validator)14966_storage",
       "encoding": "dynamic_array",
       "label": "struct Validator[]",
       "numberOfBytes": "32"
@@ -59,7 +59,7 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_enum(StakingOperation)14833": {
+    "t_enum(StakingOperation)14862": {
       "encoding": "inplace",
       "label": "enum StakingOperation",
       "numberOfBytes": "1"
@@ -76,12 +76,12 @@
       "numberOfBytes": "32",
       "value": "t_bytes_storage"
     },
-    "t_mapping(t_address,t_struct(ValidatorInfo)14895_storage)": {
+    "t_mapping(t_address,t_struct(ValidatorInfo)14924_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ValidatorInfo)",
       "numberOfBytes": "32",
-      "value": "t_struct(ValidatorInfo)14895_storage"
+      "value": "t_struct(ValidatorInfo)14924_storage"
     },
     "t_mapping(t_address,t_uint16)": {
       "encoding": "mapping",
@@ -90,26 +90,26 @@
       "numberOfBytes": "32",
       "value": "t_uint16"
     },
-    "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)14758_storage)dyn_storage))": {
+    "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)14787_storage)dyn_storage))": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => mapping(uint256 => struct CrossMsg[]))",
       "numberOfBytes": "32",
-      "value": "t_mapping(t_uint256,t_array(t_struct(CrossMsg)14758_storage)dyn_storage)"
+      "value": "t_mapping(t_uint256,t_array(t_struct(CrossMsg)14787_storage)dyn_storage)"
     },
-    "t_mapping(t_bytes32,t_struct(CrossMsg)14758_storage)": {
+    "t_mapping(t_bytes32,t_struct(CrossMsg)14787_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct CrossMsg)",
       "numberOfBytes": "32",
-      "value": "t_struct(CrossMsg)14758_storage"
+      "value": "t_struct(CrossMsg)14787_storage"
     },
-    "t_mapping(t_bytes32,t_struct(Subnet)14829_storage)": {
+    "t_mapping(t_bytes32,t_struct(Subnet)14858_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct Subnet)",
       "numberOfBytes": "32",
-      "value": "t_struct(Subnet)14829_storage"
+      "value": "t_struct(Subnet)14858_storage"
     },
     "t_mapping(t_bytes32,t_uint256)": {
       "encoding": "mapping",
@@ -125,26 +125,26 @@
       "numberOfBytes": "32",
       "value": "t_address"
     },
-    "t_mapping(t_uint256,t_array(t_struct(CrossMsg)14758_storage)dyn_storage)": {
+    "t_mapping(t_uint256,t_array(t_struct(CrossMsg)14787_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct CrossMsg[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(CrossMsg)14758_storage)dyn_storage"
+      "value": "t_array(t_struct(CrossMsg)14787_storage)dyn_storage"
     },
-    "t_mapping(t_uint256,t_struct(ParentFinality)14719_storage)": {
+    "t_mapping(t_uint256,t_struct(ParentFinality)14748_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct ParentFinality)",
       "numberOfBytes": "32",
-      "value": "t_struct(ParentFinality)14719_storage"
+      "value": "t_struct(ParentFinality)14748_storage"
     },
-    "t_mapping(t_uint64,t_array(t_struct(CrossMsg)14758_storage)dyn_storage)": {
+    "t_mapping(t_uint64,t_array(t_struct(CrossMsg)14787_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct CrossMsg[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(CrossMsg)14758_storage)dyn_storage"
+      "value": "t_array(t_struct(CrossMsg)14787_storage)dyn_storage"
     },
     "t_mapping(t_uint64,t_mapping(t_address,t_bytes_storage))": {
       "encoding": "mapping",
@@ -167,26 +167,26 @@
       "numberOfBytes": "32",
       "value": "t_struct(AddressSet)3420_storage"
     },
-    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)14736_storage)": {
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)14765_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)14736_storage"
+      "value": "t_struct(BottomUpCheckpoint)14765_storage"
     },
-    "t_mapping(t_uint64,t_struct(CheckpointInfo)14752_storage)": {
+    "t_mapping(t_uint64,t_struct(CheckpointInfo)14781_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct CheckpointInfo)",
       "numberOfBytes": "32",
-      "value": "t_struct(CheckpointInfo)14752_storage"
+      "value": "t_struct(CheckpointInfo)14781_storage"
     },
-    "t_mapping(t_uint64,t_struct(StakingChange)14841_storage)": {
+    "t_mapping(t_uint64,t_struct(StakingChange)14870_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct StakingChange)",
       "numberOfBytes": "32",
-      "value": "t_struct(StakingChange)14841_storage"
+      "value": "t_struct(StakingChange)14870_storage"
     },
     "t_struct(AddressSet)3420_storage": {
       "encoding": "inplace",
@@ -203,20 +203,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(BottomUpCheckpoint)14736_storage": {
+    "t_struct(BottomUpCheckpoint)14765_storage": {
       "encoding": "inplace",
       "label": "struct BottomUpCheckpoint",
       "members": [
         {
-          "astId": 14723,
+          "astId": 14752,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "subnetID",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)14812_storage"
+          "type": "t_struct(SubnetID)14841_storage"
         },
         {
-          "astId": 14726,
+          "astId": 14755,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "blockHeight",
           "offset": 0,
@@ -224,7 +224,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14729,
+          "astId": 14758,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "blockHash",
           "offset": 0,
@@ -232,7 +232,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14732,
+          "astId": 14761,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -240,7 +240,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14735,
+          "astId": 14764,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "crossMessagesHash",
           "offset": 0,
@@ -250,12 +250,12 @@
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(CheckpointInfo)14752_storage": {
+    "t_struct(CheckpointInfo)14781_storage": {
       "encoding": "inplace",
       "label": "struct CheckpointInfo",
       "members": [
         {
-          "astId": 14739,
+          "astId": 14768,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "hash",
           "offset": 0,
@@ -263,7 +263,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14742,
+          "astId": 14771,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "rootHash",
           "offset": 0,
@@ -271,7 +271,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14745,
+          "astId": 14774,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "threshold",
           "offset": 0,
@@ -279,7 +279,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14748,
+          "astId": 14777,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "currentWeight",
           "offset": 0,
@@ -287,7 +287,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14751,
+          "astId": 14780,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "reached",
           "offset": 0,
@@ -297,20 +297,20 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(CrossMsg)14758_storage": {
+    "t_struct(CrossMsg)14787_storage": {
       "encoding": "inplace",
       "label": "struct CrossMsg",
       "members": [
         {
-          "astId": 14755,
+          "astId": 14784,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "message",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(StorableMsg)14775_storage"
+          "type": "t_struct(StorableMsg)14804_storage"
         },
         {
-          "astId": 14757,
+          "astId": 14786,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "wrapped",
           "offset": 0,
@@ -320,12 +320,12 @@
       ],
       "numberOfBytes": "416"
     },
-    "t_struct(FvmAddress)14782_storage": {
+    "t_struct(FvmAddress)14811_storage": {
       "encoding": "inplace",
       "label": "struct FvmAddress",
       "members": [
         {
-          "astId": 14779,
+          "astId": 14808,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "addrType",
           "offset": 0,
@@ -333,7 +333,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 14781,
+          "astId": 14810,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "payload",
           "offset": 0,
@@ -343,36 +343,36 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(GatewayActorStorage)9902_storage": {
+    "t_struct(GatewayActorStorage)9931_storage": {
       "encoding": "inplace",
       "label": "struct GatewayActorStorage",
       "members": [
         {
-          "astId": 9788,
+          "astId": 9817,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "subnets",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_bytes32,t_struct(Subnet)14829_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(Subnet)14858_storage)"
         },
         {
-          "astId": 9797,
+          "astId": 9826,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "topDownMsgs",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)14758_storage)dyn_storage))"
+          "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)14787_storage)dyn_storage))"
         },
         {
-          "astId": 9803,
+          "astId": 9832,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "finalitiesMap",
           "offset": 0,
           "slot": "2",
-          "type": "t_mapping(t_uint256,t_struct(ParentFinality)14719_storage)"
+          "type": "t_mapping(t_uint256,t_struct(ParentFinality)14748_storage)"
         },
         {
-          "astId": 9806,
+          "astId": 9835,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "latestParentHeight",
           "offset": 0,
@@ -380,15 +380,15 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9812,
+          "astId": 9841,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "postbox",
           "offset": 0,
           "slot": "4",
-          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)14758_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)14787_storage)"
         },
         {
-          "astId": 9819,
+          "astId": 9848,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "validatorSetWeights",
           "offset": 0,
@@ -396,47 +396,47 @@
           "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_uint256))"
         },
         {
-          "astId": 9823,
+          "astId": 9852,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "currentMembership",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(Membership)14944_storage"
+          "type": "t_struct(Membership)14973_storage"
         },
         {
-          "astId": 9827,
+          "astId": 9856,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "lastMembership",
           "offset": 0,
           "slot": "8",
-          "type": "t_struct(Membership)14944_storage"
+          "type": "t_struct(Membership)14973_storage"
         },
         {
-          "astId": 9833,
+          "astId": 9862,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpCheckpoints",
           "offset": 0,
           "slot": "10",
-          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)14736_storage)"
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)14765_storage)"
         },
         {
-          "astId": 9839,
+          "astId": 9868,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpCheckpointInfo",
           "offset": 0,
           "slot": "11",
-          "type": "t_mapping(t_uint64,t_struct(CheckpointInfo)14752_storage)"
+          "type": "t_mapping(t_uint64,t_struct(CheckpointInfo)14781_storage)"
         },
         {
-          "astId": 9846,
+          "astId": 9875,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpMessages",
           "offset": 0,
           "slot": "12",
-          "type": "t_mapping(t_uint64,t_array(t_struct(CrossMsg)14758_storage)dyn_storage)"
+          "type": "t_mapping(t_uint64,t_array(t_struct(CrossMsg)14787_storage)dyn_storage)"
         },
         {
-          "astId": 9849,
+          "astId": 9878,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpCheckpointRetentionHeight",
           "offset": 0,
@@ -444,7 +444,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9853,
+          "astId": 9882,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "incompleteCheckpoints",
           "offset": 0,
@@ -452,7 +452,7 @@
           "type": "t_struct(UintSet)3577_storage"
         },
         {
-          "astId": 9859,
+          "astId": 9888,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpSignatureSenders",
           "offset": 0,
@@ -460,7 +460,7 @@
           "type": "t_mapping(t_uint64,t_struct(AddressSet)3420_storage)"
         },
         {
-          "astId": 9866,
+          "astId": 9895,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpSignatures",
           "offset": 0,
@@ -468,7 +468,7 @@
           "type": "t_mapping(t_uint64,t_mapping(t_address,t_bytes_storage))"
         },
         {
-          "astId": 9870,
+          "astId": 9899,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "subnetKeys",
           "offset": 0,
@@ -476,15 +476,15 @@
           "type": "t_array(t_bytes32)dyn_storage"
         },
         {
-          "astId": 9874,
+          "astId": 9903,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "networkName",
           "offset": 0,
           "slot": "19",
-          "type": "t_struct(SubnetID)14812_storage"
+          "type": "t_struct(SubnetID)14841_storage"
         },
         {
-          "astId": 9877,
+          "astId": 9906,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "minStake",
           "offset": 0,
@@ -492,7 +492,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9880,
+          "astId": 9909,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "minCrossMsgFee",
           "offset": 0,
@@ -500,7 +500,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 9883,
+          "astId": 9912,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "majorityPercentage",
           "offset": 0,
@@ -508,7 +508,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 9886,
+          "astId": 9915,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpNonce",
           "offset": 1,
@@ -516,7 +516,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9889,
+          "astId": 9918,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "appliedTopDownNonce",
           "offset": 9,
@@ -524,7 +524,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9892,
+          "astId": 9921,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "totalSubnets",
           "offset": 17,
@@ -532,7 +532,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9894,
+          "astId": 9923,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpCheckPeriod",
           "offset": 0,
@@ -540,15 +540,15 @@
           "type": "t_uint64"
         },
         {
-          "astId": 9898,
+          "astId": 9927,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "validatorsTracker",
           "offset": 0,
           "slot": "25",
-          "type": "t_struct(ParentValidatorsTracker)14923_storage"
+          "type": "t_struct(ParentValidatorsTracker)14952_storage"
         },
         {
-          "astId": 9901,
+          "astId": 9930,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "lastBottomUpExecutedCheckpointHeight",
           "offset": 0,
@@ -558,58 +558,58 @@
       ],
       "numberOfBytes": "1184"
     },
-    "t_struct(IPCAddress)14930_storage": {
+    "t_struct(IPCAddress)14959_storage": {
       "encoding": "inplace",
       "label": "struct IPCAddress",
       "members": [
         {
-          "astId": 14926,
+          "astId": 14955,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "subnetId",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)14812_storage"
+          "type": "t_struct(SubnetID)14841_storage"
         },
         {
-          "astId": 14929,
+          "astId": 14958,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "rawAddress",
           "offset": 0,
           "slot": "2",
-          "type": "t_struct(FvmAddress)14782_storage"
+          "type": "t_struct(FvmAddress)14811_storage"
         }
       ],
       "numberOfBytes": "128"
     },
-    "t_struct(MaxPQ)13270_storage": {
+    "t_struct(MaxPQ)13299_storage": {
       "encoding": "inplace",
       "label": "struct MaxPQ",
       "members": [
         {
-          "astId": 13269,
+          "astId": 13298,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)14507_storage"
+          "type": "t_struct(PQ)14536_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(Membership)14944_storage": {
+    "t_struct(Membership)14973_storage": {
       "encoding": "inplace",
       "label": "struct Membership",
       "members": [
         {
-          "astId": 14941,
+          "astId": 14970,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "validators",
           "offset": 0,
           "slot": "0",
-          "type": "t_array(t_struct(Validator)14937_storage)dyn_storage"
+          "type": "t_array(t_struct(Validator)14966_storage)dyn_storage"
         },
         {
-          "astId": 14943,
+          "astId": 14972,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "configurationNumber",
           "offset": 0,
@@ -619,27 +619,27 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(MinPQ)13883_storage": {
+    "t_struct(MinPQ)13912_storage": {
       "encoding": "inplace",
       "label": "struct MinPQ",
       "members": [
         {
-          "astId": 13882,
+          "astId": 13911,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)14507_storage"
+          "type": "t_struct(PQ)14536_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(PQ)14507_storage": {
+    "t_struct(PQ)14536_storage": {
       "encoding": "inplace",
       "label": "struct PQ",
       "members": [
         {
-          "astId": 14496,
+          "astId": 14525,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "size",
           "offset": 0,
@@ -647,7 +647,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 14501,
+          "astId": 14530,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "addressToPos",
           "offset": 0,
@@ -655,7 +655,7 @@
           "type": "t_mapping(t_address,t_uint16)"
         },
         {
-          "astId": 14506,
+          "astId": 14535,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "posToAddress",
           "offset": 0,
@@ -665,12 +665,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ParentFinality)14719_storage": {
+    "t_struct(ParentFinality)14748_storage": {
       "encoding": "inplace",
       "label": "struct ParentFinality",
       "members": [
         {
-          "astId": 14716,
+          "astId": 14745,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "height",
           "offset": 0,
@@ -678,7 +678,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14718,
+          "astId": 14747,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "blockHash",
           "offset": 0,
@@ -688,25 +688,25 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(ParentValidatorsTracker)14923_storage": {
+    "t_struct(ParentValidatorsTracker)14952_storage": {
       "encoding": "inplace",
       "label": "struct ParentValidatorsTracker",
       "members": [
         {
-          "astId": 14919,
+          "astId": 14948,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "validators",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(ValidatorSet)14916_storage"
+          "type": "t_struct(ValidatorSet)14945_storage"
         },
         {
-          "astId": 14922,
+          "astId": 14951,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "changes",
           "offset": 0,
           "slot": "9",
-          "type": "t_struct(StakingChangeLog)14860_storage"
+          "type": "t_struct(StakingChangeLog)14889_storage"
         }
       ],
       "numberOfBytes": "352"
@@ -734,20 +734,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingChange)14841_storage": {
+    "t_struct(StakingChange)14870_storage": {
       "encoding": "inplace",
       "label": "struct StakingChange",
       "members": [
         {
-          "astId": 14836,
+          "astId": 14865,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "op",
           "offset": 0,
           "slot": "0",
-          "type": "t_enum(StakingOperation)14833"
+          "type": "t_enum(StakingOperation)14862"
         },
         {
-          "astId": 14838,
+          "astId": 14867,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "payload",
           "offset": 0,
@@ -755,7 +755,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 14840,
+          "astId": 14869,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "validator",
           "offset": 0,
@@ -765,12 +765,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(StakingChangeLog)14860_storage": {
+    "t_struct(StakingChangeLog)14889_storage": {
       "encoding": "inplace",
       "label": "struct StakingChangeLog",
       "members": [
         {
-          "astId": 14850,
+          "astId": 14879,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -778,7 +778,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14853,
+          "astId": 14882,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "startConfigurationNumber",
           "offset": 8,
@@ -786,38 +786,38 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14859,
+          "astId": 14888,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "changes",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_uint64,t_struct(StakingChange)14841_storage)"
+          "type": "t_mapping(t_uint64,t_struct(StakingChange)14870_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StorableMsg)14775_storage": {
+    "t_struct(StorableMsg)14804_storage": {
       "encoding": "inplace",
       "label": "struct StorableMsg",
       "members": [
         {
-          "astId": 14761,
+          "astId": 14790,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "from",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(IPCAddress)14930_storage"
+          "type": "t_struct(IPCAddress)14959_storage"
         },
         {
-          "astId": 14764,
+          "astId": 14793,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "to",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(IPCAddress)14930_storage"
+          "type": "t_struct(IPCAddress)14959_storage"
         },
         {
-          "astId": 14766,
+          "astId": 14795,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "value",
           "offset": 0,
@@ -825,7 +825,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14768,
+          "astId": 14797,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "nonce",
           "offset": 0,
@@ -833,7 +833,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14770,
+          "astId": 14799,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "method",
           "offset": 8,
@@ -841,7 +841,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 14772,
+          "astId": 14801,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "params",
           "offset": 0,
@@ -849,7 +849,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 14774,
+          "astId": 14803,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "fee",
           "offset": 0,
@@ -859,12 +859,12 @@
       ],
       "numberOfBytes": "384"
     },
-    "t_struct(Subnet)14829_storage": {
+    "t_struct(Subnet)14858_storage": {
       "encoding": "inplace",
       "label": "struct Subnet",
       "members": [
         {
-          "astId": 14814,
+          "astId": 14843,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "stake",
           "offset": 0,
@@ -872,7 +872,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14816,
+          "astId": 14845,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "genesisEpoch",
           "offset": 0,
@@ -880,7 +880,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14818,
+          "astId": 14847,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "circSupply",
           "offset": 0,
@@ -888,7 +888,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14820,
+          "astId": 14849,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "topDownNonce",
           "offset": 0,
@@ -896,7 +896,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14822,
+          "astId": 14851,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "appliedBottomUpNonce",
           "offset": 8,
@@ -904,7 +904,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14825,
+          "astId": 14854,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "status",
           "offset": 16,
@@ -912,22 +912,22 @@
           "type": "t_enum(Status)5033"
         },
         {
-          "astId": 14828,
+          "astId": 14857,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "id",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(SubnetID)14812_storage"
+          "type": "t_struct(SubnetID)14841_storage"
         }
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(SubnetID)14812_storage": {
+    "t_struct(SubnetID)14841_storage": {
       "encoding": "inplace",
       "label": "struct SubnetID",
       "members": [
         {
-          "astId": 14807,
+          "astId": 14836,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "root",
           "offset": 0,
@@ -935,7 +935,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14811,
+          "astId": 14840,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "route",
           "offset": 0,
@@ -960,12 +960,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(Validator)14937_storage": {
+    "t_struct(Validator)14966_storage": {
       "encoding": "inplace",
       "label": "struct Validator",
       "members": [
         {
-          "astId": 14932,
+          "astId": 14961,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "weight",
           "offset": 0,
@@ -973,7 +973,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14934,
+          "astId": 14963,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "addr",
           "offset": 0,
@@ -981,7 +981,7 @@
           "type": "t_address"
         },
         {
-          "astId": 14936,
+          "astId": 14965,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "metadata",
           "offset": 0,
@@ -991,12 +991,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorInfo)14895_storage": {
+    "t_struct(ValidatorInfo)14924_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorInfo",
       "members": [
         {
-          "astId": 14889,
+          "astId": 14918,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "confirmedCollateral",
           "offset": 0,
@@ -1004,7 +1004,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14891,
+          "astId": 14920,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "totalCollateral",
           "offset": 0,
@@ -1012,7 +1012,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14894,
+          "astId": 14923,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "metadata",
           "offset": 0,
@@ -1022,12 +1022,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorSet)14916_storage": {
+    "t_struct(ValidatorSet)14945_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorSet",
       "members": [
         {
-          "astId": 14898,
+          "astId": 14927,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "activeLimit",
           "offset": 0,
@@ -1035,7 +1035,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 14901,
+          "astId": 14930,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "totalConfirmedCollateral",
           "offset": 0,
@@ -1043,28 +1043,28 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14907,
+          "astId": 14936,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "validators",
           "offset": 0,
           "slot": "2",
-          "type": "t_mapping(t_address,t_struct(ValidatorInfo)14895_storage)"
+          "type": "t_mapping(t_address,t_struct(ValidatorInfo)14924_storage)"
         },
         {
-          "astId": 14911,
+          "astId": 14940,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "activeValidators",
           "offset": 0,
           "slot": "3",
-          "type": "t_struct(MinPQ)13883_storage"
+          "type": "t_struct(MinPQ)13912_storage"
         },
         {
-          "astId": 14915,
+          "astId": 14944,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "waitingValidators",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(MaxPQ)13270_storage"
+          "type": "t_struct(MaxPQ)13299_storage"
         }
       ],
       "numberOfBytes": "288"

--- a/.storage-layouts/SubnetActorDiamond.json
+++ b/.storage-layouts/SubnetActorDiamond.json
@@ -6,7 +6,7 @@
       "label": "s",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(SubnetActorStorage)12513_storage"
+      "type": "t_struct(SubnetActorStorage)12542_storage"
     }
   ],
   "types": {
@@ -27,8 +27,8 @@
       "label": "bytes32[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(Validator)14937_storage)dyn_storage": {
-      "base": "t_struct(Validator)14937_storage",
+    "t_array(t_struct(Validator)14966_storage)dyn_storage": {
+      "base": "t_struct(Validator)14966_storage",
       "encoding": "dynamic_array",
       "label": "struct Validator[]",
       "numberOfBytes": "32"
@@ -53,7 +53,7 @@
       "label": "enum ConsensusType",
       "numberOfBytes": "1"
     },
-    "t_enum(StakingOperation)14833": {
+    "t_enum(StakingOperation)14862": {
       "encoding": "inplace",
       "label": "enum StakingOperation",
       "numberOfBytes": "1"
@@ -70,19 +70,19 @@
       "numberOfBytes": "32",
       "value": "t_string_storage"
     },
-    "t_mapping(t_address,t_struct(AddressStakingReleases)14877_storage)": {
+    "t_mapping(t_address,t_struct(AddressStakingReleases)14906_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct AddressStakingReleases)",
       "numberOfBytes": "32",
-      "value": "t_struct(AddressStakingReleases)14877_storage"
+      "value": "t_struct(AddressStakingReleases)14906_storage"
     },
-    "t_mapping(t_address,t_struct(ValidatorInfo)14895_storage)": {
+    "t_mapping(t_address,t_struct(ValidatorInfo)14924_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ValidatorInfo)",
       "numberOfBytes": "32",
-      "value": "t_struct(ValidatorInfo)14895_storage"
+      "value": "t_struct(ValidatorInfo)14924_storage"
     },
     "t_mapping(t_address,t_uint16)": {
       "encoding": "mapping",
@@ -112,12 +112,12 @@
       "numberOfBytes": "32",
       "value": "t_address"
     },
-    "t_mapping(t_uint16,t_struct(StakingRelease)14867_storage)": {
+    "t_mapping(t_uint16,t_struct(StakingRelease)14896_storage)": {
       "encoding": "mapping",
       "key": "t_uint16",
       "label": "mapping(uint16 => struct StakingRelease)",
       "numberOfBytes": "32",
-      "value": "t_struct(StakingRelease)14867_storage"
+      "value": "t_struct(StakingRelease)14896_storage"
     },
     "t_mapping(t_uint64,t_struct(AddressSet)3420_storage)": {
       "encoding": "mapping",
@@ -126,19 +126,19 @@
       "numberOfBytes": "32",
       "value": "t_struct(AddressSet)3420_storage"
     },
-    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)14736_storage)": {
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)14765_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)14736_storage"
+      "value": "t_struct(BottomUpCheckpoint)14765_storage"
     },
-    "t_mapping(t_uint64,t_struct(StakingChange)14841_storage)": {
+    "t_mapping(t_uint64,t_struct(StakingChange)14870_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct StakingChange)",
       "numberOfBytes": "32",
-      "value": "t_struct(StakingChange)14841_storage"
+      "value": "t_struct(StakingChange)14870_storage"
     },
     "t_string_storage": {
       "encoding": "bytes",
@@ -160,12 +160,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(AddressStakingReleases)14877_storage": {
+    "t_struct(AddressStakingReleases)14906_storage": {
       "encoding": "inplace",
       "label": "struct AddressStakingReleases",
       "members": [
         {
-          "astId": 14869,
+          "astId": 14898,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "length",
           "offset": 0,
@@ -173,7 +173,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 14871,
+          "astId": 14900,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "startIdx",
           "offset": 2,
@@ -181,30 +181,30 @@
           "type": "t_uint16"
         },
         {
-          "astId": 14876,
+          "astId": 14905,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "releases",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_uint16,t_struct(StakingRelease)14867_storage)"
+          "type": "t_mapping(t_uint16,t_struct(StakingRelease)14896_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(BottomUpCheckpoint)14736_storage": {
+    "t_struct(BottomUpCheckpoint)14765_storage": {
       "encoding": "inplace",
       "label": "struct BottomUpCheckpoint",
       "members": [
         {
-          "astId": 14723,
+          "astId": 14752,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "subnetID",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)14812_storage"
+          "type": "t_struct(SubnetID)14841_storage"
         },
         {
-          "astId": 14726,
+          "astId": 14755,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "blockHeight",
           "offset": 0,
@@ -212,7 +212,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14729,
+          "astId": 14758,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "blockHash",
           "offset": 0,
@@ -220,7 +220,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14732,
+          "astId": 14761,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -228,7 +228,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14735,
+          "astId": 14764,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "crossMessagesHash",
           "offset": 0,
@@ -238,42 +238,42 @@
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(MaxPQ)13270_storage": {
+    "t_struct(MaxPQ)13299_storage": {
       "encoding": "inplace",
       "label": "struct MaxPQ",
       "members": [
         {
-          "astId": 13269,
+          "astId": 13298,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)14507_storage"
+          "type": "t_struct(PQ)14536_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(MinPQ)13883_storage": {
+    "t_struct(MinPQ)13912_storage": {
       "encoding": "inplace",
       "label": "struct MinPQ",
       "members": [
         {
-          "astId": 13882,
+          "astId": 13911,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)14507_storage"
+          "type": "t_struct(PQ)14536_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(PQ)14507_storage": {
+    "t_struct(PQ)14536_storage": {
       "encoding": "inplace",
       "label": "struct PQ",
       "members": [
         {
-          "astId": 14496,
+          "astId": 14525,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "size",
           "offset": 0,
@@ -281,7 +281,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 14501,
+          "astId": 14530,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "addressToPos",
           "offset": 0,
@@ -289,7 +289,7 @@
           "type": "t_mapping(t_address,t_uint16)"
         },
         {
-          "astId": 14506,
+          "astId": 14535,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "posToAddress",
           "offset": 0,
@@ -322,20 +322,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingChange)14841_storage": {
+    "t_struct(StakingChange)14870_storage": {
       "encoding": "inplace",
       "label": "struct StakingChange",
       "members": [
         {
-          "astId": 14836,
+          "astId": 14865,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "op",
           "offset": 0,
           "slot": "0",
-          "type": "t_enum(StakingOperation)14833"
+          "type": "t_enum(StakingOperation)14862"
         },
         {
-          "astId": 14838,
+          "astId": 14867,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "payload",
           "offset": 0,
@@ -343,7 +343,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 14840,
+          "astId": 14869,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "validator",
           "offset": 0,
@@ -353,12 +353,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(StakingChangeLog)14860_storage": {
+    "t_struct(StakingChangeLog)14889_storage": {
       "encoding": "inplace",
       "label": "struct StakingChangeLog",
       "members": [
         {
-          "astId": 14850,
+          "astId": 14879,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -366,7 +366,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14853,
+          "astId": 14882,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "startConfigurationNumber",
           "offset": 8,
@@ -374,22 +374,22 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14859,
+          "astId": 14888,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "changes",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_uint64,t_struct(StakingChange)14841_storage)"
+          "type": "t_mapping(t_uint64,t_struct(StakingChange)14870_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingRelease)14867_storage": {
+    "t_struct(StakingRelease)14896_storage": {
       "encoding": "inplace",
       "label": "struct StakingRelease",
       "members": [
         {
-          "astId": 14863,
+          "astId": 14892,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "releaseAt",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14866,
+          "astId": 14895,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "amount",
           "offset": 0,
@@ -407,12 +407,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingReleaseQueue)14887_storage": {
+    "t_struct(StakingReleaseQueue)14916_storage": {
       "encoding": "inplace",
       "label": "struct StakingReleaseQueue",
       "members": [
         {
-          "astId": 14880,
+          "astId": 14909,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "lockingDuration",
           "offset": 0,
@@ -420,38 +420,38 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14886,
+          "astId": 14915,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "releases",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_address,t_struct(AddressStakingReleases)14877_storage)"
+          "type": "t_mapping(t_address,t_struct(AddressStakingReleases)14906_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(SubnetActorStorage)12513_storage": {
+    "t_struct(SubnetActorStorage)12542_storage": {
       "encoding": "inplace",
       "label": "struct SubnetActorStorage",
       "members": [
         {
-          "astId": 12436,
+          "astId": 12465,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "committedCheckpoints",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)14736_storage)"
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)14765_storage)"
         },
         {
-          "astId": 12440,
+          "astId": 12469,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "genesisValidators",
           "offset": 0,
           "slot": "1",
-          "type": "t_array(t_struct(Validator)14937_storage)dyn_storage"
+          "type": "t_array(t_struct(Validator)14966_storage)dyn_storage"
         },
         {
-          "astId": 12443,
+          "astId": 12472,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "lastBottomUpCheckpointHeight",
           "offset": 0,
@@ -459,7 +459,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 12446,
+          "astId": 12475,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "minActivationCollateral",
           "offset": 0,
@@ -467,7 +467,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 12449,
+          "astId": 12478,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "bottomUpCheckPeriod",
           "offset": 0,
@@ -475,7 +475,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 12452,
+          "astId": 12481,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "minValidators",
           "offset": 8,
@@ -483,7 +483,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 12454,
+          "astId": 12483,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "currentSubnetHash",
           "offset": 0,
@@ -491,7 +491,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 12457,
+          "astId": 12486,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "ipcGatewayAddr",
           "offset": 0,
@@ -499,7 +499,7 @@
           "type": "t_address"
         },
         {
-          "astId": 12460,
+          "astId": 12489,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "majorityPercentage",
           "offset": 20,
@@ -507,7 +507,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 12463,
+          "astId": 12492,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "minCrossMsgFee",
           "offset": 0,
@@ -515,15 +515,15 @@
           "type": "t_uint256"
         },
         {
-          "astId": 12467,
+          "astId": 12496,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "parentId",
           "offset": 0,
           "slot": "8",
-          "type": "t_struct(SubnetID)14812_storage"
+          "type": "t_struct(SubnetID)14841_storage"
         },
         {
-          "astId": 12471,
+          "astId": 12500,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "consensus",
           "offset": 0,
@@ -531,7 +531,7 @@
           "type": "t_enum(ConsensusType)5019"
         },
         {
-          "astId": 12474,
+          "astId": 12503,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "bootstrapped",
           "offset": 1,
@@ -539,7 +539,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 12477,
+          "astId": 12506,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "killed",
           "offset": 2,
@@ -547,31 +547,31 @@
           "type": "t_bool"
         },
         {
-          "astId": 12481,
+          "astId": 12510,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "validatorSet",
           "offset": 0,
           "slot": "11",
-          "type": "t_struct(ValidatorSet)14916_storage"
+          "type": "t_struct(ValidatorSet)14945_storage"
         },
         {
-          "astId": 12485,
+          "astId": 12514,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "changeSet",
           "offset": 0,
           "slot": "20",
-          "type": "t_struct(StakingChangeLog)14860_storage"
+          "type": "t_struct(StakingChangeLog)14889_storage"
         },
         {
-          "astId": 12489,
+          "astId": 12518,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "releaseQueue",
           "offset": 0,
           "slot": "22",
-          "type": "t_struct(StakingReleaseQueue)14887_storage"
+          "type": "t_struct(StakingReleaseQueue)14916_storage"
         },
         {
-          "astId": 12492,
+          "astId": 12521,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "powerScale",
           "offset": 0,
@@ -579,7 +579,7 @@
           "type": "t_int8"
         },
         {
-          "astId": 12497,
+          "astId": 12526,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "relayerRewards",
           "offset": 0,
@@ -587,7 +587,7 @@
           "type": "t_mapping(t_address,t_uint256)"
         },
         {
-          "astId": 12503,
+          "astId": 12532,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "rewardedRelayers",
           "offset": 0,
@@ -595,7 +595,7 @@
           "type": "t_mapping(t_uint64,t_struct(AddressSet)3420_storage)"
         },
         {
-          "astId": 12508,
+          "astId": 12537,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "bootstrapNodes",
           "offset": 0,
@@ -603,7 +603,7 @@
           "type": "t_mapping(t_address,t_string_storage)"
         },
         {
-          "astId": 12512,
+          "astId": 12541,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "bootstrapOwners",
           "offset": 0,
@@ -613,12 +613,12 @@
       ],
       "numberOfBytes": "960"
     },
-    "t_struct(SubnetID)14812_storage": {
+    "t_struct(SubnetID)14841_storage": {
       "encoding": "inplace",
       "label": "struct SubnetID",
       "members": [
         {
-          "astId": 14807,
+          "astId": 14836,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "root",
           "offset": 0,
@@ -626,7 +626,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14811,
+          "astId": 14840,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "route",
           "offset": 0,
@@ -636,12 +636,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(Validator)14937_storage": {
+    "t_struct(Validator)14966_storage": {
       "encoding": "inplace",
       "label": "struct Validator",
       "members": [
         {
-          "astId": 14932,
+          "astId": 14961,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "weight",
           "offset": 0,
@@ -649,7 +649,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14934,
+          "astId": 14963,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "addr",
           "offset": 0,
@@ -657,7 +657,7 @@
           "type": "t_address"
         },
         {
-          "astId": 14936,
+          "astId": 14965,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "metadata",
           "offset": 0,
@@ -667,12 +667,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorInfo)14895_storage": {
+    "t_struct(ValidatorInfo)14924_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorInfo",
       "members": [
         {
-          "astId": 14889,
+          "astId": 14918,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "confirmedCollateral",
           "offset": 0,
@@ -680,7 +680,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14891,
+          "astId": 14920,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "totalCollateral",
           "offset": 0,
@@ -688,7 +688,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14894,
+          "astId": 14923,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "metadata",
           "offset": 0,
@@ -698,12 +698,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorSet)14916_storage": {
+    "t_struct(ValidatorSet)14945_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorSet",
       "members": [
         {
-          "astId": 14898,
+          "astId": 14927,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "activeLimit",
           "offset": 0,
@@ -711,7 +711,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 14901,
+          "astId": 14930,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "totalConfirmedCollateral",
           "offset": 0,
@@ -719,28 +719,28 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14907,
+          "astId": 14936,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "validators",
           "offset": 0,
           "slot": "2",
-          "type": "t_mapping(t_address,t_struct(ValidatorInfo)14895_storage)"
+          "type": "t_mapping(t_address,t_struct(ValidatorInfo)14924_storage)"
         },
         {
-          "astId": 14911,
+          "astId": 14940,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "activeValidators",
           "offset": 0,
           "slot": "3",
-          "type": "t_struct(MinPQ)13883_storage"
+          "type": "t_struct(MinPQ)13912_storage"
         },
         {
-          "astId": 14915,
+          "astId": 14944,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "waitingValidators",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(MaxPQ)13270_storage"
+          "type": "t_struct(MaxPQ)13299_storage"
         }
       ],
       "numberOfBytes": "288"

--- a/.storage-layouts/SubnetActorModifiers.json
+++ b/.storage-layouts/SubnetActorModifiers.json
@@ -1,12 +1,12 @@
 {
   "storage": [
     {
-      "astId": 12527,
+      "astId": 12556,
       "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
       "label": "s",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(SubnetActorStorage)12513_storage"
+      "type": "t_struct(SubnetActorStorage)12542_storage"
     }
   ],
   "types": {
@@ -27,8 +27,8 @@
       "label": "bytes32[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(Validator)14937_storage)dyn_storage": {
-      "base": "t_struct(Validator)14937_storage",
+    "t_array(t_struct(Validator)14966_storage)dyn_storage": {
+      "base": "t_struct(Validator)14966_storage",
       "encoding": "dynamic_array",
       "label": "struct Validator[]",
       "numberOfBytes": "32"
@@ -53,7 +53,7 @@
       "label": "enum ConsensusType",
       "numberOfBytes": "1"
     },
-    "t_enum(StakingOperation)14833": {
+    "t_enum(StakingOperation)14862": {
       "encoding": "inplace",
       "label": "enum StakingOperation",
       "numberOfBytes": "1"
@@ -70,19 +70,19 @@
       "numberOfBytes": "32",
       "value": "t_string_storage"
     },
-    "t_mapping(t_address,t_struct(AddressStakingReleases)14877_storage)": {
+    "t_mapping(t_address,t_struct(AddressStakingReleases)14906_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct AddressStakingReleases)",
       "numberOfBytes": "32",
-      "value": "t_struct(AddressStakingReleases)14877_storage"
+      "value": "t_struct(AddressStakingReleases)14906_storage"
     },
-    "t_mapping(t_address,t_struct(ValidatorInfo)14895_storage)": {
+    "t_mapping(t_address,t_struct(ValidatorInfo)14924_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ValidatorInfo)",
       "numberOfBytes": "32",
-      "value": "t_struct(ValidatorInfo)14895_storage"
+      "value": "t_struct(ValidatorInfo)14924_storage"
     },
     "t_mapping(t_address,t_uint16)": {
       "encoding": "mapping",
@@ -112,12 +112,12 @@
       "numberOfBytes": "32",
       "value": "t_address"
     },
-    "t_mapping(t_uint16,t_struct(StakingRelease)14867_storage)": {
+    "t_mapping(t_uint16,t_struct(StakingRelease)14896_storage)": {
       "encoding": "mapping",
       "key": "t_uint16",
       "label": "mapping(uint16 => struct StakingRelease)",
       "numberOfBytes": "32",
-      "value": "t_struct(StakingRelease)14867_storage"
+      "value": "t_struct(StakingRelease)14896_storage"
     },
     "t_mapping(t_uint64,t_struct(AddressSet)3420_storage)": {
       "encoding": "mapping",
@@ -126,19 +126,19 @@
       "numberOfBytes": "32",
       "value": "t_struct(AddressSet)3420_storage"
     },
-    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)14736_storage)": {
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)14765_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)14736_storage"
+      "value": "t_struct(BottomUpCheckpoint)14765_storage"
     },
-    "t_mapping(t_uint64,t_struct(StakingChange)14841_storage)": {
+    "t_mapping(t_uint64,t_struct(StakingChange)14870_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct StakingChange)",
       "numberOfBytes": "32",
-      "value": "t_struct(StakingChange)14841_storage"
+      "value": "t_struct(StakingChange)14870_storage"
     },
     "t_string_storage": {
       "encoding": "bytes",
@@ -160,12 +160,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(AddressStakingReleases)14877_storage": {
+    "t_struct(AddressStakingReleases)14906_storage": {
       "encoding": "inplace",
       "label": "struct AddressStakingReleases",
       "members": [
         {
-          "astId": 14869,
+          "astId": 14898,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "length",
           "offset": 0,
@@ -173,7 +173,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 14871,
+          "astId": 14900,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "startIdx",
           "offset": 2,
@@ -181,30 +181,30 @@
           "type": "t_uint16"
         },
         {
-          "astId": 14876,
+          "astId": 14905,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "releases",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_uint16,t_struct(StakingRelease)14867_storage)"
+          "type": "t_mapping(t_uint16,t_struct(StakingRelease)14896_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(BottomUpCheckpoint)14736_storage": {
+    "t_struct(BottomUpCheckpoint)14765_storage": {
       "encoding": "inplace",
       "label": "struct BottomUpCheckpoint",
       "members": [
         {
-          "astId": 14723,
+          "astId": 14752,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "subnetID",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)14812_storage"
+          "type": "t_struct(SubnetID)14841_storage"
         },
         {
-          "astId": 14726,
+          "astId": 14755,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "blockHeight",
           "offset": 0,
@@ -212,7 +212,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14729,
+          "astId": 14758,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "blockHash",
           "offset": 0,
@@ -220,7 +220,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 14732,
+          "astId": 14761,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -228,7 +228,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14735,
+          "astId": 14764,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "crossMessagesHash",
           "offset": 0,
@@ -238,42 +238,42 @@
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(MaxPQ)13270_storage": {
+    "t_struct(MaxPQ)13299_storage": {
       "encoding": "inplace",
       "label": "struct MaxPQ",
       "members": [
         {
-          "astId": 13269,
+          "astId": 13298,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)14507_storage"
+          "type": "t_struct(PQ)14536_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(MinPQ)13883_storage": {
+    "t_struct(MinPQ)13912_storage": {
       "encoding": "inplace",
       "label": "struct MinPQ",
       "members": [
         {
-          "astId": 13882,
+          "astId": 13911,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)14507_storage"
+          "type": "t_struct(PQ)14536_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(PQ)14507_storage": {
+    "t_struct(PQ)14536_storage": {
       "encoding": "inplace",
       "label": "struct PQ",
       "members": [
         {
-          "astId": 14496,
+          "astId": 14525,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "size",
           "offset": 0,
@@ -281,7 +281,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 14501,
+          "astId": 14530,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "addressToPos",
           "offset": 0,
@@ -289,7 +289,7 @@
           "type": "t_mapping(t_address,t_uint16)"
         },
         {
-          "astId": 14506,
+          "astId": 14535,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "posToAddress",
           "offset": 0,
@@ -322,20 +322,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingChange)14841_storage": {
+    "t_struct(StakingChange)14870_storage": {
       "encoding": "inplace",
       "label": "struct StakingChange",
       "members": [
         {
-          "astId": 14836,
+          "astId": 14865,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "op",
           "offset": 0,
           "slot": "0",
-          "type": "t_enum(StakingOperation)14833"
+          "type": "t_enum(StakingOperation)14862"
         },
         {
-          "astId": 14838,
+          "astId": 14867,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "payload",
           "offset": 0,
@@ -343,7 +343,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 14840,
+          "astId": 14869,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "validator",
           "offset": 0,
@@ -353,12 +353,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(StakingChangeLog)14860_storage": {
+    "t_struct(StakingChangeLog)14889_storage": {
       "encoding": "inplace",
       "label": "struct StakingChangeLog",
       "members": [
         {
-          "astId": 14850,
+          "astId": 14879,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -366,7 +366,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14853,
+          "astId": 14882,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "startConfigurationNumber",
           "offset": 8,
@@ -374,22 +374,22 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14859,
+          "astId": 14888,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "changes",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_uint64,t_struct(StakingChange)14841_storage)"
+          "type": "t_mapping(t_uint64,t_struct(StakingChange)14870_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingRelease)14867_storage": {
+    "t_struct(StakingRelease)14896_storage": {
       "encoding": "inplace",
       "label": "struct StakingRelease",
       "members": [
         {
-          "astId": 14863,
+          "astId": 14892,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "releaseAt",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14866,
+          "astId": 14895,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "amount",
           "offset": 0,
@@ -407,12 +407,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingReleaseQueue)14887_storage": {
+    "t_struct(StakingReleaseQueue)14916_storage": {
       "encoding": "inplace",
       "label": "struct StakingReleaseQueue",
       "members": [
         {
-          "astId": 14880,
+          "astId": 14909,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "lockingDuration",
           "offset": 0,
@@ -420,38 +420,38 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14886,
+          "astId": 14915,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "releases",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_address,t_struct(AddressStakingReleases)14877_storage)"
+          "type": "t_mapping(t_address,t_struct(AddressStakingReleases)14906_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(SubnetActorStorage)12513_storage": {
+    "t_struct(SubnetActorStorage)12542_storage": {
       "encoding": "inplace",
       "label": "struct SubnetActorStorage",
       "members": [
         {
-          "astId": 12436,
+          "astId": 12465,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "committedCheckpoints",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)14736_storage)"
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)14765_storage)"
         },
         {
-          "astId": 12440,
+          "astId": 12469,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "genesisValidators",
           "offset": 0,
           "slot": "1",
-          "type": "t_array(t_struct(Validator)14937_storage)dyn_storage"
+          "type": "t_array(t_struct(Validator)14966_storage)dyn_storage"
         },
         {
-          "astId": 12443,
+          "astId": 12472,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "lastBottomUpCheckpointHeight",
           "offset": 0,
@@ -459,7 +459,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 12446,
+          "astId": 12475,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "minActivationCollateral",
           "offset": 0,
@@ -467,7 +467,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 12449,
+          "astId": 12478,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "bottomUpCheckPeriod",
           "offset": 0,
@@ -475,7 +475,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 12452,
+          "astId": 12481,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "minValidators",
           "offset": 8,
@@ -483,7 +483,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 12454,
+          "astId": 12483,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "currentSubnetHash",
           "offset": 0,
@@ -491,7 +491,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 12457,
+          "astId": 12486,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "ipcGatewayAddr",
           "offset": 0,
@@ -499,7 +499,7 @@
           "type": "t_address"
         },
         {
-          "astId": 12460,
+          "astId": 12489,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "majorityPercentage",
           "offset": 20,
@@ -507,7 +507,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 12463,
+          "astId": 12492,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "minCrossMsgFee",
           "offset": 0,
@@ -515,15 +515,15 @@
           "type": "t_uint256"
         },
         {
-          "astId": 12467,
+          "astId": 12496,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "parentId",
           "offset": 0,
           "slot": "8",
-          "type": "t_struct(SubnetID)14812_storage"
+          "type": "t_struct(SubnetID)14841_storage"
         },
         {
-          "astId": 12471,
+          "astId": 12500,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "consensus",
           "offset": 0,
@@ -531,7 +531,7 @@
           "type": "t_enum(ConsensusType)5019"
         },
         {
-          "astId": 12474,
+          "astId": 12503,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "bootstrapped",
           "offset": 1,
@@ -539,7 +539,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 12477,
+          "astId": 12506,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "killed",
           "offset": 2,
@@ -547,31 +547,31 @@
           "type": "t_bool"
         },
         {
-          "astId": 12481,
+          "astId": 12510,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "validatorSet",
           "offset": 0,
           "slot": "11",
-          "type": "t_struct(ValidatorSet)14916_storage"
+          "type": "t_struct(ValidatorSet)14945_storage"
         },
         {
-          "astId": 12485,
+          "astId": 12514,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "changeSet",
           "offset": 0,
           "slot": "20",
-          "type": "t_struct(StakingChangeLog)14860_storage"
+          "type": "t_struct(StakingChangeLog)14889_storage"
         },
         {
-          "astId": 12489,
+          "astId": 12518,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "releaseQueue",
           "offset": 0,
           "slot": "22",
-          "type": "t_struct(StakingReleaseQueue)14887_storage"
+          "type": "t_struct(StakingReleaseQueue)14916_storage"
         },
         {
-          "astId": 12492,
+          "astId": 12521,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "powerScale",
           "offset": 0,
@@ -579,7 +579,7 @@
           "type": "t_int8"
         },
         {
-          "astId": 12497,
+          "astId": 12526,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "relayerRewards",
           "offset": 0,
@@ -587,7 +587,7 @@
           "type": "t_mapping(t_address,t_uint256)"
         },
         {
-          "astId": 12503,
+          "astId": 12532,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "rewardedRelayers",
           "offset": 0,
@@ -595,7 +595,7 @@
           "type": "t_mapping(t_uint64,t_struct(AddressSet)3420_storage)"
         },
         {
-          "astId": 12508,
+          "astId": 12537,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "bootstrapNodes",
           "offset": 0,
@@ -603,7 +603,7 @@
           "type": "t_mapping(t_address,t_string_storage)"
         },
         {
-          "astId": 12512,
+          "astId": 12541,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "bootstrapOwners",
           "offset": 0,
@@ -613,12 +613,12 @@
       ],
       "numberOfBytes": "960"
     },
-    "t_struct(SubnetID)14812_storage": {
+    "t_struct(SubnetID)14841_storage": {
       "encoding": "inplace",
       "label": "struct SubnetID",
       "members": [
         {
-          "astId": 14807,
+          "astId": 14836,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "root",
           "offset": 0,
@@ -626,7 +626,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 14811,
+          "astId": 14840,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "route",
           "offset": 0,
@@ -636,12 +636,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(Validator)14937_storage": {
+    "t_struct(Validator)14966_storage": {
       "encoding": "inplace",
       "label": "struct Validator",
       "members": [
         {
-          "astId": 14932,
+          "astId": 14961,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "weight",
           "offset": 0,
@@ -649,7 +649,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14934,
+          "astId": 14963,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "addr",
           "offset": 0,
@@ -657,7 +657,7 @@
           "type": "t_address"
         },
         {
-          "astId": 14936,
+          "astId": 14965,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "metadata",
           "offset": 0,
@@ -667,12 +667,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorInfo)14895_storage": {
+    "t_struct(ValidatorInfo)14924_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorInfo",
       "members": [
         {
-          "astId": 14889,
+          "astId": 14918,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "confirmedCollateral",
           "offset": 0,
@@ -680,7 +680,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14891,
+          "astId": 14920,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "totalCollateral",
           "offset": 0,
@@ -688,7 +688,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14894,
+          "astId": 14923,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "metadata",
           "offset": 0,
@@ -698,12 +698,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorSet)14916_storage": {
+    "t_struct(ValidatorSet)14945_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorSet",
       "members": [
         {
-          "astId": 14898,
+          "astId": 14927,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "activeLimit",
           "offset": 0,
@@ -711,7 +711,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 14901,
+          "astId": 14930,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "totalConfirmedCollateral",
           "offset": 0,
@@ -719,28 +719,28 @@
           "type": "t_uint256"
         },
         {
-          "astId": 14907,
+          "astId": 14936,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "validators",
           "offset": 0,
           "slot": "2",
-          "type": "t_mapping(t_address,t_struct(ValidatorInfo)14895_storage)"
+          "type": "t_mapping(t_address,t_struct(ValidatorInfo)14924_storage)"
         },
         {
-          "astId": 14911,
+          "astId": 14940,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "activeValidators",
           "offset": 0,
           "slot": "3",
-          "type": "t_struct(MinPQ)13883_storage"
+          "type": "t_struct(MinPQ)13912_storage"
         },
         {
-          "astId": 14915,
+          "astId": 14944,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "waitingValidators",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(MaxPQ)13270_storage"
+          "type": "t_struct(MaxPQ)13299_storage"
         }
       ],
       "numberOfBytes": "288"

--- a/src/gateway/GatewayRouterFacet.sol
+++ b/src/gateway/GatewayRouterFacet.sol
@@ -99,6 +99,7 @@ contract GatewayRouterFacet is GatewayActorModifiers {
     }
 
     /// @notice commit the ipc parent finality into storage and returns the previous committed finality
+    /// This is useful to understand if the finalities are consistent or if there have been reorgs.
     /// @param finality - the parent finality
     function commitParentFinality(
         ParentFinality calldata finality

--- a/src/gateway/GatewayRouterFacet.sol
+++ b/src/gateway/GatewayRouterFacet.sol
@@ -98,10 +98,13 @@ contract GatewayRouterFacet is GatewayActorModifiers {
         });
     }
 
-    /// @notice commit the ipc parent finality into storage
+    /// @notice commit the ipc parent finality into storage and returns the previous committed finality
     /// @param finality - the parent finality
-    function commitParentFinality(ParentFinality calldata finality) external systemActorOnly {
-        LibGateway.commitParentFinality(finality);
+    function commitParentFinality(
+        ParentFinality calldata finality
+    ) external systemActorOnly returns (bool hasCommittedBefore, ParentFinality memory previousFinality) {
+        previousFinality = LibGateway.commitParentFinality(finality);
+        hasCommittedBefore = previousFinality.height != 0;
     }
 
     /// @notice Store the validator change requests from parent.

--- a/src/lib/LibGateway.sol
+++ b/src/lib/LibGateway.sol
@@ -55,12 +55,17 @@ library LibGateway {
 
     /// @notice commit the ipc parent finality into storage
     /// @param finality - the finality to be committed
-    function commitParentFinality(ParentFinality calldata finality) internal {
+    function commitParentFinality(
+        ParentFinality calldata finality
+    ) internal returns (ParentFinality memory lastFinality) {
         GatewayActorStorage storage s = LibGatewayActorStorage.appStorage();
 
-        if (s.latestParentHeight > finality.height) {
+        uint256 lastHeight = s.latestParentHeight;
+        if (lastHeight > finality.height) {
             revert ParentFinalityAlreadyCommitted();
         }
+        lastFinality = s.finalitiesMap[lastHeight];
+
         s.finalitiesMap[finality.height] = finality;
         s.latestParentHeight = finality.height;
     }


### PR DESCRIPTION
When committing parent finality, return the previous finality. This is for fendermint to validate the finalities are consistent.