### PR TITLE
FIX: funds weren't being burnt in release

### DIFF
--- a/src/gateway/GatewayManagerFacet.sol
+++ b/src/gateway/GatewayManagerFacet.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.19;
 
 import {GatewayActorModifiers} from "../lib/LibGatewayActorStorage.sol";
+import {BURNT_FUNDS_ACTOR} from "../constants/Constants.sol";
 import {CrossMsg} from "../structs/Checkpoint.sol";
 import {Status} from "../enums/Status.sol";
 import {FvmAddress} from "../structs/FvmAddress.sol";
@@ -149,5 +150,7 @@ contract GatewayManagerFacet is GatewayActorModifiers, ReentrancyGuard {
         });
 
         LibGateway.commitBottomUpMsg(crossMsg);
+        // burn funds that are being released
+        payable(BURNT_FUNDS_ACTOR).sendValue(msg.value);
     }
 }


### PR DESCRIPTION
This PR fixes a bug for which burns were being burnt when [sending arbitrary cross-net message,](https://github.com/consensus-shipyard/ipc-solidity-actors/blob/3f72d21d0ad601fbb673b6a9bc650d14f7be9c9f/src/gateway/GatewayMessengerFacet.sol#L41) but not when a simple `release` message was being triggered.