### PR TITLE
Remove check

### DIFF
--- a/.storage-layouts/GatewayActorModifiers.json
+++ b/.storage-layouts/GatewayActorModifiers.json
@@ -1,12 +1,12 @@
 {
   "storage": [
     {
-      "astId": 10327,
+      "astId": 10305,
       "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
       "label": "s",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(GatewayActorStorage)10313_storage"
+      "type": "t_struct(GatewayActorStorage)10291_storage"
     }
   ],
   "types": {
@@ -27,14 +27,14 @@
       "label": "bytes32[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(CrossMsg)15284_storage)dyn_storage": {
-      "base": "t_struct(CrossMsg)15284_storage",
+    "t_array(t_struct(CrossMsg)15262_storage)dyn_storage": {
+      "base": "t_struct(CrossMsg)15262_storage",
       "encoding": "dynamic_array",
       "label": "struct CrossMsg[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(Validator)15463_storage)dyn_storage": {
-      "base": "t_struct(Validator)15463_storage",
+    "t_array(t_struct(Validator)15441_storage)dyn_storage": {
+      "base": "t_struct(Validator)15441_storage",
       "encoding": "dynamic_array",
       "label": "struct Validator[]",
       "numberOfBytes": "32"
@@ -59,7 +59,7 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_enum(StakingOperation)15359": {
+    "t_enum(StakingOperation)15337": {
       "encoding": "inplace",
       "label": "enum StakingOperation",
       "numberOfBytes": "1"
@@ -76,12 +76,12 @@
       "numberOfBytes": "32",
       "value": "t_bytes_storage"
     },
-    "t_mapping(t_address,t_struct(ValidatorInfo)15421_storage)": {
+    "t_mapping(t_address,t_struct(ValidatorInfo)15399_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ValidatorInfo)",
       "numberOfBytes": "32",
-      "value": "t_struct(ValidatorInfo)15421_storage"
+      "value": "t_struct(ValidatorInfo)15399_storage"
     },
     "t_mapping(t_address,t_uint16)": {
       "encoding": "mapping",
@@ -90,26 +90,26 @@
       "numberOfBytes": "32",
       "value": "t_uint16"
     },
-    "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)15284_storage)dyn_storage))": {
+    "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)15262_storage)dyn_storage))": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => mapping(uint256 => struct CrossMsg[]))",
       "numberOfBytes": "32",
-      "value": "t_mapping(t_uint256,t_array(t_struct(CrossMsg)15284_storage)dyn_storage)"
+      "value": "t_mapping(t_uint256,t_array(t_struct(CrossMsg)15262_storage)dyn_storage)"
     },
-    "t_mapping(t_bytes32,t_struct(CrossMsg)15284_storage)": {
+    "t_mapping(t_bytes32,t_struct(CrossMsg)15262_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct CrossMsg)",
       "numberOfBytes": "32",
-      "value": "t_struct(CrossMsg)15284_storage"
+      "value": "t_struct(CrossMsg)15262_storage"
     },
-    "t_mapping(t_bytes32,t_struct(Subnet)15355_storage)": {
+    "t_mapping(t_bytes32,t_struct(Subnet)15333_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct Subnet)",
       "numberOfBytes": "32",
-      "value": "t_struct(Subnet)15355_storage"
+      "value": "t_struct(Subnet)15333_storage"
     },
     "t_mapping(t_bytes32,t_uint256)": {
       "encoding": "mapping",
@@ -125,26 +125,26 @@
       "numberOfBytes": "32",
       "value": "t_address"
     },
-    "t_mapping(t_uint256,t_array(t_struct(CrossMsg)15284_storage)dyn_storage)": {
+    "t_mapping(t_uint256,t_array(t_struct(CrossMsg)15262_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct CrossMsg[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(CrossMsg)15284_storage)dyn_storage"
+      "value": "t_array(t_struct(CrossMsg)15262_storage)dyn_storage"
     },
-    "t_mapping(t_uint256,t_struct(ParentFinality)15245_storage)": {
+    "t_mapping(t_uint256,t_struct(ParentFinality)15223_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct ParentFinality)",
       "numberOfBytes": "32",
-      "value": "t_struct(ParentFinality)15245_storage"
+      "value": "t_struct(ParentFinality)15223_storage"
     },
-    "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15284_storage)dyn_storage)": {
+    "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15262_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct CrossMsg[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(CrossMsg)15284_storage)dyn_storage"
+      "value": "t_array(t_struct(CrossMsg)15262_storage)dyn_storage"
     },
     "t_mapping(t_uint64,t_mapping(t_address,t_bytes_storage))": {
       "encoding": "mapping",
@@ -167,26 +167,26 @@
       "numberOfBytes": "32",
       "value": "t_struct(AddressSet)3420_storage"
     },
-    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15262_storage)": {
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15240_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)15262_storage"
+      "value": "t_struct(BottomUpCheckpoint)15240_storage"
     },
-    "t_mapping(t_uint64,t_struct(CheckpointInfo)15278_storage)": {
+    "t_mapping(t_uint64,t_struct(CheckpointInfo)15256_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct CheckpointInfo)",
       "numberOfBytes": "32",
-      "value": "t_struct(CheckpointInfo)15278_storage"
+      "value": "t_struct(CheckpointInfo)15256_storage"
     },
-    "t_mapping(t_uint64,t_struct(StakingChange)15367_storage)": {
+    "t_mapping(t_uint64,t_struct(StakingChange)15345_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct StakingChange)",
       "numberOfBytes": "32",
-      "value": "t_struct(StakingChange)15367_storage"
+      "value": "t_struct(StakingChange)15345_storage"
     },
     "t_struct(AddressSet)3420_storage": {
       "encoding": "inplace",
@@ -203,20 +203,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(BottomUpCheckpoint)15262_storage": {
+    "t_struct(BottomUpCheckpoint)15240_storage": {
       "encoding": "inplace",
       "label": "struct BottomUpCheckpoint",
       "members": [
         {
-          "astId": 15249,
+          "astId": 15227,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "subnetID",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)15338_storage"
+          "type": "t_struct(SubnetID)15316_storage"
         },
         {
-          "astId": 15252,
+          "astId": 15230,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "blockHeight",
           "offset": 0,
@@ -224,7 +224,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15255,
+          "astId": 15233,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "blockHash",
           "offset": 0,
@@ -232,7 +232,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 15258,
+          "astId": 15236,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -240,7 +240,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15261,
+          "astId": 15239,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "crossMessagesHash",
           "offset": 0,
@@ -250,12 +250,12 @@
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(CheckpointInfo)15278_storage": {
+    "t_struct(CheckpointInfo)15256_storage": {
       "encoding": "inplace",
       "label": "struct CheckpointInfo",
       "members": [
         {
-          "astId": 15265,
+          "astId": 15243,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "hash",
           "offset": 0,
@@ -263,7 +263,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 15268,
+          "astId": 15246,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "rootHash",
           "offset": 0,
@@ -271,7 +271,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 15271,
+          "astId": 15249,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "threshold",
           "offset": 0,
@@ -279,7 +279,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15274,
+          "astId": 15252,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "currentWeight",
           "offset": 0,
@@ -287,7 +287,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15277,
+          "astId": 15255,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "reached",
           "offset": 0,
@@ -297,20 +297,20 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(CrossMsg)15284_storage": {
+    "t_struct(CrossMsg)15262_storage": {
       "encoding": "inplace",
       "label": "struct CrossMsg",
       "members": [
         {
-          "astId": 15281,
+          "astId": 15259,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "message",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(StorableMsg)15301_storage"
+          "type": "t_struct(StorableMsg)15279_storage"
         },
         {
-          "astId": 15283,
+          "astId": 15261,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "wrapped",
           "offset": 0,
@@ -320,12 +320,12 @@
       ],
       "numberOfBytes": "416"
     },
-    "t_struct(FvmAddress)15308_storage": {
+    "t_struct(FvmAddress)15286_storage": {
       "encoding": "inplace",
       "label": "struct FvmAddress",
       "members": [
         {
-          "astId": 15305,
+          "astId": 15283,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "addrType",
           "offset": 0,
@@ -333,7 +333,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 15307,
+          "astId": 15285,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "payload",
           "offset": 0,
@@ -343,36 +343,36 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(GatewayActorStorage)10313_storage": {
+    "t_struct(GatewayActorStorage)10291_storage": {
       "encoding": "inplace",
       "label": "struct GatewayActorStorage",
       "members": [
         {
-          "astId": 10202,
+          "astId": 10180,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "subnets",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_bytes32,t_struct(Subnet)15355_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(Subnet)15333_storage)"
         },
         {
-          "astId": 10211,
+          "astId": 10189,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "topDownMsgs",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)15284_storage)dyn_storage))"
+          "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)15262_storage)dyn_storage))"
         },
         {
-          "astId": 10217,
+          "astId": 10195,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "finalitiesMap",
           "offset": 0,
           "slot": "2",
-          "type": "t_mapping(t_uint256,t_struct(ParentFinality)15245_storage)"
+          "type": "t_mapping(t_uint256,t_struct(ParentFinality)15223_storage)"
         },
         {
-          "astId": 10220,
+          "astId": 10198,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "latestParentHeight",
           "offset": 0,
@@ -380,15 +380,15 @@
           "type": "t_uint256"
         },
         {
-          "astId": 10226,
+          "astId": 10204,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "postbox",
           "offset": 0,
           "slot": "4",
-          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)15284_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)15262_storage)"
         },
         {
-          "astId": 10233,
+          "astId": 10211,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "validatorSetWeights",
           "offset": 0,
@@ -396,47 +396,47 @@
           "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_uint256))"
         },
         {
-          "astId": 10237,
+          "astId": 10215,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "currentMembership",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(Membership)15476_storage"
+          "type": "t_struct(Membership)15448_storage"
         },
         {
-          "astId": 10241,
+          "astId": 10219,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "lastMembership",
           "offset": 0,
           "slot": "8",
-          "type": "t_struct(Membership)15476_storage"
+          "type": "t_struct(Membership)15448_storage"
         },
         {
-          "astId": 10247,
+          "astId": 10225,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpCheckpoints",
           "offset": 0,
           "slot": "10",
-          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15262_storage)"
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15240_storage)"
         },
         {
-          "astId": 10253,
+          "astId": 10231,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpCheckpointInfo",
           "offset": 0,
           "slot": "11",
-          "type": "t_mapping(t_uint64,t_struct(CheckpointInfo)15278_storage)"
+          "type": "t_mapping(t_uint64,t_struct(CheckpointInfo)15256_storage)"
         },
         {
-          "astId": 10260,
+          "astId": 10238,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpMessages",
           "offset": 0,
           "slot": "12",
-          "type": "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15284_storage)dyn_storage)"
+          "type": "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15262_storage)dyn_storage)"
         },
         {
-          "astId": 10263,
+          "astId": 10241,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpCheckpointRetentionHeight",
           "offset": 0,
@@ -444,7 +444,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 10267,
+          "astId": 10245,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "incompleteCheckpoints",
           "offset": 0,
@@ -452,7 +452,7 @@
           "type": "t_struct(UintSet)3577_storage"
         },
         {
-          "astId": 10273,
+          "astId": 10251,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpSignatureSenders",
           "offset": 0,
@@ -460,7 +460,7 @@
           "type": "t_mapping(t_uint64,t_struct(AddressSet)3420_storage)"
         },
         {
-          "astId": 10280,
+          "astId": 10258,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpSignatures",
           "offset": 0,
@@ -468,7 +468,7 @@
           "type": "t_mapping(t_uint64,t_mapping(t_address,t_bytes_storage))"
         },
         {
-          "astId": 10284,
+          "astId": 10262,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "subnetKeys",
           "offset": 0,
@@ -476,15 +476,15 @@
           "type": "t_array(t_bytes32)dyn_storage"
         },
         {
-          "astId": 10288,
+          "astId": 10266,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "networkName",
           "offset": 0,
           "slot": "19",
-          "type": "t_struct(SubnetID)15338_storage"
+          "type": "t_struct(SubnetID)15316_storage"
         },
         {
-          "astId": 10291,
+          "astId": 10269,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "minStake",
           "offset": 0,
@@ -492,7 +492,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 10294,
+          "astId": 10272,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "minCrossMsgFee",
           "offset": 0,
@@ -500,7 +500,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 10297,
+          "astId": 10275,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "majorityPercentage",
           "offset": 0,
@@ -508,7 +508,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 10300,
+          "astId": 10278,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpNonce",
           "offset": 1,
@@ -516,7 +516,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 10303,
+          "astId": 10281,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "appliedTopDownNonce",
           "offset": 9,
@@ -524,7 +524,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 10306,
+          "astId": 10284,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "totalSubnets",
           "offset": 17,
@@ -532,7 +532,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 10308,
+          "astId": 10286,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpCheckPeriod",
           "offset": 0,
@@ -540,68 +540,68 @@
           "type": "t_uint64"
         },
         {
-          "astId": 10312,
+          "astId": 10290,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "validatorsTracker",
           "offset": 0,
           "slot": "25",
-          "type": "t_struct(ParentValidatorsTracker)15449_storage"
+          "type": "t_struct(ParentValidatorsTracker)15427_storage"
         }
       ],
       "numberOfBytes": "1152"
     },
-    "t_struct(IPCAddress)15456_storage": {
+    "t_struct(IPCAddress)15434_storage": {
       "encoding": "inplace",
       "label": "struct IPCAddress",
       "members": [
         {
-          "astId": 15452,
+          "astId": 15430,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "subnetId",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)15338_storage"
+          "type": "t_struct(SubnetID)15316_storage"
         },
         {
-          "astId": 15455,
+          "astId": 15433,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "rawAddress",
           "offset": 0,
           "slot": "2",
-          "type": "t_struct(FvmAddress)15308_storage"
+          "type": "t_struct(FvmAddress)15286_storage"
         }
       ],
       "numberOfBytes": "128"
     },
-    "t_struct(MaxPQ)13770_storage": {
+    "t_struct(MaxPQ)13748_storage": {
       "encoding": "inplace",
       "label": "struct MaxPQ",
       "members": [
         {
-          "astId": 13769,
+          "astId": 13747,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)15019_storage"
+          "type": "t_struct(PQ)14997_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(Membership)15476_storage": {
+    "t_struct(Membership)15448_storage": {
       "encoding": "inplace",
       "label": "struct Membership",
       "members": [
         {
-          "astId": 15473,
+          "astId": 15445,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "validators",
           "offset": 0,
           "slot": "0",
-          "type": "t_array(t_struct(Validator)15463_storage)dyn_storage"
+          "type": "t_array(t_struct(Validator)15441_storage)dyn_storage"
         },
         {
-          "astId": 15475,
+          "astId": 15447,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "configurationNumber",
           "offset": 0,
@@ -611,27 +611,27 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(MinPQ)14389_storage": {
+    "t_struct(MinPQ)14367_storage": {
       "encoding": "inplace",
       "label": "struct MinPQ",
       "members": [
         {
-          "astId": 14388,
+          "astId": 14366,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)15019_storage"
+          "type": "t_struct(PQ)14997_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(PQ)15019_storage": {
+    "t_struct(PQ)14997_storage": {
       "encoding": "inplace",
       "label": "struct PQ",
       "members": [
         {
-          "astId": 15008,
+          "astId": 14986,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "size",
           "offset": 0,
@@ -639,7 +639,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 15013,
+          "astId": 14991,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "addressToPos",
           "offset": 0,
@@ -647,7 +647,7 @@
           "type": "t_mapping(t_address,t_uint16)"
         },
         {
-          "astId": 15018,
+          "astId": 14996,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "posToAddress",
           "offset": 0,
@@ -657,12 +657,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ParentFinality)15245_storage": {
+    "t_struct(ParentFinality)15223_storage": {
       "encoding": "inplace",
       "label": "struct ParentFinality",
       "members": [
         {
-          "astId": 15242,
+          "astId": 15220,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "height",
           "offset": 0,
@@ -670,7 +670,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15244,
+          "astId": 15222,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "blockHash",
           "offset": 0,
@@ -680,25 +680,25 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(ParentValidatorsTracker)15449_storage": {
+    "t_struct(ParentValidatorsTracker)15427_storage": {
       "encoding": "inplace",
       "label": "struct ParentValidatorsTracker",
       "members": [
         {
-          "astId": 15445,
+          "astId": 15423,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "validators",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(ValidatorSet)15442_storage"
+          "type": "t_struct(ValidatorSet)15420_storage"
         },
         {
-          "astId": 15448,
+          "astId": 15426,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "changes",
           "offset": 0,
           "slot": "9",
-          "type": "t_struct(StakingChangeLog)15386_storage"
+          "type": "t_struct(StakingChangeLog)15364_storage"
         }
       ],
       "numberOfBytes": "352"
@@ -726,20 +726,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingChange)15367_storage": {
+    "t_struct(StakingChange)15345_storage": {
       "encoding": "inplace",
       "label": "struct StakingChange",
       "members": [
         {
-          "astId": 15362,
+          "astId": 15340,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "op",
           "offset": 0,
           "slot": "0",
-          "type": "t_enum(StakingOperation)15359"
+          "type": "t_enum(StakingOperation)15337"
         },
         {
-          "astId": 15364,
+          "astId": 15342,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "payload",
           "offset": 0,
@@ -747,7 +747,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 15366,
+          "astId": 15344,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "validator",
           "offset": 0,
@@ -757,12 +757,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(StakingChangeLog)15386_storage": {
+    "t_struct(StakingChangeLog)15364_storage": {
       "encoding": "inplace",
       "label": "struct StakingChangeLog",
       "members": [
         {
-          "astId": 15376,
+          "astId": 15354,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -770,7 +770,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15379,
+          "astId": 15357,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "startConfigurationNumber",
           "offset": 8,
@@ -778,38 +778,38 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15385,
+          "astId": 15363,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "changes",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_uint64,t_struct(StakingChange)15367_storage)"
+          "type": "t_mapping(t_uint64,t_struct(StakingChange)15345_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StorableMsg)15301_storage": {
+    "t_struct(StorableMsg)15279_storage": {
       "encoding": "inplace",
       "label": "struct StorableMsg",
       "members": [
         {
-          "astId": 15287,
+          "astId": 15265,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "from",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(IPCAddress)15456_storage"
+          "type": "t_struct(IPCAddress)15434_storage"
         },
         {
-          "astId": 15290,
+          "astId": 15268,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "to",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(IPCAddress)15456_storage"
+          "type": "t_struct(IPCAddress)15434_storage"
         },
         {
-          "astId": 15292,
+          "astId": 15270,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "value",
           "offset": 0,
@@ -817,7 +817,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15294,
+          "astId": 15272,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "nonce",
           "offset": 0,
@@ -825,7 +825,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15296,
+          "astId": 15274,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "method",
           "offset": 8,
@@ -833,7 +833,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 15298,
+          "astId": 15276,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "params",
           "offset": 0,
@@ -841,7 +841,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 15300,
+          "astId": 15278,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "fee",
           "offset": 0,
@@ -851,12 +851,12 @@
       ],
       "numberOfBytes": "384"
     },
-    "t_struct(Subnet)15355_storage": {
+    "t_struct(Subnet)15333_storage": {
       "encoding": "inplace",
       "label": "struct Subnet",
       "members": [
         {
-          "astId": 15340,
+          "astId": 15318,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "stake",
           "offset": 0,
@@ -864,7 +864,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15342,
+          "astId": 15320,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "genesisEpoch",
           "offset": 0,
@@ -872,7 +872,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15344,
+          "astId": 15322,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "circSupply",
           "offset": 0,
@@ -880,7 +880,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15346,
+          "astId": 15324,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "topDownNonce",
           "offset": 0,
@@ -888,7 +888,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15348,
+          "astId": 15326,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "appliedBottomUpNonce",
           "offset": 8,
@@ -896,7 +896,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15351,
+          "astId": 15329,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "status",
           "offset": 16,
@@ -904,22 +904,22 @@
           "type": "t_enum(Status)5093"
         },
         {
-          "astId": 15354,
+          "astId": 15332,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "id",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(SubnetID)15338_storage"
+          "type": "t_struct(SubnetID)15316_storage"
         }
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(SubnetID)15338_storage": {
+    "t_struct(SubnetID)15316_storage": {
       "encoding": "inplace",
       "label": "struct SubnetID",
       "members": [
         {
-          "astId": 15333,
+          "astId": 15311,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "root",
           "offset": 0,
@@ -927,7 +927,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15337,
+          "astId": 15315,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "route",
           "offset": 0,
@@ -952,12 +952,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(Validator)15463_storage": {
+    "t_struct(Validator)15441_storage": {
       "encoding": "inplace",
       "label": "struct Validator",
       "members": [
         {
-          "astId": 15458,
+          "astId": 15436,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "weight",
           "offset": 0,
@@ -965,7 +965,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15460,
+          "astId": 15438,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "addr",
           "offset": 0,
@@ -973,7 +973,7 @@
           "type": "t_address"
         },
         {
-          "astId": 15462,
+          "astId": 15440,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "metadata",
           "offset": 0,
@@ -983,12 +983,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorInfo)15421_storage": {
+    "t_struct(ValidatorInfo)15399_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorInfo",
       "members": [
         {
-          "astId": 15415,
+          "astId": 15393,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "confirmedCollateral",
           "offset": 0,
@@ -996,7 +996,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15417,
+          "astId": 15395,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "totalCollateral",
           "offset": 0,
@@ -1004,7 +1004,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15420,
+          "astId": 15398,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "metadata",
           "offset": 0,
@@ -1014,12 +1014,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorSet)15442_storage": {
+    "t_struct(ValidatorSet)15420_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorSet",
       "members": [
         {
-          "astId": 15424,
+          "astId": 15402,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "activeLimit",
           "offset": 0,
@@ -1027,7 +1027,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 15427,
+          "astId": 15405,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "totalConfirmedCollateral",
           "offset": 0,
@@ -1035,28 +1035,28 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15433,
+          "astId": 15411,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "validators",
           "offset": 0,
           "slot": "2",
-          "type": "t_mapping(t_address,t_struct(ValidatorInfo)15421_storage)"
+          "type": "t_mapping(t_address,t_struct(ValidatorInfo)15399_storage)"
         },
         {
-          "astId": 15437,
+          "astId": 15415,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "activeValidators",
           "offset": 0,
           "slot": "3",
-          "type": "t_struct(MinPQ)14389_storage"
+          "type": "t_struct(MinPQ)14367_storage"
         },
         {
-          "astId": 15441,
+          "astId": 15419,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "waitingValidators",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(MaxPQ)13770_storage"
+          "type": "t_struct(MaxPQ)13748_storage"
         }
       ],
       "numberOfBytes": "288"

--- a/.storage-layouts/GatewayActorModifiers.json
+++ b/.storage-layouts/GatewayActorModifiers.json
@@ -1,12 +1,12 @@
 {
   "storage": [
     {
-      "astId": 10305,
+      "astId": 10395,
       "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
       "label": "s",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(GatewayActorStorage)10291_storage"
+      "type": "t_struct(GatewayActorStorage)10381_storage"
     }
   ],
   "types": {
@@ -27,14 +27,14 @@
       "label": "bytes32[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(CrossMsg)15262_storage)dyn_storage": {
-      "base": "t_struct(CrossMsg)15262_storage",
+    "t_array(t_struct(CrossMsg)15352_storage)dyn_storage": {
+      "base": "t_struct(CrossMsg)15352_storage",
       "encoding": "dynamic_array",
       "label": "struct CrossMsg[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(Validator)15441_storage)dyn_storage": {
-      "base": "t_struct(Validator)15441_storage",
+    "t_array(t_struct(Validator)15531_storage)dyn_storage": {
+      "base": "t_struct(Validator)15531_storage",
       "encoding": "dynamic_array",
       "label": "struct Validator[]",
       "numberOfBytes": "32"
@@ -59,7 +59,7 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_enum(StakingOperation)15337": {
+    "t_enum(StakingOperation)15427": {
       "encoding": "inplace",
       "label": "enum StakingOperation",
       "numberOfBytes": "1"
@@ -76,12 +76,12 @@
       "numberOfBytes": "32",
       "value": "t_bytes_storage"
     },
-    "t_mapping(t_address,t_struct(ValidatorInfo)15399_storage)": {
+    "t_mapping(t_address,t_struct(ValidatorInfo)15489_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ValidatorInfo)",
       "numberOfBytes": "32",
-      "value": "t_struct(ValidatorInfo)15399_storage"
+      "value": "t_struct(ValidatorInfo)15489_storage"
     },
     "t_mapping(t_address,t_uint16)": {
       "encoding": "mapping",
@@ -90,26 +90,26 @@
       "numberOfBytes": "32",
       "value": "t_uint16"
     },
-    "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)15262_storage)dyn_storage))": {
+    "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)15352_storage)dyn_storage))": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => mapping(uint256 => struct CrossMsg[]))",
       "numberOfBytes": "32",
-      "value": "t_mapping(t_uint256,t_array(t_struct(CrossMsg)15262_storage)dyn_storage)"
+      "value": "t_mapping(t_uint256,t_array(t_struct(CrossMsg)15352_storage)dyn_storage)"
     },
-    "t_mapping(t_bytes32,t_struct(CrossMsg)15262_storage)": {
+    "t_mapping(t_bytes32,t_struct(CrossMsg)15352_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct CrossMsg)",
       "numberOfBytes": "32",
-      "value": "t_struct(CrossMsg)15262_storage"
+      "value": "t_struct(CrossMsg)15352_storage"
     },
-    "t_mapping(t_bytes32,t_struct(Subnet)15333_storage)": {
+    "t_mapping(t_bytes32,t_struct(Subnet)15423_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct Subnet)",
       "numberOfBytes": "32",
-      "value": "t_struct(Subnet)15333_storage"
+      "value": "t_struct(Subnet)15423_storage"
     },
     "t_mapping(t_bytes32,t_uint256)": {
       "encoding": "mapping",
@@ -125,26 +125,26 @@
       "numberOfBytes": "32",
       "value": "t_address"
     },
-    "t_mapping(t_uint256,t_array(t_struct(CrossMsg)15262_storage)dyn_storage)": {
+    "t_mapping(t_uint256,t_array(t_struct(CrossMsg)15352_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct CrossMsg[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(CrossMsg)15262_storage)dyn_storage"
+      "value": "t_array(t_struct(CrossMsg)15352_storage)dyn_storage"
     },
-    "t_mapping(t_uint256,t_struct(ParentFinality)15223_storage)": {
+    "t_mapping(t_uint256,t_struct(ParentFinality)15313_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct ParentFinality)",
       "numberOfBytes": "32",
-      "value": "t_struct(ParentFinality)15223_storage"
+      "value": "t_struct(ParentFinality)15313_storage"
     },
-    "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15262_storage)dyn_storage)": {
+    "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15352_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct CrossMsg[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(CrossMsg)15262_storage)dyn_storage"
+      "value": "t_array(t_struct(CrossMsg)15352_storage)dyn_storage"
     },
     "t_mapping(t_uint64,t_mapping(t_address,t_bytes_storage))": {
       "encoding": "mapping",
@@ -167,26 +167,26 @@
       "numberOfBytes": "32",
       "value": "t_struct(AddressSet)3420_storage"
     },
-    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15240_storage)": {
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15330_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)15240_storage"
+      "value": "t_struct(BottomUpCheckpoint)15330_storage"
     },
-    "t_mapping(t_uint64,t_struct(CheckpointInfo)15256_storage)": {
+    "t_mapping(t_uint64,t_struct(CheckpointInfo)15346_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct CheckpointInfo)",
       "numberOfBytes": "32",
-      "value": "t_struct(CheckpointInfo)15256_storage"
+      "value": "t_struct(CheckpointInfo)15346_storage"
     },
-    "t_mapping(t_uint64,t_struct(StakingChange)15345_storage)": {
+    "t_mapping(t_uint64,t_struct(StakingChange)15435_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct StakingChange)",
       "numberOfBytes": "32",
-      "value": "t_struct(StakingChange)15345_storage"
+      "value": "t_struct(StakingChange)15435_storage"
     },
     "t_struct(AddressSet)3420_storage": {
       "encoding": "inplace",
@@ -203,20 +203,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(BottomUpCheckpoint)15240_storage": {
+    "t_struct(BottomUpCheckpoint)15330_storage": {
       "encoding": "inplace",
       "label": "struct BottomUpCheckpoint",
       "members": [
         {
-          "astId": 15227,
+          "astId": 15317,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "subnetID",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)15316_storage"
+          "type": "t_struct(SubnetID)15406_storage"
         },
         {
-          "astId": 15230,
+          "astId": 15320,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "blockHeight",
           "offset": 0,
@@ -224,7 +224,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15233,
+          "astId": 15323,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "blockHash",
           "offset": 0,
@@ -232,7 +232,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 15236,
+          "astId": 15326,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -240,7 +240,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15239,
+          "astId": 15329,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "crossMessagesHash",
           "offset": 0,
@@ -250,12 +250,12 @@
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(CheckpointInfo)15256_storage": {
+    "t_struct(CheckpointInfo)15346_storage": {
       "encoding": "inplace",
       "label": "struct CheckpointInfo",
       "members": [
         {
-          "astId": 15243,
+          "astId": 15333,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "hash",
           "offset": 0,
@@ -263,7 +263,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 15246,
+          "astId": 15336,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "rootHash",
           "offset": 0,
@@ -271,7 +271,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 15249,
+          "astId": 15339,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "threshold",
           "offset": 0,
@@ -279,7 +279,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15252,
+          "astId": 15342,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "currentWeight",
           "offset": 0,
@@ -287,7 +287,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15255,
+          "astId": 15345,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "reached",
           "offset": 0,
@@ -297,20 +297,20 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(CrossMsg)15262_storage": {
+    "t_struct(CrossMsg)15352_storage": {
       "encoding": "inplace",
       "label": "struct CrossMsg",
       "members": [
         {
-          "astId": 15259,
+          "astId": 15349,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "message",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(StorableMsg)15279_storage"
+          "type": "t_struct(StorableMsg)15369_storage"
         },
         {
-          "astId": 15261,
+          "astId": 15351,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "wrapped",
           "offset": 0,
@@ -320,12 +320,12 @@
       ],
       "numberOfBytes": "416"
     },
-    "t_struct(FvmAddress)15286_storage": {
+    "t_struct(FvmAddress)15376_storage": {
       "encoding": "inplace",
       "label": "struct FvmAddress",
       "members": [
         {
-          "astId": 15283,
+          "astId": 15373,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "addrType",
           "offset": 0,
@@ -333,7 +333,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 15285,
+          "astId": 15375,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "payload",
           "offset": 0,
@@ -343,36 +343,36 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(GatewayActorStorage)10291_storage": {
+    "t_struct(GatewayActorStorage)10381_storage": {
       "encoding": "inplace",
       "label": "struct GatewayActorStorage",
       "members": [
         {
-          "astId": 10180,
+          "astId": 10270,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "subnets",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_bytes32,t_struct(Subnet)15333_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(Subnet)15423_storage)"
         },
         {
-          "astId": 10189,
+          "astId": 10279,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "topDownMsgs",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)15262_storage)dyn_storage))"
+          "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)15352_storage)dyn_storage))"
         },
         {
-          "astId": 10195,
+          "astId": 10285,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "finalitiesMap",
           "offset": 0,
           "slot": "2",
-          "type": "t_mapping(t_uint256,t_struct(ParentFinality)15223_storage)"
+          "type": "t_mapping(t_uint256,t_struct(ParentFinality)15313_storage)"
         },
         {
-          "astId": 10198,
+          "astId": 10288,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "latestParentHeight",
           "offset": 0,
@@ -380,15 +380,15 @@
           "type": "t_uint256"
         },
         {
-          "astId": 10204,
+          "astId": 10294,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "postbox",
           "offset": 0,
           "slot": "4",
-          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)15262_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)15352_storage)"
         },
         {
-          "astId": 10211,
+          "astId": 10301,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "validatorSetWeights",
           "offset": 0,
@@ -396,47 +396,47 @@
           "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_uint256))"
         },
         {
-          "astId": 10215,
+          "astId": 10305,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "currentMembership",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(Membership)15448_storage"
+          "type": "t_struct(Membership)15538_storage"
         },
         {
-          "astId": 10219,
+          "astId": 10309,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "lastMembership",
           "offset": 0,
           "slot": "8",
-          "type": "t_struct(Membership)15448_storage"
+          "type": "t_struct(Membership)15538_storage"
         },
         {
-          "astId": 10225,
+          "astId": 10315,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpCheckpoints",
           "offset": 0,
           "slot": "10",
-          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15240_storage)"
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15330_storage)"
         },
         {
-          "astId": 10231,
+          "astId": 10321,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpCheckpointInfo",
           "offset": 0,
           "slot": "11",
-          "type": "t_mapping(t_uint64,t_struct(CheckpointInfo)15256_storage)"
+          "type": "t_mapping(t_uint64,t_struct(CheckpointInfo)15346_storage)"
         },
         {
-          "astId": 10238,
+          "astId": 10328,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpMessages",
           "offset": 0,
           "slot": "12",
-          "type": "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15262_storage)dyn_storage)"
+          "type": "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15352_storage)dyn_storage)"
         },
         {
-          "astId": 10241,
+          "astId": 10331,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpCheckpointRetentionHeight",
           "offset": 0,
@@ -444,7 +444,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 10245,
+          "astId": 10335,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "incompleteCheckpoints",
           "offset": 0,
@@ -452,7 +452,7 @@
           "type": "t_struct(UintSet)3577_storage"
         },
         {
-          "astId": 10251,
+          "astId": 10341,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpSignatureSenders",
           "offset": 0,
@@ -460,7 +460,7 @@
           "type": "t_mapping(t_uint64,t_struct(AddressSet)3420_storage)"
         },
         {
-          "astId": 10258,
+          "astId": 10348,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpSignatures",
           "offset": 0,
@@ -468,7 +468,7 @@
           "type": "t_mapping(t_uint64,t_mapping(t_address,t_bytes_storage))"
         },
         {
-          "astId": 10262,
+          "astId": 10352,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "subnetKeys",
           "offset": 0,
@@ -476,15 +476,15 @@
           "type": "t_array(t_bytes32)dyn_storage"
         },
         {
-          "astId": 10266,
+          "astId": 10356,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "networkName",
           "offset": 0,
           "slot": "19",
-          "type": "t_struct(SubnetID)15316_storage"
+          "type": "t_struct(SubnetID)15406_storage"
         },
         {
-          "astId": 10269,
+          "astId": 10359,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "minStake",
           "offset": 0,
@@ -492,7 +492,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 10272,
+          "astId": 10362,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "minCrossMsgFee",
           "offset": 0,
@@ -500,7 +500,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 10275,
+          "astId": 10365,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "majorityPercentage",
           "offset": 0,
@@ -508,7 +508,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 10278,
+          "astId": 10368,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpNonce",
           "offset": 1,
@@ -516,7 +516,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 10281,
+          "astId": 10371,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "appliedTopDownNonce",
           "offset": 9,
@@ -524,7 +524,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 10284,
+          "astId": 10374,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "totalSubnets",
           "offset": 17,
@@ -532,7 +532,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 10286,
+          "astId": 10376,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "bottomUpCheckPeriod",
           "offset": 0,
@@ -540,68 +540,68 @@
           "type": "t_uint64"
         },
         {
-          "astId": 10290,
+          "astId": 10380,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "validatorsTracker",
           "offset": 0,
           "slot": "25",
-          "type": "t_struct(ParentValidatorsTracker)15427_storage"
+          "type": "t_struct(ParentValidatorsTracker)15517_storage"
         }
       ],
       "numberOfBytes": "1152"
     },
-    "t_struct(IPCAddress)15434_storage": {
+    "t_struct(IPCAddress)15524_storage": {
       "encoding": "inplace",
       "label": "struct IPCAddress",
       "members": [
         {
-          "astId": 15430,
+          "astId": 15520,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "subnetId",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)15316_storage"
+          "type": "t_struct(SubnetID)15406_storage"
         },
         {
-          "astId": 15433,
+          "astId": 15523,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "rawAddress",
           "offset": 0,
           "slot": "2",
-          "type": "t_struct(FvmAddress)15286_storage"
+          "type": "t_struct(FvmAddress)15376_storage"
         }
       ],
       "numberOfBytes": "128"
     },
-    "t_struct(MaxPQ)13748_storage": {
+    "t_struct(MaxPQ)13838_storage": {
       "encoding": "inplace",
       "label": "struct MaxPQ",
       "members": [
         {
-          "astId": 13747,
+          "astId": 13837,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)14997_storage"
+          "type": "t_struct(PQ)15087_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(Membership)15448_storage": {
+    "t_struct(Membership)15538_storage": {
       "encoding": "inplace",
       "label": "struct Membership",
       "members": [
         {
-          "astId": 15445,
+          "astId": 15535,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "validators",
           "offset": 0,
           "slot": "0",
-          "type": "t_array(t_struct(Validator)15441_storage)dyn_storage"
+          "type": "t_array(t_struct(Validator)15531_storage)dyn_storage"
         },
         {
-          "astId": 15447,
+          "astId": 15537,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "configurationNumber",
           "offset": 0,
@@ -611,27 +611,27 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(MinPQ)14367_storage": {
+    "t_struct(MinPQ)14457_storage": {
       "encoding": "inplace",
       "label": "struct MinPQ",
       "members": [
         {
-          "astId": 14366,
+          "astId": 14456,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)14997_storage"
+          "type": "t_struct(PQ)15087_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(PQ)14997_storage": {
+    "t_struct(PQ)15087_storage": {
       "encoding": "inplace",
       "label": "struct PQ",
       "members": [
         {
-          "astId": 14986,
+          "astId": 15076,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "size",
           "offset": 0,
@@ -639,7 +639,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 14991,
+          "astId": 15081,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "addressToPos",
           "offset": 0,
@@ -647,7 +647,7 @@
           "type": "t_mapping(t_address,t_uint16)"
         },
         {
-          "astId": 14996,
+          "astId": 15086,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "posToAddress",
           "offset": 0,
@@ -657,12 +657,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ParentFinality)15223_storage": {
+    "t_struct(ParentFinality)15313_storage": {
       "encoding": "inplace",
       "label": "struct ParentFinality",
       "members": [
         {
-          "astId": 15220,
+          "astId": 15310,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "height",
           "offset": 0,
@@ -670,7 +670,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15222,
+          "astId": 15312,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "blockHash",
           "offset": 0,
@@ -680,25 +680,25 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(ParentValidatorsTracker)15427_storage": {
+    "t_struct(ParentValidatorsTracker)15517_storage": {
       "encoding": "inplace",
       "label": "struct ParentValidatorsTracker",
       "members": [
         {
-          "astId": 15423,
+          "astId": 15513,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "validators",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(ValidatorSet)15420_storage"
+          "type": "t_struct(ValidatorSet)15510_storage"
         },
         {
-          "astId": 15426,
+          "astId": 15516,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "changes",
           "offset": 0,
           "slot": "9",
-          "type": "t_struct(StakingChangeLog)15364_storage"
+          "type": "t_struct(StakingChangeLog)15454_storage"
         }
       ],
       "numberOfBytes": "352"
@@ -726,20 +726,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingChange)15345_storage": {
+    "t_struct(StakingChange)15435_storage": {
       "encoding": "inplace",
       "label": "struct StakingChange",
       "members": [
         {
-          "astId": 15340,
+          "astId": 15430,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "op",
           "offset": 0,
           "slot": "0",
-          "type": "t_enum(StakingOperation)15337"
+          "type": "t_enum(StakingOperation)15427"
         },
         {
-          "astId": 15342,
+          "astId": 15432,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "payload",
           "offset": 0,
@@ -747,7 +747,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 15344,
+          "astId": 15434,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "validator",
           "offset": 0,
@@ -757,12 +757,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(StakingChangeLog)15364_storage": {
+    "t_struct(StakingChangeLog)15454_storage": {
       "encoding": "inplace",
       "label": "struct StakingChangeLog",
       "members": [
         {
-          "astId": 15354,
+          "astId": 15444,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -770,7 +770,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15357,
+          "astId": 15447,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "startConfigurationNumber",
           "offset": 8,
@@ -778,38 +778,38 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15363,
+          "astId": 15453,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "changes",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_uint64,t_struct(StakingChange)15345_storage)"
+          "type": "t_mapping(t_uint64,t_struct(StakingChange)15435_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StorableMsg)15279_storage": {
+    "t_struct(StorableMsg)15369_storage": {
       "encoding": "inplace",
       "label": "struct StorableMsg",
       "members": [
         {
-          "astId": 15265,
+          "astId": 15355,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "from",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(IPCAddress)15434_storage"
+          "type": "t_struct(IPCAddress)15524_storage"
         },
         {
-          "astId": 15268,
+          "astId": 15358,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "to",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(IPCAddress)15434_storage"
+          "type": "t_struct(IPCAddress)15524_storage"
         },
         {
-          "astId": 15270,
+          "astId": 15360,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "value",
           "offset": 0,
@@ -817,7 +817,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15272,
+          "astId": 15362,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "nonce",
           "offset": 0,
@@ -825,7 +825,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15274,
+          "astId": 15364,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "method",
           "offset": 8,
@@ -833,7 +833,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 15276,
+          "astId": 15366,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "params",
           "offset": 0,
@@ -841,7 +841,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 15278,
+          "astId": 15368,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "fee",
           "offset": 0,
@@ -851,12 +851,12 @@
       ],
       "numberOfBytes": "384"
     },
-    "t_struct(Subnet)15333_storage": {
+    "t_struct(Subnet)15423_storage": {
       "encoding": "inplace",
       "label": "struct Subnet",
       "members": [
         {
-          "astId": 15318,
+          "astId": 15408,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "stake",
           "offset": 0,
@@ -864,7 +864,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15320,
+          "astId": 15410,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "genesisEpoch",
           "offset": 0,
@@ -872,7 +872,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15322,
+          "astId": 15412,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "circSupply",
           "offset": 0,
@@ -880,7 +880,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15324,
+          "astId": 15414,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "topDownNonce",
           "offset": 0,
@@ -888,7 +888,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15326,
+          "astId": 15416,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "appliedBottomUpNonce",
           "offset": 8,
@@ -896,7 +896,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15329,
+          "astId": 15419,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "status",
           "offset": 16,
@@ -904,22 +904,22 @@
           "type": "t_enum(Status)5093"
         },
         {
-          "astId": 15332,
+          "astId": 15422,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "id",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(SubnetID)15316_storage"
+          "type": "t_struct(SubnetID)15406_storage"
         }
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(SubnetID)15316_storage": {
+    "t_struct(SubnetID)15406_storage": {
       "encoding": "inplace",
       "label": "struct SubnetID",
       "members": [
         {
-          "astId": 15311,
+          "astId": 15401,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "root",
           "offset": 0,
@@ -927,7 +927,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15315,
+          "astId": 15405,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "route",
           "offset": 0,
@@ -952,12 +952,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(Validator)15441_storage": {
+    "t_struct(Validator)15531_storage": {
       "encoding": "inplace",
       "label": "struct Validator",
       "members": [
         {
-          "astId": 15436,
+          "astId": 15526,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "weight",
           "offset": 0,
@@ -965,7 +965,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15438,
+          "astId": 15528,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "addr",
           "offset": 0,
@@ -973,7 +973,7 @@
           "type": "t_address"
         },
         {
-          "astId": 15440,
+          "astId": 15530,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "metadata",
           "offset": 0,
@@ -983,12 +983,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorInfo)15399_storage": {
+    "t_struct(ValidatorInfo)15489_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorInfo",
       "members": [
         {
-          "astId": 15393,
+          "astId": 15483,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "confirmedCollateral",
           "offset": 0,
@@ -996,7 +996,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15395,
+          "astId": 15485,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "totalCollateral",
           "offset": 0,
@@ -1004,7 +1004,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15398,
+          "astId": 15488,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "metadata",
           "offset": 0,
@@ -1014,12 +1014,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorSet)15420_storage": {
+    "t_struct(ValidatorSet)15510_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorSet",
       "members": [
         {
-          "astId": 15402,
+          "astId": 15492,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "activeLimit",
           "offset": 0,
@@ -1027,7 +1027,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 15405,
+          "astId": 15495,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "totalConfirmedCollateral",
           "offset": 0,
@@ -1035,28 +1035,28 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15411,
+          "astId": 15501,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "validators",
           "offset": 0,
           "slot": "2",
-          "type": "t_mapping(t_address,t_struct(ValidatorInfo)15399_storage)"
+          "type": "t_mapping(t_address,t_struct(ValidatorInfo)15489_storage)"
         },
         {
-          "astId": 15415,
+          "astId": 15505,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "activeValidators",
           "offset": 0,
           "slot": "3",
-          "type": "t_struct(MinPQ)14367_storage"
+          "type": "t_struct(MinPQ)14457_storage"
         },
         {
-          "astId": 15419,
+          "astId": 15509,
           "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
           "label": "waitingValidators",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(MaxPQ)13748_storage"
+          "type": "t_struct(MaxPQ)13838_storage"
         }
       ],
       "numberOfBytes": "288"

--- a/.storage-layouts/GatewayDiamond.json
+++ b/.storage-layouts/GatewayDiamond.json
@@ -6,7 +6,7 @@
       "label": "s",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(GatewayActorStorage)10291_storage"
+      "type": "t_struct(GatewayActorStorage)10381_storage"
     }
   ],
   "types": {
@@ -27,14 +27,14 @@
       "label": "bytes32[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(CrossMsg)15262_storage)dyn_storage": {
-      "base": "t_struct(CrossMsg)15262_storage",
+    "t_array(t_struct(CrossMsg)15352_storage)dyn_storage": {
+      "base": "t_struct(CrossMsg)15352_storage",
       "encoding": "dynamic_array",
       "label": "struct CrossMsg[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(Validator)15441_storage)dyn_storage": {
-      "base": "t_struct(Validator)15441_storage",
+    "t_array(t_struct(Validator)15531_storage)dyn_storage": {
+      "base": "t_struct(Validator)15531_storage",
       "encoding": "dynamic_array",
       "label": "struct Validator[]",
       "numberOfBytes": "32"
@@ -59,7 +59,7 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_enum(StakingOperation)15337": {
+    "t_enum(StakingOperation)15427": {
       "encoding": "inplace",
       "label": "enum StakingOperation",
       "numberOfBytes": "1"
@@ -76,12 +76,12 @@
       "numberOfBytes": "32",
       "value": "t_bytes_storage"
     },
-    "t_mapping(t_address,t_struct(ValidatorInfo)15399_storage)": {
+    "t_mapping(t_address,t_struct(ValidatorInfo)15489_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ValidatorInfo)",
       "numberOfBytes": "32",
-      "value": "t_struct(ValidatorInfo)15399_storage"
+      "value": "t_struct(ValidatorInfo)15489_storage"
     },
     "t_mapping(t_address,t_uint16)": {
       "encoding": "mapping",
@@ -90,26 +90,26 @@
       "numberOfBytes": "32",
       "value": "t_uint16"
     },
-    "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)15262_storage)dyn_storage))": {
+    "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)15352_storage)dyn_storage))": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => mapping(uint256 => struct CrossMsg[]))",
       "numberOfBytes": "32",
-      "value": "t_mapping(t_uint256,t_array(t_struct(CrossMsg)15262_storage)dyn_storage)"
+      "value": "t_mapping(t_uint256,t_array(t_struct(CrossMsg)15352_storage)dyn_storage)"
     },
-    "t_mapping(t_bytes32,t_struct(CrossMsg)15262_storage)": {
+    "t_mapping(t_bytes32,t_struct(CrossMsg)15352_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct CrossMsg)",
       "numberOfBytes": "32",
-      "value": "t_struct(CrossMsg)15262_storage"
+      "value": "t_struct(CrossMsg)15352_storage"
     },
-    "t_mapping(t_bytes32,t_struct(Subnet)15333_storage)": {
+    "t_mapping(t_bytes32,t_struct(Subnet)15423_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct Subnet)",
       "numberOfBytes": "32",
-      "value": "t_struct(Subnet)15333_storage"
+      "value": "t_struct(Subnet)15423_storage"
     },
     "t_mapping(t_bytes32,t_uint256)": {
       "encoding": "mapping",
@@ -125,26 +125,26 @@
       "numberOfBytes": "32",
       "value": "t_address"
     },
-    "t_mapping(t_uint256,t_array(t_struct(CrossMsg)15262_storage)dyn_storage)": {
+    "t_mapping(t_uint256,t_array(t_struct(CrossMsg)15352_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct CrossMsg[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(CrossMsg)15262_storage)dyn_storage"
+      "value": "t_array(t_struct(CrossMsg)15352_storage)dyn_storage"
     },
-    "t_mapping(t_uint256,t_struct(ParentFinality)15223_storage)": {
+    "t_mapping(t_uint256,t_struct(ParentFinality)15313_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct ParentFinality)",
       "numberOfBytes": "32",
-      "value": "t_struct(ParentFinality)15223_storage"
+      "value": "t_struct(ParentFinality)15313_storage"
     },
-    "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15262_storage)dyn_storage)": {
+    "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15352_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct CrossMsg[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(CrossMsg)15262_storage)dyn_storage"
+      "value": "t_array(t_struct(CrossMsg)15352_storage)dyn_storage"
     },
     "t_mapping(t_uint64,t_mapping(t_address,t_bytes_storage))": {
       "encoding": "mapping",
@@ -167,26 +167,26 @@
       "numberOfBytes": "32",
       "value": "t_struct(AddressSet)3420_storage"
     },
-    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15240_storage)": {
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15330_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)15240_storage"
+      "value": "t_struct(BottomUpCheckpoint)15330_storage"
     },
-    "t_mapping(t_uint64,t_struct(CheckpointInfo)15256_storage)": {
+    "t_mapping(t_uint64,t_struct(CheckpointInfo)15346_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct CheckpointInfo)",
       "numberOfBytes": "32",
-      "value": "t_struct(CheckpointInfo)15256_storage"
+      "value": "t_struct(CheckpointInfo)15346_storage"
     },
-    "t_mapping(t_uint64,t_struct(StakingChange)15345_storage)": {
+    "t_mapping(t_uint64,t_struct(StakingChange)15435_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct StakingChange)",
       "numberOfBytes": "32",
-      "value": "t_struct(StakingChange)15345_storage"
+      "value": "t_struct(StakingChange)15435_storage"
     },
     "t_struct(AddressSet)3420_storage": {
       "encoding": "inplace",
@@ -203,20 +203,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(BottomUpCheckpoint)15240_storage": {
+    "t_struct(BottomUpCheckpoint)15330_storage": {
       "encoding": "inplace",
       "label": "struct BottomUpCheckpoint",
       "members": [
         {
-          "astId": 15227,
+          "astId": 15317,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "subnetID",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)15316_storage"
+          "type": "t_struct(SubnetID)15406_storage"
         },
         {
-          "astId": 15230,
+          "astId": 15320,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "blockHeight",
           "offset": 0,
@@ -224,7 +224,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15233,
+          "astId": 15323,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "blockHash",
           "offset": 0,
@@ -232,7 +232,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 15236,
+          "astId": 15326,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -240,7 +240,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15239,
+          "astId": 15329,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "crossMessagesHash",
           "offset": 0,
@@ -250,12 +250,12 @@
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(CheckpointInfo)15256_storage": {
+    "t_struct(CheckpointInfo)15346_storage": {
       "encoding": "inplace",
       "label": "struct CheckpointInfo",
       "members": [
         {
-          "astId": 15243,
+          "astId": 15333,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "hash",
           "offset": 0,
@@ -263,7 +263,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 15246,
+          "astId": 15336,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "rootHash",
           "offset": 0,
@@ -271,7 +271,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 15249,
+          "astId": 15339,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "threshold",
           "offset": 0,
@@ -279,7 +279,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15252,
+          "astId": 15342,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "currentWeight",
           "offset": 0,
@@ -287,7 +287,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15255,
+          "astId": 15345,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "reached",
           "offset": 0,
@@ -297,20 +297,20 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(CrossMsg)15262_storage": {
+    "t_struct(CrossMsg)15352_storage": {
       "encoding": "inplace",
       "label": "struct CrossMsg",
       "members": [
         {
-          "astId": 15259,
+          "astId": 15349,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "message",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(StorableMsg)15279_storage"
+          "type": "t_struct(StorableMsg)15369_storage"
         },
         {
-          "astId": 15261,
+          "astId": 15351,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "wrapped",
           "offset": 0,
@@ -320,12 +320,12 @@
       ],
       "numberOfBytes": "416"
     },
-    "t_struct(FvmAddress)15286_storage": {
+    "t_struct(FvmAddress)15376_storage": {
       "encoding": "inplace",
       "label": "struct FvmAddress",
       "members": [
         {
-          "astId": 15283,
+          "astId": 15373,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "addrType",
           "offset": 0,
@@ -333,7 +333,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 15285,
+          "astId": 15375,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "payload",
           "offset": 0,
@@ -343,36 +343,36 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(GatewayActorStorage)10291_storage": {
+    "t_struct(GatewayActorStorage)10381_storage": {
       "encoding": "inplace",
       "label": "struct GatewayActorStorage",
       "members": [
         {
-          "astId": 10180,
+          "astId": 10270,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "subnets",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_bytes32,t_struct(Subnet)15333_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(Subnet)15423_storage)"
         },
         {
-          "astId": 10189,
+          "astId": 10279,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "topDownMsgs",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)15262_storage)dyn_storage))"
+          "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)15352_storage)dyn_storage))"
         },
         {
-          "astId": 10195,
+          "astId": 10285,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "finalitiesMap",
           "offset": 0,
           "slot": "2",
-          "type": "t_mapping(t_uint256,t_struct(ParentFinality)15223_storage)"
+          "type": "t_mapping(t_uint256,t_struct(ParentFinality)15313_storage)"
         },
         {
-          "astId": 10198,
+          "astId": 10288,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "latestParentHeight",
           "offset": 0,
@@ -380,15 +380,15 @@
           "type": "t_uint256"
         },
         {
-          "astId": 10204,
+          "astId": 10294,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "postbox",
           "offset": 0,
           "slot": "4",
-          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)15262_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)15352_storage)"
         },
         {
-          "astId": 10211,
+          "astId": 10301,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "validatorSetWeights",
           "offset": 0,
@@ -396,47 +396,47 @@
           "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_uint256))"
         },
         {
-          "astId": 10215,
+          "astId": 10305,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "currentMembership",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(Membership)15448_storage"
+          "type": "t_struct(Membership)15538_storage"
         },
         {
-          "astId": 10219,
+          "astId": 10309,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "lastMembership",
           "offset": 0,
           "slot": "8",
-          "type": "t_struct(Membership)15448_storage"
+          "type": "t_struct(Membership)15538_storage"
         },
         {
-          "astId": 10225,
+          "astId": 10315,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpCheckpoints",
           "offset": 0,
           "slot": "10",
-          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15240_storage)"
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15330_storage)"
         },
         {
-          "astId": 10231,
+          "astId": 10321,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpCheckpointInfo",
           "offset": 0,
           "slot": "11",
-          "type": "t_mapping(t_uint64,t_struct(CheckpointInfo)15256_storage)"
+          "type": "t_mapping(t_uint64,t_struct(CheckpointInfo)15346_storage)"
         },
         {
-          "astId": 10238,
+          "astId": 10328,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpMessages",
           "offset": 0,
           "slot": "12",
-          "type": "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15262_storage)dyn_storage)"
+          "type": "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15352_storage)dyn_storage)"
         },
         {
-          "astId": 10241,
+          "astId": 10331,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpCheckpointRetentionHeight",
           "offset": 0,
@@ -444,7 +444,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 10245,
+          "astId": 10335,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "incompleteCheckpoints",
           "offset": 0,
@@ -452,7 +452,7 @@
           "type": "t_struct(UintSet)3577_storage"
         },
         {
-          "astId": 10251,
+          "astId": 10341,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpSignatureSenders",
           "offset": 0,
@@ -460,7 +460,7 @@
           "type": "t_mapping(t_uint64,t_struct(AddressSet)3420_storage)"
         },
         {
-          "astId": 10258,
+          "astId": 10348,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpSignatures",
           "offset": 0,
@@ -468,7 +468,7 @@
           "type": "t_mapping(t_uint64,t_mapping(t_address,t_bytes_storage))"
         },
         {
-          "astId": 10262,
+          "astId": 10352,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "subnetKeys",
           "offset": 0,
@@ -476,15 +476,15 @@
           "type": "t_array(t_bytes32)dyn_storage"
         },
         {
-          "astId": 10266,
+          "astId": 10356,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "networkName",
           "offset": 0,
           "slot": "19",
-          "type": "t_struct(SubnetID)15316_storage"
+          "type": "t_struct(SubnetID)15406_storage"
         },
         {
-          "astId": 10269,
+          "astId": 10359,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "minStake",
           "offset": 0,
@@ -492,7 +492,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 10272,
+          "astId": 10362,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "minCrossMsgFee",
           "offset": 0,
@@ -500,7 +500,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 10275,
+          "astId": 10365,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "majorityPercentage",
           "offset": 0,
@@ -508,7 +508,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 10278,
+          "astId": 10368,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpNonce",
           "offset": 1,
@@ -516,7 +516,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 10281,
+          "astId": 10371,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "appliedTopDownNonce",
           "offset": 9,
@@ -524,7 +524,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 10284,
+          "astId": 10374,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "totalSubnets",
           "offset": 17,
@@ -532,7 +532,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 10286,
+          "astId": 10376,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpCheckPeriod",
           "offset": 0,
@@ -540,68 +540,68 @@
           "type": "t_uint64"
         },
         {
-          "astId": 10290,
+          "astId": 10380,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "validatorsTracker",
           "offset": 0,
           "slot": "25",
-          "type": "t_struct(ParentValidatorsTracker)15427_storage"
+          "type": "t_struct(ParentValidatorsTracker)15517_storage"
         }
       ],
       "numberOfBytes": "1152"
     },
-    "t_struct(IPCAddress)15434_storage": {
+    "t_struct(IPCAddress)15524_storage": {
       "encoding": "inplace",
       "label": "struct IPCAddress",
       "members": [
         {
-          "astId": 15430,
+          "astId": 15520,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "subnetId",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)15316_storage"
+          "type": "t_struct(SubnetID)15406_storage"
         },
         {
-          "astId": 15433,
+          "astId": 15523,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "rawAddress",
           "offset": 0,
           "slot": "2",
-          "type": "t_struct(FvmAddress)15286_storage"
+          "type": "t_struct(FvmAddress)15376_storage"
         }
       ],
       "numberOfBytes": "128"
     },
-    "t_struct(MaxPQ)13748_storage": {
+    "t_struct(MaxPQ)13838_storage": {
       "encoding": "inplace",
       "label": "struct MaxPQ",
       "members": [
         {
-          "astId": 13747,
+          "astId": 13837,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)14997_storage"
+          "type": "t_struct(PQ)15087_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(Membership)15448_storage": {
+    "t_struct(Membership)15538_storage": {
       "encoding": "inplace",
       "label": "struct Membership",
       "members": [
         {
-          "astId": 15445,
+          "astId": 15535,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "validators",
           "offset": 0,
           "slot": "0",
-          "type": "t_array(t_struct(Validator)15441_storage)dyn_storage"
+          "type": "t_array(t_struct(Validator)15531_storage)dyn_storage"
         },
         {
-          "astId": 15447,
+          "astId": 15537,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "configurationNumber",
           "offset": 0,
@@ -611,27 +611,27 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(MinPQ)14367_storage": {
+    "t_struct(MinPQ)14457_storage": {
       "encoding": "inplace",
       "label": "struct MinPQ",
       "members": [
         {
-          "astId": 14366,
+          "astId": 14456,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)14997_storage"
+          "type": "t_struct(PQ)15087_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(PQ)14997_storage": {
+    "t_struct(PQ)15087_storage": {
       "encoding": "inplace",
       "label": "struct PQ",
       "members": [
         {
-          "astId": 14986,
+          "astId": 15076,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "size",
           "offset": 0,
@@ -639,7 +639,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 14991,
+          "astId": 15081,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "addressToPos",
           "offset": 0,
@@ -647,7 +647,7 @@
           "type": "t_mapping(t_address,t_uint16)"
         },
         {
-          "astId": 14996,
+          "astId": 15086,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "posToAddress",
           "offset": 0,
@@ -657,12 +657,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ParentFinality)15223_storage": {
+    "t_struct(ParentFinality)15313_storage": {
       "encoding": "inplace",
       "label": "struct ParentFinality",
       "members": [
         {
-          "astId": 15220,
+          "astId": 15310,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "height",
           "offset": 0,
@@ -670,7 +670,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15222,
+          "astId": 15312,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "blockHash",
           "offset": 0,
@@ -680,25 +680,25 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(ParentValidatorsTracker)15427_storage": {
+    "t_struct(ParentValidatorsTracker)15517_storage": {
       "encoding": "inplace",
       "label": "struct ParentValidatorsTracker",
       "members": [
         {
-          "astId": 15423,
+          "astId": 15513,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "validators",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(ValidatorSet)15420_storage"
+          "type": "t_struct(ValidatorSet)15510_storage"
         },
         {
-          "astId": 15426,
+          "astId": 15516,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "changes",
           "offset": 0,
           "slot": "9",
-          "type": "t_struct(StakingChangeLog)15364_storage"
+          "type": "t_struct(StakingChangeLog)15454_storage"
         }
       ],
       "numberOfBytes": "352"
@@ -726,20 +726,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingChange)15345_storage": {
+    "t_struct(StakingChange)15435_storage": {
       "encoding": "inplace",
       "label": "struct StakingChange",
       "members": [
         {
-          "astId": 15340,
+          "astId": 15430,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "op",
           "offset": 0,
           "slot": "0",
-          "type": "t_enum(StakingOperation)15337"
+          "type": "t_enum(StakingOperation)15427"
         },
         {
-          "astId": 15342,
+          "astId": 15432,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "payload",
           "offset": 0,
@@ -747,7 +747,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 15344,
+          "astId": 15434,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "validator",
           "offset": 0,
@@ -757,12 +757,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(StakingChangeLog)15364_storage": {
+    "t_struct(StakingChangeLog)15454_storage": {
       "encoding": "inplace",
       "label": "struct StakingChangeLog",
       "members": [
         {
-          "astId": 15354,
+          "astId": 15444,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -770,7 +770,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15357,
+          "astId": 15447,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "startConfigurationNumber",
           "offset": 8,
@@ -778,38 +778,38 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15363,
+          "astId": 15453,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "changes",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_uint64,t_struct(StakingChange)15345_storage)"
+          "type": "t_mapping(t_uint64,t_struct(StakingChange)15435_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StorableMsg)15279_storage": {
+    "t_struct(StorableMsg)15369_storage": {
       "encoding": "inplace",
       "label": "struct StorableMsg",
       "members": [
         {
-          "astId": 15265,
+          "astId": 15355,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "from",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(IPCAddress)15434_storage"
+          "type": "t_struct(IPCAddress)15524_storage"
         },
         {
-          "astId": 15268,
+          "astId": 15358,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "to",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(IPCAddress)15434_storage"
+          "type": "t_struct(IPCAddress)15524_storage"
         },
         {
-          "astId": 15270,
+          "astId": 15360,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "value",
           "offset": 0,
@@ -817,7 +817,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15272,
+          "astId": 15362,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "nonce",
           "offset": 0,
@@ -825,7 +825,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15274,
+          "astId": 15364,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "method",
           "offset": 8,
@@ -833,7 +833,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 15276,
+          "astId": 15366,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "params",
           "offset": 0,
@@ -841,7 +841,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 15278,
+          "astId": 15368,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "fee",
           "offset": 0,
@@ -851,12 +851,12 @@
       ],
       "numberOfBytes": "384"
     },
-    "t_struct(Subnet)15333_storage": {
+    "t_struct(Subnet)15423_storage": {
       "encoding": "inplace",
       "label": "struct Subnet",
       "members": [
         {
-          "astId": 15318,
+          "astId": 15408,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "stake",
           "offset": 0,
@@ -864,7 +864,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15320,
+          "astId": 15410,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "genesisEpoch",
           "offset": 0,
@@ -872,7 +872,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15322,
+          "astId": 15412,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "circSupply",
           "offset": 0,
@@ -880,7 +880,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15324,
+          "astId": 15414,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "topDownNonce",
           "offset": 0,
@@ -888,7 +888,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15326,
+          "astId": 15416,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "appliedBottomUpNonce",
           "offset": 8,
@@ -896,7 +896,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15329,
+          "astId": 15419,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "status",
           "offset": 16,
@@ -904,22 +904,22 @@
           "type": "t_enum(Status)5093"
         },
         {
-          "astId": 15332,
+          "astId": 15422,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "id",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(SubnetID)15316_storage"
+          "type": "t_struct(SubnetID)15406_storage"
         }
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(SubnetID)15316_storage": {
+    "t_struct(SubnetID)15406_storage": {
       "encoding": "inplace",
       "label": "struct SubnetID",
       "members": [
         {
-          "astId": 15311,
+          "astId": 15401,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "root",
           "offset": 0,
@@ -927,7 +927,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15315,
+          "astId": 15405,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "route",
           "offset": 0,
@@ -952,12 +952,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(Validator)15441_storage": {
+    "t_struct(Validator)15531_storage": {
       "encoding": "inplace",
       "label": "struct Validator",
       "members": [
         {
-          "astId": 15436,
+          "astId": 15526,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "weight",
           "offset": 0,
@@ -965,7 +965,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15438,
+          "astId": 15528,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "addr",
           "offset": 0,
@@ -973,7 +973,7 @@
           "type": "t_address"
         },
         {
-          "astId": 15440,
+          "astId": 15530,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "metadata",
           "offset": 0,
@@ -983,12 +983,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorInfo)15399_storage": {
+    "t_struct(ValidatorInfo)15489_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorInfo",
       "members": [
         {
-          "astId": 15393,
+          "astId": 15483,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "confirmedCollateral",
           "offset": 0,
@@ -996,7 +996,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15395,
+          "astId": 15485,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "totalCollateral",
           "offset": 0,
@@ -1004,7 +1004,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15398,
+          "astId": 15488,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "metadata",
           "offset": 0,
@@ -1014,12 +1014,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorSet)15420_storage": {
+    "t_struct(ValidatorSet)15510_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorSet",
       "members": [
         {
-          "astId": 15402,
+          "astId": 15492,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "activeLimit",
           "offset": 0,
@@ -1027,7 +1027,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 15405,
+          "astId": 15495,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "totalConfirmedCollateral",
           "offset": 0,
@@ -1035,28 +1035,28 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15411,
+          "astId": 15501,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "validators",
           "offset": 0,
           "slot": "2",
-          "type": "t_mapping(t_address,t_struct(ValidatorInfo)15399_storage)"
+          "type": "t_mapping(t_address,t_struct(ValidatorInfo)15489_storage)"
         },
         {
-          "astId": 15415,
+          "astId": 15505,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "activeValidators",
           "offset": 0,
           "slot": "3",
-          "type": "t_struct(MinPQ)14367_storage"
+          "type": "t_struct(MinPQ)14457_storage"
         },
         {
-          "astId": 15419,
+          "astId": 15509,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "waitingValidators",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(MaxPQ)13748_storage"
+          "type": "t_struct(MaxPQ)13838_storage"
         }
       ],
       "numberOfBytes": "288"

--- a/.storage-layouts/GatewayDiamond.json
+++ b/.storage-layouts/GatewayDiamond.json
@@ -6,7 +6,7 @@
       "label": "s",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(GatewayActorStorage)10313_storage"
+      "type": "t_struct(GatewayActorStorage)10291_storage"
     }
   ],
   "types": {
@@ -27,14 +27,14 @@
       "label": "bytes32[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(CrossMsg)15284_storage)dyn_storage": {
-      "base": "t_struct(CrossMsg)15284_storage",
+    "t_array(t_struct(CrossMsg)15262_storage)dyn_storage": {
+      "base": "t_struct(CrossMsg)15262_storage",
       "encoding": "dynamic_array",
       "label": "struct CrossMsg[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(Validator)15463_storage)dyn_storage": {
-      "base": "t_struct(Validator)15463_storage",
+    "t_array(t_struct(Validator)15441_storage)dyn_storage": {
+      "base": "t_struct(Validator)15441_storage",
       "encoding": "dynamic_array",
       "label": "struct Validator[]",
       "numberOfBytes": "32"
@@ -59,7 +59,7 @@
       "label": "bytes",
       "numberOfBytes": "32"
     },
-    "t_enum(StakingOperation)15359": {
+    "t_enum(StakingOperation)15337": {
       "encoding": "inplace",
       "label": "enum StakingOperation",
       "numberOfBytes": "1"
@@ -76,12 +76,12 @@
       "numberOfBytes": "32",
       "value": "t_bytes_storage"
     },
-    "t_mapping(t_address,t_struct(ValidatorInfo)15421_storage)": {
+    "t_mapping(t_address,t_struct(ValidatorInfo)15399_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ValidatorInfo)",
       "numberOfBytes": "32",
-      "value": "t_struct(ValidatorInfo)15421_storage"
+      "value": "t_struct(ValidatorInfo)15399_storage"
     },
     "t_mapping(t_address,t_uint16)": {
       "encoding": "mapping",
@@ -90,26 +90,26 @@
       "numberOfBytes": "32",
       "value": "t_uint16"
     },
-    "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)15284_storage)dyn_storage))": {
+    "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)15262_storage)dyn_storage))": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => mapping(uint256 => struct CrossMsg[]))",
       "numberOfBytes": "32",
-      "value": "t_mapping(t_uint256,t_array(t_struct(CrossMsg)15284_storage)dyn_storage)"
+      "value": "t_mapping(t_uint256,t_array(t_struct(CrossMsg)15262_storage)dyn_storage)"
     },
-    "t_mapping(t_bytes32,t_struct(CrossMsg)15284_storage)": {
+    "t_mapping(t_bytes32,t_struct(CrossMsg)15262_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct CrossMsg)",
       "numberOfBytes": "32",
-      "value": "t_struct(CrossMsg)15284_storage"
+      "value": "t_struct(CrossMsg)15262_storage"
     },
-    "t_mapping(t_bytes32,t_struct(Subnet)15355_storage)": {
+    "t_mapping(t_bytes32,t_struct(Subnet)15333_storage)": {
       "encoding": "mapping",
       "key": "t_bytes32",
       "label": "mapping(bytes32 => struct Subnet)",
       "numberOfBytes": "32",
-      "value": "t_struct(Subnet)15355_storage"
+      "value": "t_struct(Subnet)15333_storage"
     },
     "t_mapping(t_bytes32,t_uint256)": {
       "encoding": "mapping",
@@ -125,26 +125,26 @@
       "numberOfBytes": "32",
       "value": "t_address"
     },
-    "t_mapping(t_uint256,t_array(t_struct(CrossMsg)15284_storage)dyn_storage)": {
+    "t_mapping(t_uint256,t_array(t_struct(CrossMsg)15262_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct CrossMsg[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(CrossMsg)15284_storage)dyn_storage"
+      "value": "t_array(t_struct(CrossMsg)15262_storage)dyn_storage"
     },
-    "t_mapping(t_uint256,t_struct(ParentFinality)15245_storage)": {
+    "t_mapping(t_uint256,t_struct(ParentFinality)15223_storage)": {
       "encoding": "mapping",
       "key": "t_uint256",
       "label": "mapping(uint256 => struct ParentFinality)",
       "numberOfBytes": "32",
-      "value": "t_struct(ParentFinality)15245_storage"
+      "value": "t_struct(ParentFinality)15223_storage"
     },
-    "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15284_storage)dyn_storage)": {
+    "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15262_storage)dyn_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct CrossMsg[])",
       "numberOfBytes": "32",
-      "value": "t_array(t_struct(CrossMsg)15284_storage)dyn_storage"
+      "value": "t_array(t_struct(CrossMsg)15262_storage)dyn_storage"
     },
     "t_mapping(t_uint64,t_mapping(t_address,t_bytes_storage))": {
       "encoding": "mapping",
@@ -167,26 +167,26 @@
       "numberOfBytes": "32",
       "value": "t_struct(AddressSet)3420_storage"
     },
-    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15262_storage)": {
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15240_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)15262_storage"
+      "value": "t_struct(BottomUpCheckpoint)15240_storage"
     },
-    "t_mapping(t_uint64,t_struct(CheckpointInfo)15278_storage)": {
+    "t_mapping(t_uint64,t_struct(CheckpointInfo)15256_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct CheckpointInfo)",
       "numberOfBytes": "32",
-      "value": "t_struct(CheckpointInfo)15278_storage"
+      "value": "t_struct(CheckpointInfo)15256_storage"
     },
-    "t_mapping(t_uint64,t_struct(StakingChange)15367_storage)": {
+    "t_mapping(t_uint64,t_struct(StakingChange)15345_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct StakingChange)",
       "numberOfBytes": "32",
-      "value": "t_struct(StakingChange)15367_storage"
+      "value": "t_struct(StakingChange)15345_storage"
     },
     "t_struct(AddressSet)3420_storage": {
       "encoding": "inplace",
@@ -203,20 +203,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(BottomUpCheckpoint)15262_storage": {
+    "t_struct(BottomUpCheckpoint)15240_storage": {
       "encoding": "inplace",
       "label": "struct BottomUpCheckpoint",
       "members": [
         {
-          "astId": 15249,
+          "astId": 15227,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "subnetID",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)15338_storage"
+          "type": "t_struct(SubnetID)15316_storage"
         },
         {
-          "astId": 15252,
+          "astId": 15230,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "blockHeight",
           "offset": 0,
@@ -224,7 +224,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15255,
+          "astId": 15233,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "blockHash",
           "offset": 0,
@@ -232,7 +232,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 15258,
+          "astId": 15236,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -240,7 +240,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15261,
+          "astId": 15239,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "crossMessagesHash",
           "offset": 0,
@@ -250,12 +250,12 @@
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(CheckpointInfo)15278_storage": {
+    "t_struct(CheckpointInfo)15256_storage": {
       "encoding": "inplace",
       "label": "struct CheckpointInfo",
       "members": [
         {
-          "astId": 15265,
+          "astId": 15243,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "hash",
           "offset": 0,
@@ -263,7 +263,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 15268,
+          "astId": 15246,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "rootHash",
           "offset": 0,
@@ -271,7 +271,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 15271,
+          "astId": 15249,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "threshold",
           "offset": 0,
@@ -279,7 +279,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15274,
+          "astId": 15252,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "currentWeight",
           "offset": 0,
@@ -287,7 +287,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15277,
+          "astId": 15255,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "reached",
           "offset": 0,
@@ -297,20 +297,20 @@
       ],
       "numberOfBytes": "160"
     },
-    "t_struct(CrossMsg)15284_storage": {
+    "t_struct(CrossMsg)15262_storage": {
       "encoding": "inplace",
       "label": "struct CrossMsg",
       "members": [
         {
-          "astId": 15281,
+          "astId": 15259,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "message",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(StorableMsg)15301_storage"
+          "type": "t_struct(StorableMsg)15279_storage"
         },
         {
-          "astId": 15283,
+          "astId": 15261,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "wrapped",
           "offset": 0,
@@ -320,12 +320,12 @@
       ],
       "numberOfBytes": "416"
     },
-    "t_struct(FvmAddress)15308_storage": {
+    "t_struct(FvmAddress)15286_storage": {
       "encoding": "inplace",
       "label": "struct FvmAddress",
       "members": [
         {
-          "astId": 15305,
+          "astId": 15283,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "addrType",
           "offset": 0,
@@ -333,7 +333,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 15307,
+          "astId": 15285,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "payload",
           "offset": 0,
@@ -343,36 +343,36 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(GatewayActorStorage)10313_storage": {
+    "t_struct(GatewayActorStorage)10291_storage": {
       "encoding": "inplace",
       "label": "struct GatewayActorStorage",
       "members": [
         {
-          "astId": 10202,
+          "astId": 10180,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "subnets",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_bytes32,t_struct(Subnet)15355_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(Subnet)15333_storage)"
         },
         {
-          "astId": 10211,
+          "astId": 10189,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "topDownMsgs",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)15284_storage)dyn_storage))"
+          "type": "t_mapping(t_bytes32,t_mapping(t_uint256,t_array(t_struct(CrossMsg)15262_storage)dyn_storage))"
         },
         {
-          "astId": 10217,
+          "astId": 10195,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "finalitiesMap",
           "offset": 0,
           "slot": "2",
-          "type": "t_mapping(t_uint256,t_struct(ParentFinality)15245_storage)"
+          "type": "t_mapping(t_uint256,t_struct(ParentFinality)15223_storage)"
         },
         {
-          "astId": 10220,
+          "astId": 10198,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "latestParentHeight",
           "offset": 0,
@@ -380,15 +380,15 @@
           "type": "t_uint256"
         },
         {
-          "astId": 10226,
+          "astId": 10204,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "postbox",
           "offset": 0,
           "slot": "4",
-          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)15284_storage)"
+          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)15262_storage)"
         },
         {
-          "astId": 10233,
+          "astId": 10211,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "validatorSetWeights",
           "offset": 0,
@@ -396,47 +396,47 @@
           "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_uint256))"
         },
         {
-          "astId": 10237,
+          "astId": 10215,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "currentMembership",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(Membership)15476_storage"
+          "type": "t_struct(Membership)15448_storage"
         },
         {
-          "astId": 10241,
+          "astId": 10219,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "lastMembership",
           "offset": 0,
           "slot": "8",
-          "type": "t_struct(Membership)15476_storage"
+          "type": "t_struct(Membership)15448_storage"
         },
         {
-          "astId": 10247,
+          "astId": 10225,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpCheckpoints",
           "offset": 0,
           "slot": "10",
-          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15262_storage)"
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15240_storage)"
         },
         {
-          "astId": 10253,
+          "astId": 10231,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpCheckpointInfo",
           "offset": 0,
           "slot": "11",
-          "type": "t_mapping(t_uint64,t_struct(CheckpointInfo)15278_storage)"
+          "type": "t_mapping(t_uint64,t_struct(CheckpointInfo)15256_storage)"
         },
         {
-          "astId": 10260,
+          "astId": 10238,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpMessages",
           "offset": 0,
           "slot": "12",
-          "type": "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15284_storage)dyn_storage)"
+          "type": "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15262_storage)dyn_storage)"
         },
         {
-          "astId": 10263,
+          "astId": 10241,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpCheckpointRetentionHeight",
           "offset": 0,
@@ -444,7 +444,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 10267,
+          "astId": 10245,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "incompleteCheckpoints",
           "offset": 0,
@@ -452,7 +452,7 @@
           "type": "t_struct(UintSet)3577_storage"
         },
         {
-          "astId": 10273,
+          "astId": 10251,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpSignatureSenders",
           "offset": 0,
@@ -460,7 +460,7 @@
           "type": "t_mapping(t_uint64,t_struct(AddressSet)3420_storage)"
         },
         {
-          "astId": 10280,
+          "astId": 10258,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpSignatures",
           "offset": 0,
@@ -468,7 +468,7 @@
           "type": "t_mapping(t_uint64,t_mapping(t_address,t_bytes_storage))"
         },
         {
-          "astId": 10284,
+          "astId": 10262,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "subnetKeys",
           "offset": 0,
@@ -476,15 +476,15 @@
           "type": "t_array(t_bytes32)dyn_storage"
         },
         {
-          "astId": 10288,
+          "astId": 10266,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "networkName",
           "offset": 0,
           "slot": "19",
-          "type": "t_struct(SubnetID)15338_storage"
+          "type": "t_struct(SubnetID)15316_storage"
         },
         {
-          "astId": 10291,
+          "astId": 10269,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "minStake",
           "offset": 0,
@@ -492,7 +492,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 10294,
+          "astId": 10272,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "minCrossMsgFee",
           "offset": 0,
@@ -500,7 +500,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 10297,
+          "astId": 10275,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "majorityPercentage",
           "offset": 0,
@@ -508,7 +508,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 10300,
+          "astId": 10278,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpNonce",
           "offset": 1,
@@ -516,7 +516,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 10303,
+          "astId": 10281,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "appliedTopDownNonce",
           "offset": 9,
@@ -524,7 +524,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 10306,
+          "astId": 10284,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "totalSubnets",
           "offset": 17,
@@ -532,7 +532,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 10308,
+          "astId": 10286,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "bottomUpCheckPeriod",
           "offset": 0,
@@ -540,68 +540,68 @@
           "type": "t_uint64"
         },
         {
-          "astId": 10312,
+          "astId": 10290,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "validatorsTracker",
           "offset": 0,
           "slot": "25",
-          "type": "t_struct(ParentValidatorsTracker)15449_storage"
+          "type": "t_struct(ParentValidatorsTracker)15427_storage"
         }
       ],
       "numberOfBytes": "1152"
     },
-    "t_struct(IPCAddress)15456_storage": {
+    "t_struct(IPCAddress)15434_storage": {
       "encoding": "inplace",
       "label": "struct IPCAddress",
       "members": [
         {
-          "astId": 15452,
+          "astId": 15430,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "subnetId",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)15338_storage"
+          "type": "t_struct(SubnetID)15316_storage"
         },
         {
-          "astId": 15455,
+          "astId": 15433,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "rawAddress",
           "offset": 0,
           "slot": "2",
-          "type": "t_struct(FvmAddress)15308_storage"
+          "type": "t_struct(FvmAddress)15286_storage"
         }
       ],
       "numberOfBytes": "128"
     },
-    "t_struct(MaxPQ)13770_storage": {
+    "t_struct(MaxPQ)13748_storage": {
       "encoding": "inplace",
       "label": "struct MaxPQ",
       "members": [
         {
-          "astId": 13769,
+          "astId": 13747,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)15019_storage"
+          "type": "t_struct(PQ)14997_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(Membership)15476_storage": {
+    "t_struct(Membership)15448_storage": {
       "encoding": "inplace",
       "label": "struct Membership",
       "members": [
         {
-          "astId": 15473,
+          "astId": 15445,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "validators",
           "offset": 0,
           "slot": "0",
-          "type": "t_array(t_struct(Validator)15463_storage)dyn_storage"
+          "type": "t_array(t_struct(Validator)15441_storage)dyn_storage"
         },
         {
-          "astId": 15475,
+          "astId": 15447,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "configurationNumber",
           "offset": 0,
@@ -611,27 +611,27 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(MinPQ)14389_storage": {
+    "t_struct(MinPQ)14367_storage": {
       "encoding": "inplace",
       "label": "struct MinPQ",
       "members": [
         {
-          "astId": 14388,
+          "astId": 14366,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)15019_storage"
+          "type": "t_struct(PQ)14997_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(PQ)15019_storage": {
+    "t_struct(PQ)14997_storage": {
       "encoding": "inplace",
       "label": "struct PQ",
       "members": [
         {
-          "astId": 15008,
+          "astId": 14986,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "size",
           "offset": 0,
@@ -639,7 +639,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 15013,
+          "astId": 14991,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "addressToPos",
           "offset": 0,
@@ -647,7 +647,7 @@
           "type": "t_mapping(t_address,t_uint16)"
         },
         {
-          "astId": 15018,
+          "astId": 14996,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "posToAddress",
           "offset": 0,
@@ -657,12 +657,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ParentFinality)15245_storage": {
+    "t_struct(ParentFinality)15223_storage": {
       "encoding": "inplace",
       "label": "struct ParentFinality",
       "members": [
         {
-          "astId": 15242,
+          "astId": 15220,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "height",
           "offset": 0,
@@ -670,7 +670,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15244,
+          "astId": 15222,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "blockHash",
           "offset": 0,
@@ -680,25 +680,25 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(ParentValidatorsTracker)15449_storage": {
+    "t_struct(ParentValidatorsTracker)15427_storage": {
       "encoding": "inplace",
       "label": "struct ParentValidatorsTracker",
       "members": [
         {
-          "astId": 15445,
+          "astId": 15423,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "validators",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(ValidatorSet)15442_storage"
+          "type": "t_struct(ValidatorSet)15420_storage"
         },
         {
-          "astId": 15448,
+          "astId": 15426,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "changes",
           "offset": 0,
           "slot": "9",
-          "type": "t_struct(StakingChangeLog)15386_storage"
+          "type": "t_struct(StakingChangeLog)15364_storage"
         }
       ],
       "numberOfBytes": "352"
@@ -726,20 +726,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingChange)15367_storage": {
+    "t_struct(StakingChange)15345_storage": {
       "encoding": "inplace",
       "label": "struct StakingChange",
       "members": [
         {
-          "astId": 15362,
+          "astId": 15340,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "op",
           "offset": 0,
           "slot": "0",
-          "type": "t_enum(StakingOperation)15359"
+          "type": "t_enum(StakingOperation)15337"
         },
         {
-          "astId": 15364,
+          "astId": 15342,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "payload",
           "offset": 0,
@@ -747,7 +747,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 15366,
+          "astId": 15344,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "validator",
           "offset": 0,
@@ -757,12 +757,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(StakingChangeLog)15386_storage": {
+    "t_struct(StakingChangeLog)15364_storage": {
       "encoding": "inplace",
       "label": "struct StakingChangeLog",
       "members": [
         {
-          "astId": 15376,
+          "astId": 15354,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -770,7 +770,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15379,
+          "astId": 15357,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "startConfigurationNumber",
           "offset": 8,
@@ -778,38 +778,38 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15385,
+          "astId": 15363,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "changes",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_uint64,t_struct(StakingChange)15367_storage)"
+          "type": "t_mapping(t_uint64,t_struct(StakingChange)15345_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StorableMsg)15301_storage": {
+    "t_struct(StorableMsg)15279_storage": {
       "encoding": "inplace",
       "label": "struct StorableMsg",
       "members": [
         {
-          "astId": 15287,
+          "astId": 15265,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "from",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(IPCAddress)15456_storage"
+          "type": "t_struct(IPCAddress)15434_storage"
         },
         {
-          "astId": 15290,
+          "astId": 15268,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "to",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(IPCAddress)15456_storage"
+          "type": "t_struct(IPCAddress)15434_storage"
         },
         {
-          "astId": 15292,
+          "astId": 15270,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "value",
           "offset": 0,
@@ -817,7 +817,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15294,
+          "astId": 15272,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "nonce",
           "offset": 0,
@@ -825,7 +825,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15296,
+          "astId": 15274,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "method",
           "offset": 8,
@@ -833,7 +833,7 @@
           "type": "t_bytes4"
         },
         {
-          "astId": 15298,
+          "astId": 15276,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "params",
           "offset": 0,
@@ -841,7 +841,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 15300,
+          "astId": 15278,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "fee",
           "offset": 0,
@@ -851,12 +851,12 @@
       ],
       "numberOfBytes": "384"
     },
-    "t_struct(Subnet)15355_storage": {
+    "t_struct(Subnet)15333_storage": {
       "encoding": "inplace",
       "label": "struct Subnet",
       "members": [
         {
-          "astId": 15340,
+          "astId": 15318,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "stake",
           "offset": 0,
@@ -864,7 +864,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15342,
+          "astId": 15320,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "genesisEpoch",
           "offset": 0,
@@ -872,7 +872,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15344,
+          "astId": 15322,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "circSupply",
           "offset": 0,
@@ -880,7 +880,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15346,
+          "astId": 15324,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "topDownNonce",
           "offset": 0,
@@ -888,7 +888,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15348,
+          "astId": 15326,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "appliedBottomUpNonce",
           "offset": 8,
@@ -896,7 +896,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15351,
+          "astId": 15329,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "status",
           "offset": 16,
@@ -904,22 +904,22 @@
           "type": "t_enum(Status)5093"
         },
         {
-          "astId": 15354,
+          "astId": 15332,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "id",
           "offset": 0,
           "slot": "4",
-          "type": "t_struct(SubnetID)15338_storage"
+          "type": "t_struct(SubnetID)15316_storage"
         }
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(SubnetID)15338_storage": {
+    "t_struct(SubnetID)15316_storage": {
       "encoding": "inplace",
       "label": "struct SubnetID",
       "members": [
         {
-          "astId": 15333,
+          "astId": 15311,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "root",
           "offset": 0,
@@ -927,7 +927,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15337,
+          "astId": 15315,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "route",
           "offset": 0,
@@ -952,12 +952,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(Validator)15463_storage": {
+    "t_struct(Validator)15441_storage": {
       "encoding": "inplace",
       "label": "struct Validator",
       "members": [
         {
-          "astId": 15458,
+          "astId": 15436,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "weight",
           "offset": 0,
@@ -965,7 +965,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15460,
+          "astId": 15438,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "addr",
           "offset": 0,
@@ -973,7 +973,7 @@
           "type": "t_address"
         },
         {
-          "astId": 15462,
+          "astId": 15440,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "metadata",
           "offset": 0,
@@ -983,12 +983,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorInfo)15421_storage": {
+    "t_struct(ValidatorInfo)15399_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorInfo",
       "members": [
         {
-          "astId": 15415,
+          "astId": 15393,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "confirmedCollateral",
           "offset": 0,
@@ -996,7 +996,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15417,
+          "astId": 15395,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "totalCollateral",
           "offset": 0,
@@ -1004,7 +1004,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15420,
+          "astId": 15398,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "metadata",
           "offset": 0,
@@ -1014,12 +1014,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorSet)15442_storage": {
+    "t_struct(ValidatorSet)15420_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorSet",
       "members": [
         {
-          "astId": 15424,
+          "astId": 15402,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "activeLimit",
           "offset": 0,
@@ -1027,7 +1027,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 15427,
+          "astId": 15405,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "totalConfirmedCollateral",
           "offset": 0,
@@ -1035,28 +1035,28 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15433,
+          "astId": 15411,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "validators",
           "offset": 0,
           "slot": "2",
-          "type": "t_mapping(t_address,t_struct(ValidatorInfo)15421_storage)"
+          "type": "t_mapping(t_address,t_struct(ValidatorInfo)15399_storage)"
         },
         {
-          "astId": 15437,
+          "astId": 15415,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "activeValidators",
           "offset": 0,
           "slot": "3",
-          "type": "t_struct(MinPQ)14389_storage"
+          "type": "t_struct(MinPQ)14367_storage"
         },
         {
-          "astId": 15441,
+          "astId": 15419,
           "contract": "src/GatewayDiamond.sol:GatewayDiamond",
           "label": "waitingValidators",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(MaxPQ)13770_storage"
+          "type": "t_struct(MaxPQ)13748_storage"
         }
       ],
       "numberOfBytes": "288"

--- a/.storage-layouts/SubnetActorDiamond.json
+++ b/.storage-layouts/SubnetActorDiamond.json
@@ -6,7 +6,7 @@
       "label": "s",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(SubnetActorStorage)12991_storage"
+      "type": "t_struct(SubnetActorStorage)13081_storage"
     }
   ],
   "types": {
@@ -27,8 +27,8 @@
       "label": "bytes32[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(Validator)15441_storage)dyn_storage": {
-      "base": "t_struct(Validator)15441_storage",
+    "t_array(t_struct(Validator)15531_storage)dyn_storage": {
+      "base": "t_struct(Validator)15531_storage",
       "encoding": "dynamic_array",
       "label": "struct Validator[]",
       "numberOfBytes": "32"
@@ -53,7 +53,7 @@
       "label": "enum ConsensusType",
       "numberOfBytes": "1"
     },
-    "t_enum(StakingOperation)15337": {
+    "t_enum(StakingOperation)15427": {
       "encoding": "inplace",
       "label": "enum StakingOperation",
       "numberOfBytes": "1"
@@ -70,19 +70,19 @@
       "numberOfBytes": "32",
       "value": "t_string_storage"
     },
-    "t_mapping(t_address,t_struct(AddressStakingReleases)15381_storage)": {
+    "t_mapping(t_address,t_struct(AddressStakingReleases)15471_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct AddressStakingReleases)",
       "numberOfBytes": "32",
-      "value": "t_struct(AddressStakingReleases)15381_storage"
+      "value": "t_struct(AddressStakingReleases)15471_storage"
     },
-    "t_mapping(t_address,t_struct(ValidatorInfo)15399_storage)": {
+    "t_mapping(t_address,t_struct(ValidatorInfo)15489_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ValidatorInfo)",
       "numberOfBytes": "32",
-      "value": "t_struct(ValidatorInfo)15399_storage"
+      "value": "t_struct(ValidatorInfo)15489_storage"
     },
     "t_mapping(t_address,t_uint16)": {
       "encoding": "mapping",
@@ -112,12 +112,12 @@
       "numberOfBytes": "32",
       "value": "t_address"
     },
-    "t_mapping(t_uint16,t_struct(StakingRelease)15371_storage)": {
+    "t_mapping(t_uint16,t_struct(StakingRelease)15461_storage)": {
       "encoding": "mapping",
       "key": "t_uint16",
       "label": "mapping(uint16 => struct StakingRelease)",
       "numberOfBytes": "32",
-      "value": "t_struct(StakingRelease)15371_storage"
+      "value": "t_struct(StakingRelease)15461_storage"
     },
     "t_mapping(t_uint64,t_struct(AddressSet)3420_storage)": {
       "encoding": "mapping",
@@ -126,19 +126,19 @@
       "numberOfBytes": "32",
       "value": "t_struct(AddressSet)3420_storage"
     },
-    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15240_storage)": {
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15330_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)15240_storage"
+      "value": "t_struct(BottomUpCheckpoint)15330_storage"
     },
-    "t_mapping(t_uint64,t_struct(StakingChange)15345_storage)": {
+    "t_mapping(t_uint64,t_struct(StakingChange)15435_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct StakingChange)",
       "numberOfBytes": "32",
-      "value": "t_struct(StakingChange)15345_storage"
+      "value": "t_struct(StakingChange)15435_storage"
     },
     "t_string_storage": {
       "encoding": "bytes",
@@ -160,12 +160,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(AddressStakingReleases)15381_storage": {
+    "t_struct(AddressStakingReleases)15471_storage": {
       "encoding": "inplace",
       "label": "struct AddressStakingReleases",
       "members": [
         {
-          "astId": 15373,
+          "astId": 15463,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "length",
           "offset": 0,
@@ -173,7 +173,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 15375,
+          "astId": 15465,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "startIdx",
           "offset": 2,
@@ -181,30 +181,30 @@
           "type": "t_uint16"
         },
         {
-          "astId": 15380,
+          "astId": 15470,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "releases",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_uint16,t_struct(StakingRelease)15371_storage)"
+          "type": "t_mapping(t_uint16,t_struct(StakingRelease)15461_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(BottomUpCheckpoint)15240_storage": {
+    "t_struct(BottomUpCheckpoint)15330_storage": {
       "encoding": "inplace",
       "label": "struct BottomUpCheckpoint",
       "members": [
         {
-          "astId": 15227,
+          "astId": 15317,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "subnetID",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)15316_storage"
+          "type": "t_struct(SubnetID)15406_storage"
         },
         {
-          "astId": 15230,
+          "astId": 15320,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "blockHeight",
           "offset": 0,
@@ -212,7 +212,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15233,
+          "astId": 15323,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "blockHash",
           "offset": 0,
@@ -220,7 +220,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 15236,
+          "astId": 15326,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -228,7 +228,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15239,
+          "astId": 15329,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "crossMessagesHash",
           "offset": 0,
@@ -238,42 +238,42 @@
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(MaxPQ)13748_storage": {
+    "t_struct(MaxPQ)13838_storage": {
       "encoding": "inplace",
       "label": "struct MaxPQ",
       "members": [
         {
-          "astId": 13747,
+          "astId": 13837,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)14997_storage"
+          "type": "t_struct(PQ)15087_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(MinPQ)14367_storage": {
+    "t_struct(MinPQ)14457_storage": {
       "encoding": "inplace",
       "label": "struct MinPQ",
       "members": [
         {
-          "astId": 14366,
+          "astId": 14456,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)14997_storage"
+          "type": "t_struct(PQ)15087_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(PQ)14997_storage": {
+    "t_struct(PQ)15087_storage": {
       "encoding": "inplace",
       "label": "struct PQ",
       "members": [
         {
-          "astId": 14986,
+          "astId": 15076,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "size",
           "offset": 0,
@@ -281,7 +281,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 14991,
+          "astId": 15081,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "addressToPos",
           "offset": 0,
@@ -289,7 +289,7 @@
           "type": "t_mapping(t_address,t_uint16)"
         },
         {
-          "astId": 14996,
+          "astId": 15086,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "posToAddress",
           "offset": 0,
@@ -322,20 +322,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingChange)15345_storage": {
+    "t_struct(StakingChange)15435_storage": {
       "encoding": "inplace",
       "label": "struct StakingChange",
       "members": [
         {
-          "astId": 15340,
+          "astId": 15430,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "op",
           "offset": 0,
           "slot": "0",
-          "type": "t_enum(StakingOperation)15337"
+          "type": "t_enum(StakingOperation)15427"
         },
         {
-          "astId": 15342,
+          "astId": 15432,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "payload",
           "offset": 0,
@@ -343,7 +343,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 15344,
+          "astId": 15434,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "validator",
           "offset": 0,
@@ -353,12 +353,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(StakingChangeLog)15364_storage": {
+    "t_struct(StakingChangeLog)15454_storage": {
       "encoding": "inplace",
       "label": "struct StakingChangeLog",
       "members": [
         {
-          "astId": 15354,
+          "astId": 15444,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -366,7 +366,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15357,
+          "astId": 15447,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "startConfigurationNumber",
           "offset": 8,
@@ -374,22 +374,22 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15363,
+          "astId": 15453,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "changes",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_uint64,t_struct(StakingChange)15345_storage)"
+          "type": "t_mapping(t_uint64,t_struct(StakingChange)15435_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingRelease)15371_storage": {
+    "t_struct(StakingRelease)15461_storage": {
       "encoding": "inplace",
       "label": "struct StakingRelease",
       "members": [
         {
-          "astId": 15367,
+          "astId": 15457,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "releaseAt",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15370,
+          "astId": 15460,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "amount",
           "offset": 0,
@@ -407,12 +407,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingReleaseQueue)15391_storage": {
+    "t_struct(StakingReleaseQueue)15481_storage": {
       "encoding": "inplace",
       "label": "struct StakingReleaseQueue",
       "members": [
         {
-          "astId": 15384,
+          "astId": 15474,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "lockingDuration",
           "offset": 0,
@@ -420,38 +420,38 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15390,
+          "astId": 15480,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "releases",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_address,t_struct(AddressStakingReleases)15381_storage)"
+          "type": "t_mapping(t_address,t_struct(AddressStakingReleases)15471_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(SubnetActorStorage)12991_storage": {
+    "t_struct(SubnetActorStorage)13081_storage": {
       "encoding": "inplace",
       "label": "struct SubnetActorStorage",
       "members": [
         {
-          "astId": 12901,
+          "astId": 12991,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "committedCheckpoints",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15240_storage)"
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15330_storage)"
         },
         {
-          "astId": 12906,
+          "astId": 12996,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "genesisValidators",
           "offset": 0,
           "slot": "1",
-          "type": "t_array(t_struct(Validator)15441_storage)dyn_storage"
+          "type": "t_array(t_struct(Validator)15531_storage)dyn_storage"
         },
         {
-          "astId": 12909,
+          "astId": 12999,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "genesisCircSupply",
           "offset": 0,
@@ -459,7 +459,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 12914,
+          "astId": 13004,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "genesisBalance",
           "offset": 0,
@@ -467,7 +467,7 @@
           "type": "t_mapping(t_address,t_uint256)"
         },
         {
-          "astId": 12918,
+          "astId": 13008,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "genesisBalanceKeys",
           "offset": 0,
@@ -475,7 +475,7 @@
           "type": "t_array(t_address)dyn_storage"
         },
         {
-          "astId": 12921,
+          "astId": 13011,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "lastBottomUpCheckpointHeight",
           "offset": 0,
@@ -483,7 +483,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 12924,
+          "astId": 13014,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "minActivationCollateral",
           "offset": 0,
@@ -491,7 +491,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 12927,
+          "astId": 13017,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "bottomUpCheckPeriod",
           "offset": 0,
@@ -499,7 +499,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 12930,
+          "astId": 13020,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "minValidators",
           "offset": 8,
@@ -507,7 +507,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 12932,
+          "astId": 13022,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "currentSubnetHash",
           "offset": 0,
@@ -515,7 +515,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 12935,
+          "astId": 13025,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "ipcGatewayAddr",
           "offset": 0,
@@ -523,7 +523,7 @@
           "type": "t_address"
         },
         {
-          "astId": 12938,
+          "astId": 13028,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "majorityPercentage",
           "offset": 20,
@@ -531,7 +531,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 12941,
+          "astId": 13031,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "minCrossMsgFee",
           "offset": 0,
@@ -539,15 +539,15 @@
           "type": "t_uint256"
         },
         {
-          "astId": 12945,
+          "astId": 13035,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "parentId",
           "offset": 0,
           "slot": "11",
-          "type": "t_struct(SubnetID)15316_storage"
+          "type": "t_struct(SubnetID)15406_storage"
         },
         {
-          "astId": 12949,
+          "astId": 13039,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "consensus",
           "offset": 0,
@@ -555,7 +555,7 @@
           "type": "t_enum(ConsensusType)5079"
         },
         {
-          "astId": 12952,
+          "astId": 13042,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "bootstrapped",
           "offset": 1,
@@ -563,7 +563,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 12955,
+          "astId": 13045,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "killed",
           "offset": 2,
@@ -571,31 +571,31 @@
           "type": "t_bool"
         },
         {
-          "astId": 12959,
+          "astId": 13049,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "validatorSet",
           "offset": 0,
           "slot": "14",
-          "type": "t_struct(ValidatorSet)15420_storage"
+          "type": "t_struct(ValidatorSet)15510_storage"
         },
         {
-          "astId": 12963,
+          "astId": 13053,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "changeSet",
           "offset": 0,
           "slot": "23",
-          "type": "t_struct(StakingChangeLog)15364_storage"
+          "type": "t_struct(StakingChangeLog)15454_storage"
         },
         {
-          "astId": 12967,
+          "astId": 13057,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "releaseQueue",
           "offset": 0,
           "slot": "25",
-          "type": "t_struct(StakingReleaseQueue)15391_storage"
+          "type": "t_struct(StakingReleaseQueue)15481_storage"
         },
         {
-          "astId": 12970,
+          "astId": 13060,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "powerScale",
           "offset": 0,
@@ -603,7 +603,7 @@
           "type": "t_int8"
         },
         {
-          "astId": 12975,
+          "astId": 13065,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "relayerRewards",
           "offset": 0,
@@ -611,7 +611,7 @@
           "type": "t_mapping(t_address,t_uint256)"
         },
         {
-          "astId": 12981,
+          "astId": 13071,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "rewardedRelayers",
           "offset": 0,
@@ -619,7 +619,7 @@
           "type": "t_mapping(t_uint64,t_struct(AddressSet)3420_storage)"
         },
         {
-          "astId": 12986,
+          "astId": 13076,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "bootstrapNodes",
           "offset": 0,
@@ -627,7 +627,7 @@
           "type": "t_mapping(t_address,t_string_storage)"
         },
         {
-          "astId": 12990,
+          "astId": 13080,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "bootstrapOwners",
           "offset": 0,
@@ -637,12 +637,12 @@
       ],
       "numberOfBytes": "1056"
     },
-    "t_struct(SubnetID)15316_storage": {
+    "t_struct(SubnetID)15406_storage": {
       "encoding": "inplace",
       "label": "struct SubnetID",
       "members": [
         {
-          "astId": 15311,
+          "astId": 15401,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "root",
           "offset": 0,
@@ -650,7 +650,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15315,
+          "astId": 15405,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "route",
           "offset": 0,
@@ -660,12 +660,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(Validator)15441_storage": {
+    "t_struct(Validator)15531_storage": {
       "encoding": "inplace",
       "label": "struct Validator",
       "members": [
         {
-          "astId": 15436,
+          "astId": 15526,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "weight",
           "offset": 0,
@@ -673,7 +673,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15438,
+          "astId": 15528,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "addr",
           "offset": 0,
@@ -681,7 +681,7 @@
           "type": "t_address"
         },
         {
-          "astId": 15440,
+          "astId": 15530,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "metadata",
           "offset": 0,
@@ -691,12 +691,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorInfo)15399_storage": {
+    "t_struct(ValidatorInfo)15489_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorInfo",
       "members": [
         {
-          "astId": 15393,
+          "astId": 15483,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "confirmedCollateral",
           "offset": 0,
@@ -704,7 +704,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15395,
+          "astId": 15485,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "totalCollateral",
           "offset": 0,
@@ -712,7 +712,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15398,
+          "astId": 15488,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "metadata",
           "offset": 0,
@@ -722,12 +722,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorSet)15420_storage": {
+    "t_struct(ValidatorSet)15510_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorSet",
       "members": [
         {
-          "astId": 15402,
+          "astId": 15492,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "activeLimit",
           "offset": 0,
@@ -735,7 +735,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 15405,
+          "astId": 15495,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "totalConfirmedCollateral",
           "offset": 0,
@@ -743,28 +743,28 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15411,
+          "astId": 15501,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "validators",
           "offset": 0,
           "slot": "2",
-          "type": "t_mapping(t_address,t_struct(ValidatorInfo)15399_storage)"
+          "type": "t_mapping(t_address,t_struct(ValidatorInfo)15489_storage)"
         },
         {
-          "astId": 15415,
+          "astId": 15505,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "activeValidators",
           "offset": 0,
           "slot": "3",
-          "type": "t_struct(MinPQ)14367_storage"
+          "type": "t_struct(MinPQ)14457_storage"
         },
         {
-          "astId": 15419,
+          "astId": 15509,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "waitingValidators",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(MaxPQ)13748_storage"
+          "type": "t_struct(MaxPQ)13838_storage"
         }
       ],
       "numberOfBytes": "288"

--- a/.storage-layouts/SubnetActorDiamond.json
+++ b/.storage-layouts/SubnetActorDiamond.json
@@ -6,7 +6,7 @@
       "label": "s",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(SubnetActorStorage)13013_storage"
+      "type": "t_struct(SubnetActorStorage)12991_storage"
     }
   ],
   "types": {
@@ -27,8 +27,8 @@
       "label": "bytes32[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(Validator)15463_storage)dyn_storage": {
-      "base": "t_struct(Validator)15463_storage",
+    "t_array(t_struct(Validator)15441_storage)dyn_storage": {
+      "base": "t_struct(Validator)15441_storage",
       "encoding": "dynamic_array",
       "label": "struct Validator[]",
       "numberOfBytes": "32"
@@ -53,7 +53,7 @@
       "label": "enum ConsensusType",
       "numberOfBytes": "1"
     },
-    "t_enum(StakingOperation)15359": {
+    "t_enum(StakingOperation)15337": {
       "encoding": "inplace",
       "label": "enum StakingOperation",
       "numberOfBytes": "1"
@@ -70,19 +70,19 @@
       "numberOfBytes": "32",
       "value": "t_string_storage"
     },
-    "t_mapping(t_address,t_struct(AddressStakingReleases)15403_storage)": {
+    "t_mapping(t_address,t_struct(AddressStakingReleases)15381_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct AddressStakingReleases)",
       "numberOfBytes": "32",
-      "value": "t_struct(AddressStakingReleases)15403_storage"
+      "value": "t_struct(AddressStakingReleases)15381_storage"
     },
-    "t_mapping(t_address,t_struct(ValidatorInfo)15421_storage)": {
+    "t_mapping(t_address,t_struct(ValidatorInfo)15399_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ValidatorInfo)",
       "numberOfBytes": "32",
-      "value": "t_struct(ValidatorInfo)15421_storage"
+      "value": "t_struct(ValidatorInfo)15399_storage"
     },
     "t_mapping(t_address,t_uint16)": {
       "encoding": "mapping",
@@ -112,12 +112,12 @@
       "numberOfBytes": "32",
       "value": "t_address"
     },
-    "t_mapping(t_uint16,t_struct(StakingRelease)15393_storage)": {
+    "t_mapping(t_uint16,t_struct(StakingRelease)15371_storage)": {
       "encoding": "mapping",
       "key": "t_uint16",
       "label": "mapping(uint16 => struct StakingRelease)",
       "numberOfBytes": "32",
-      "value": "t_struct(StakingRelease)15393_storage"
+      "value": "t_struct(StakingRelease)15371_storage"
     },
     "t_mapping(t_uint64,t_struct(AddressSet)3420_storage)": {
       "encoding": "mapping",
@@ -126,19 +126,19 @@
       "numberOfBytes": "32",
       "value": "t_struct(AddressSet)3420_storage"
     },
-    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15262_storage)": {
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15240_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)15262_storage"
+      "value": "t_struct(BottomUpCheckpoint)15240_storage"
     },
-    "t_mapping(t_uint64,t_struct(StakingChange)15367_storage)": {
+    "t_mapping(t_uint64,t_struct(StakingChange)15345_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct StakingChange)",
       "numberOfBytes": "32",
-      "value": "t_struct(StakingChange)15367_storage"
+      "value": "t_struct(StakingChange)15345_storage"
     },
     "t_string_storage": {
       "encoding": "bytes",
@@ -160,12 +160,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(AddressStakingReleases)15403_storage": {
+    "t_struct(AddressStakingReleases)15381_storage": {
       "encoding": "inplace",
       "label": "struct AddressStakingReleases",
       "members": [
         {
-          "astId": 15395,
+          "astId": 15373,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "length",
           "offset": 0,
@@ -173,7 +173,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 15397,
+          "astId": 15375,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "startIdx",
           "offset": 2,
@@ -181,30 +181,30 @@
           "type": "t_uint16"
         },
         {
-          "astId": 15402,
+          "astId": 15380,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "releases",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_uint16,t_struct(StakingRelease)15393_storage)"
+          "type": "t_mapping(t_uint16,t_struct(StakingRelease)15371_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(BottomUpCheckpoint)15262_storage": {
+    "t_struct(BottomUpCheckpoint)15240_storage": {
       "encoding": "inplace",
       "label": "struct BottomUpCheckpoint",
       "members": [
         {
-          "astId": 15249,
+          "astId": 15227,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "subnetID",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)15338_storage"
+          "type": "t_struct(SubnetID)15316_storage"
         },
         {
-          "astId": 15252,
+          "astId": 15230,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "blockHeight",
           "offset": 0,
@@ -212,7 +212,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15255,
+          "astId": 15233,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "blockHash",
           "offset": 0,
@@ -220,7 +220,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 15258,
+          "astId": 15236,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -228,7 +228,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15261,
+          "astId": 15239,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "crossMessagesHash",
           "offset": 0,
@@ -238,42 +238,42 @@
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(MaxPQ)13770_storage": {
+    "t_struct(MaxPQ)13748_storage": {
       "encoding": "inplace",
       "label": "struct MaxPQ",
       "members": [
         {
-          "astId": 13769,
+          "astId": 13747,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)15019_storage"
+          "type": "t_struct(PQ)14997_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(MinPQ)14389_storage": {
+    "t_struct(MinPQ)14367_storage": {
       "encoding": "inplace",
       "label": "struct MinPQ",
       "members": [
         {
-          "astId": 14388,
+          "astId": 14366,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)15019_storage"
+          "type": "t_struct(PQ)14997_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(PQ)15019_storage": {
+    "t_struct(PQ)14997_storage": {
       "encoding": "inplace",
       "label": "struct PQ",
       "members": [
         {
-          "astId": 15008,
+          "astId": 14986,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "size",
           "offset": 0,
@@ -281,7 +281,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 15013,
+          "astId": 14991,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "addressToPos",
           "offset": 0,
@@ -289,7 +289,7 @@
           "type": "t_mapping(t_address,t_uint16)"
         },
         {
-          "astId": 15018,
+          "astId": 14996,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "posToAddress",
           "offset": 0,
@@ -322,20 +322,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingChange)15367_storage": {
+    "t_struct(StakingChange)15345_storage": {
       "encoding": "inplace",
       "label": "struct StakingChange",
       "members": [
         {
-          "astId": 15362,
+          "astId": 15340,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "op",
           "offset": 0,
           "slot": "0",
-          "type": "t_enum(StakingOperation)15359"
+          "type": "t_enum(StakingOperation)15337"
         },
         {
-          "astId": 15364,
+          "astId": 15342,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "payload",
           "offset": 0,
@@ -343,7 +343,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 15366,
+          "astId": 15344,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "validator",
           "offset": 0,
@@ -353,12 +353,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(StakingChangeLog)15386_storage": {
+    "t_struct(StakingChangeLog)15364_storage": {
       "encoding": "inplace",
       "label": "struct StakingChangeLog",
       "members": [
         {
-          "astId": 15376,
+          "astId": 15354,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -366,7 +366,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15379,
+          "astId": 15357,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "startConfigurationNumber",
           "offset": 8,
@@ -374,22 +374,22 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15385,
+          "astId": 15363,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "changes",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_uint64,t_struct(StakingChange)15367_storage)"
+          "type": "t_mapping(t_uint64,t_struct(StakingChange)15345_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingRelease)15393_storage": {
+    "t_struct(StakingRelease)15371_storage": {
       "encoding": "inplace",
       "label": "struct StakingRelease",
       "members": [
         {
-          "astId": 15389,
+          "astId": 15367,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "releaseAt",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15392,
+          "astId": 15370,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "amount",
           "offset": 0,
@@ -407,12 +407,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingReleaseQueue)15413_storage": {
+    "t_struct(StakingReleaseQueue)15391_storage": {
       "encoding": "inplace",
       "label": "struct StakingReleaseQueue",
       "members": [
         {
-          "astId": 15406,
+          "astId": 15384,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "lockingDuration",
           "offset": 0,
@@ -420,38 +420,38 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15412,
+          "astId": 15390,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "releases",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_address,t_struct(AddressStakingReleases)15403_storage)"
+          "type": "t_mapping(t_address,t_struct(AddressStakingReleases)15381_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(SubnetActorStorage)13013_storage": {
+    "t_struct(SubnetActorStorage)12991_storage": {
       "encoding": "inplace",
       "label": "struct SubnetActorStorage",
       "members": [
         {
-          "astId": 12923,
+          "astId": 12901,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "committedCheckpoints",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15262_storage)"
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15240_storage)"
         },
         {
-          "astId": 12928,
+          "astId": 12906,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "genesisValidators",
           "offset": 0,
           "slot": "1",
-          "type": "t_array(t_struct(Validator)15463_storage)dyn_storage"
+          "type": "t_array(t_struct(Validator)15441_storage)dyn_storage"
         },
         {
-          "astId": 12931,
+          "astId": 12909,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "genesisCircSupply",
           "offset": 0,
@@ -459,7 +459,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 12936,
+          "astId": 12914,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "genesisBalance",
           "offset": 0,
@@ -467,7 +467,7 @@
           "type": "t_mapping(t_address,t_uint256)"
         },
         {
-          "astId": 12940,
+          "astId": 12918,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "genesisBalanceKeys",
           "offset": 0,
@@ -475,7 +475,7 @@
           "type": "t_array(t_address)dyn_storage"
         },
         {
-          "astId": 12943,
+          "astId": 12921,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "lastBottomUpCheckpointHeight",
           "offset": 0,
@@ -483,7 +483,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 12946,
+          "astId": 12924,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "minActivationCollateral",
           "offset": 0,
@@ -491,7 +491,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 12949,
+          "astId": 12927,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "bottomUpCheckPeriod",
           "offset": 0,
@@ -499,7 +499,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 12952,
+          "astId": 12930,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "minValidators",
           "offset": 8,
@@ -507,7 +507,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 12954,
+          "astId": 12932,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "currentSubnetHash",
           "offset": 0,
@@ -515,7 +515,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 12957,
+          "astId": 12935,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "ipcGatewayAddr",
           "offset": 0,
@@ -523,7 +523,7 @@
           "type": "t_address"
         },
         {
-          "astId": 12960,
+          "astId": 12938,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "majorityPercentage",
           "offset": 20,
@@ -531,7 +531,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 12963,
+          "astId": 12941,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "minCrossMsgFee",
           "offset": 0,
@@ -539,15 +539,15 @@
           "type": "t_uint256"
         },
         {
-          "astId": 12967,
+          "astId": 12945,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "parentId",
           "offset": 0,
           "slot": "11",
-          "type": "t_struct(SubnetID)15338_storage"
+          "type": "t_struct(SubnetID)15316_storage"
         },
         {
-          "astId": 12971,
+          "astId": 12949,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "consensus",
           "offset": 0,
@@ -555,7 +555,7 @@
           "type": "t_enum(ConsensusType)5079"
         },
         {
-          "astId": 12974,
+          "astId": 12952,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "bootstrapped",
           "offset": 1,
@@ -563,7 +563,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 12977,
+          "astId": 12955,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "killed",
           "offset": 2,
@@ -571,31 +571,31 @@
           "type": "t_bool"
         },
         {
-          "astId": 12981,
+          "astId": 12959,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "validatorSet",
           "offset": 0,
           "slot": "14",
-          "type": "t_struct(ValidatorSet)15442_storage"
+          "type": "t_struct(ValidatorSet)15420_storage"
         },
         {
-          "astId": 12985,
+          "astId": 12963,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "changeSet",
           "offset": 0,
           "slot": "23",
-          "type": "t_struct(StakingChangeLog)15386_storage"
+          "type": "t_struct(StakingChangeLog)15364_storage"
         },
         {
-          "astId": 12989,
+          "astId": 12967,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "releaseQueue",
           "offset": 0,
           "slot": "25",
-          "type": "t_struct(StakingReleaseQueue)15413_storage"
+          "type": "t_struct(StakingReleaseQueue)15391_storage"
         },
         {
-          "astId": 12992,
+          "astId": 12970,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "powerScale",
           "offset": 0,
@@ -603,7 +603,7 @@
           "type": "t_int8"
         },
         {
-          "astId": 12997,
+          "astId": 12975,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "relayerRewards",
           "offset": 0,
@@ -611,7 +611,7 @@
           "type": "t_mapping(t_address,t_uint256)"
         },
         {
-          "astId": 13003,
+          "astId": 12981,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "rewardedRelayers",
           "offset": 0,
@@ -619,7 +619,7 @@
           "type": "t_mapping(t_uint64,t_struct(AddressSet)3420_storage)"
         },
         {
-          "astId": 13008,
+          "astId": 12986,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "bootstrapNodes",
           "offset": 0,
@@ -627,7 +627,7 @@
           "type": "t_mapping(t_address,t_string_storage)"
         },
         {
-          "astId": 13012,
+          "astId": 12990,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "bootstrapOwners",
           "offset": 0,
@@ -637,12 +637,12 @@
       ],
       "numberOfBytes": "1056"
     },
-    "t_struct(SubnetID)15338_storage": {
+    "t_struct(SubnetID)15316_storage": {
       "encoding": "inplace",
       "label": "struct SubnetID",
       "members": [
         {
-          "astId": 15333,
+          "astId": 15311,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "root",
           "offset": 0,
@@ -650,7 +650,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15337,
+          "astId": 15315,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "route",
           "offset": 0,
@@ -660,12 +660,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(Validator)15463_storage": {
+    "t_struct(Validator)15441_storage": {
       "encoding": "inplace",
       "label": "struct Validator",
       "members": [
         {
-          "astId": 15458,
+          "astId": 15436,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "weight",
           "offset": 0,
@@ -673,7 +673,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15460,
+          "astId": 15438,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "addr",
           "offset": 0,
@@ -681,7 +681,7 @@
           "type": "t_address"
         },
         {
-          "astId": 15462,
+          "astId": 15440,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "metadata",
           "offset": 0,
@@ -691,12 +691,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorInfo)15421_storage": {
+    "t_struct(ValidatorInfo)15399_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorInfo",
       "members": [
         {
-          "astId": 15415,
+          "astId": 15393,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "confirmedCollateral",
           "offset": 0,
@@ -704,7 +704,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15417,
+          "astId": 15395,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "totalCollateral",
           "offset": 0,
@@ -712,7 +712,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15420,
+          "astId": 15398,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "metadata",
           "offset": 0,
@@ -722,12 +722,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorSet)15442_storage": {
+    "t_struct(ValidatorSet)15420_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorSet",
       "members": [
         {
-          "astId": 15424,
+          "astId": 15402,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "activeLimit",
           "offset": 0,
@@ -735,7 +735,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 15427,
+          "astId": 15405,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "totalConfirmedCollateral",
           "offset": 0,
@@ -743,28 +743,28 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15433,
+          "astId": 15411,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "validators",
           "offset": 0,
           "slot": "2",
-          "type": "t_mapping(t_address,t_struct(ValidatorInfo)15421_storage)"
+          "type": "t_mapping(t_address,t_struct(ValidatorInfo)15399_storage)"
         },
         {
-          "astId": 15437,
+          "astId": 15415,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "activeValidators",
           "offset": 0,
           "slot": "3",
-          "type": "t_struct(MinPQ)14389_storage"
+          "type": "t_struct(MinPQ)14367_storage"
         },
         {
-          "astId": 15441,
+          "astId": 15419,
           "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
           "label": "waitingValidators",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(MaxPQ)13770_storage"
+          "type": "t_struct(MaxPQ)13748_storage"
         }
       ],
       "numberOfBytes": "288"

--- a/.storage-layouts/SubnetActorModifiers.json
+++ b/.storage-layouts/SubnetActorModifiers.json
@@ -1,12 +1,12 @@
 {
   "storage": [
     {
-      "astId": 13027,
+      "astId": 13005,
       "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
       "label": "s",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(SubnetActorStorage)13013_storage"
+      "type": "t_struct(SubnetActorStorage)12991_storage"
     }
   ],
   "types": {
@@ -27,8 +27,8 @@
       "label": "bytes32[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(Validator)15463_storage)dyn_storage": {
-      "base": "t_struct(Validator)15463_storage",
+    "t_array(t_struct(Validator)15441_storage)dyn_storage": {
+      "base": "t_struct(Validator)15441_storage",
       "encoding": "dynamic_array",
       "label": "struct Validator[]",
       "numberOfBytes": "32"
@@ -53,7 +53,7 @@
       "label": "enum ConsensusType",
       "numberOfBytes": "1"
     },
-    "t_enum(StakingOperation)15359": {
+    "t_enum(StakingOperation)15337": {
       "encoding": "inplace",
       "label": "enum StakingOperation",
       "numberOfBytes": "1"
@@ -70,19 +70,19 @@
       "numberOfBytes": "32",
       "value": "t_string_storage"
     },
-    "t_mapping(t_address,t_struct(AddressStakingReleases)15403_storage)": {
+    "t_mapping(t_address,t_struct(AddressStakingReleases)15381_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct AddressStakingReleases)",
       "numberOfBytes": "32",
-      "value": "t_struct(AddressStakingReleases)15403_storage"
+      "value": "t_struct(AddressStakingReleases)15381_storage"
     },
-    "t_mapping(t_address,t_struct(ValidatorInfo)15421_storage)": {
+    "t_mapping(t_address,t_struct(ValidatorInfo)15399_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ValidatorInfo)",
       "numberOfBytes": "32",
-      "value": "t_struct(ValidatorInfo)15421_storage"
+      "value": "t_struct(ValidatorInfo)15399_storage"
     },
     "t_mapping(t_address,t_uint16)": {
       "encoding": "mapping",
@@ -112,12 +112,12 @@
       "numberOfBytes": "32",
       "value": "t_address"
     },
-    "t_mapping(t_uint16,t_struct(StakingRelease)15393_storage)": {
+    "t_mapping(t_uint16,t_struct(StakingRelease)15371_storage)": {
       "encoding": "mapping",
       "key": "t_uint16",
       "label": "mapping(uint16 => struct StakingRelease)",
       "numberOfBytes": "32",
-      "value": "t_struct(StakingRelease)15393_storage"
+      "value": "t_struct(StakingRelease)15371_storage"
     },
     "t_mapping(t_uint64,t_struct(AddressSet)3420_storage)": {
       "encoding": "mapping",
@@ -126,19 +126,19 @@
       "numberOfBytes": "32",
       "value": "t_struct(AddressSet)3420_storage"
     },
-    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15262_storage)": {
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15240_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)15262_storage"
+      "value": "t_struct(BottomUpCheckpoint)15240_storage"
     },
-    "t_mapping(t_uint64,t_struct(StakingChange)15367_storage)": {
+    "t_mapping(t_uint64,t_struct(StakingChange)15345_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct StakingChange)",
       "numberOfBytes": "32",
-      "value": "t_struct(StakingChange)15367_storage"
+      "value": "t_struct(StakingChange)15345_storage"
     },
     "t_string_storage": {
       "encoding": "bytes",
@@ -160,12 +160,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(AddressStakingReleases)15403_storage": {
+    "t_struct(AddressStakingReleases)15381_storage": {
       "encoding": "inplace",
       "label": "struct AddressStakingReleases",
       "members": [
         {
-          "astId": 15395,
+          "astId": 15373,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "length",
           "offset": 0,
@@ -173,7 +173,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 15397,
+          "astId": 15375,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "startIdx",
           "offset": 2,
@@ -181,30 +181,30 @@
           "type": "t_uint16"
         },
         {
-          "astId": 15402,
+          "astId": 15380,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "releases",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_uint16,t_struct(StakingRelease)15393_storage)"
+          "type": "t_mapping(t_uint16,t_struct(StakingRelease)15371_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(BottomUpCheckpoint)15262_storage": {
+    "t_struct(BottomUpCheckpoint)15240_storage": {
       "encoding": "inplace",
       "label": "struct BottomUpCheckpoint",
       "members": [
         {
-          "astId": 15249,
+          "astId": 15227,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "subnetID",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)15338_storage"
+          "type": "t_struct(SubnetID)15316_storage"
         },
         {
-          "astId": 15252,
+          "astId": 15230,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "blockHeight",
           "offset": 0,
@@ -212,7 +212,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15255,
+          "astId": 15233,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "blockHash",
           "offset": 0,
@@ -220,7 +220,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 15258,
+          "astId": 15236,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -228,7 +228,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15261,
+          "astId": 15239,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "crossMessagesHash",
           "offset": 0,
@@ -238,42 +238,42 @@
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(MaxPQ)13770_storage": {
+    "t_struct(MaxPQ)13748_storage": {
       "encoding": "inplace",
       "label": "struct MaxPQ",
       "members": [
         {
-          "astId": 13769,
+          "astId": 13747,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)15019_storage"
+          "type": "t_struct(PQ)14997_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(MinPQ)14389_storage": {
+    "t_struct(MinPQ)14367_storage": {
       "encoding": "inplace",
       "label": "struct MinPQ",
       "members": [
         {
-          "astId": 14388,
+          "astId": 14366,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)15019_storage"
+          "type": "t_struct(PQ)14997_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(PQ)15019_storage": {
+    "t_struct(PQ)14997_storage": {
       "encoding": "inplace",
       "label": "struct PQ",
       "members": [
         {
-          "astId": 15008,
+          "astId": 14986,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "size",
           "offset": 0,
@@ -281,7 +281,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 15013,
+          "astId": 14991,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "addressToPos",
           "offset": 0,
@@ -289,7 +289,7 @@
           "type": "t_mapping(t_address,t_uint16)"
         },
         {
-          "astId": 15018,
+          "astId": 14996,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "posToAddress",
           "offset": 0,
@@ -322,20 +322,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingChange)15367_storage": {
+    "t_struct(StakingChange)15345_storage": {
       "encoding": "inplace",
       "label": "struct StakingChange",
       "members": [
         {
-          "astId": 15362,
+          "astId": 15340,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "op",
           "offset": 0,
           "slot": "0",
-          "type": "t_enum(StakingOperation)15359"
+          "type": "t_enum(StakingOperation)15337"
         },
         {
-          "astId": 15364,
+          "astId": 15342,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "payload",
           "offset": 0,
@@ -343,7 +343,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 15366,
+          "astId": 15344,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "validator",
           "offset": 0,
@@ -353,12 +353,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(StakingChangeLog)15386_storage": {
+    "t_struct(StakingChangeLog)15364_storage": {
       "encoding": "inplace",
       "label": "struct StakingChangeLog",
       "members": [
         {
-          "astId": 15376,
+          "astId": 15354,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -366,7 +366,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15379,
+          "astId": 15357,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "startConfigurationNumber",
           "offset": 8,
@@ -374,22 +374,22 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15385,
+          "astId": 15363,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "changes",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_uint64,t_struct(StakingChange)15367_storage)"
+          "type": "t_mapping(t_uint64,t_struct(StakingChange)15345_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingRelease)15393_storage": {
+    "t_struct(StakingRelease)15371_storage": {
       "encoding": "inplace",
       "label": "struct StakingRelease",
       "members": [
         {
-          "astId": 15389,
+          "astId": 15367,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "releaseAt",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15392,
+          "astId": 15370,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "amount",
           "offset": 0,
@@ -407,12 +407,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingReleaseQueue)15413_storage": {
+    "t_struct(StakingReleaseQueue)15391_storage": {
       "encoding": "inplace",
       "label": "struct StakingReleaseQueue",
       "members": [
         {
-          "astId": 15406,
+          "astId": 15384,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "lockingDuration",
           "offset": 0,
@@ -420,38 +420,38 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15412,
+          "astId": 15390,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "releases",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_address,t_struct(AddressStakingReleases)15403_storage)"
+          "type": "t_mapping(t_address,t_struct(AddressStakingReleases)15381_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(SubnetActorStorage)13013_storage": {
+    "t_struct(SubnetActorStorage)12991_storage": {
       "encoding": "inplace",
       "label": "struct SubnetActorStorage",
       "members": [
         {
-          "astId": 12923,
+          "astId": 12901,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "committedCheckpoints",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15262_storage)"
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15240_storage)"
         },
         {
-          "astId": 12928,
+          "astId": 12906,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "genesisValidators",
           "offset": 0,
           "slot": "1",
-          "type": "t_array(t_struct(Validator)15463_storage)dyn_storage"
+          "type": "t_array(t_struct(Validator)15441_storage)dyn_storage"
         },
         {
-          "astId": 12931,
+          "astId": 12909,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "genesisCircSupply",
           "offset": 0,
@@ -459,7 +459,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 12936,
+          "astId": 12914,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "genesisBalance",
           "offset": 0,
@@ -467,7 +467,7 @@
           "type": "t_mapping(t_address,t_uint256)"
         },
         {
-          "astId": 12940,
+          "astId": 12918,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "genesisBalanceKeys",
           "offset": 0,
@@ -475,7 +475,7 @@
           "type": "t_array(t_address)dyn_storage"
         },
         {
-          "astId": 12943,
+          "astId": 12921,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "lastBottomUpCheckpointHeight",
           "offset": 0,
@@ -483,7 +483,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 12946,
+          "astId": 12924,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "minActivationCollateral",
           "offset": 0,
@@ -491,7 +491,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 12949,
+          "astId": 12927,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "bottomUpCheckPeriod",
           "offset": 0,
@@ -499,7 +499,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 12952,
+          "astId": 12930,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "minValidators",
           "offset": 8,
@@ -507,7 +507,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 12954,
+          "astId": 12932,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "currentSubnetHash",
           "offset": 0,
@@ -515,7 +515,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 12957,
+          "astId": 12935,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "ipcGatewayAddr",
           "offset": 0,
@@ -523,7 +523,7 @@
           "type": "t_address"
         },
         {
-          "astId": 12960,
+          "astId": 12938,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "majorityPercentage",
           "offset": 20,
@@ -531,7 +531,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 12963,
+          "astId": 12941,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "minCrossMsgFee",
           "offset": 0,
@@ -539,15 +539,15 @@
           "type": "t_uint256"
         },
         {
-          "astId": 12967,
+          "astId": 12945,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "parentId",
           "offset": 0,
           "slot": "11",
-          "type": "t_struct(SubnetID)15338_storage"
+          "type": "t_struct(SubnetID)15316_storage"
         },
         {
-          "astId": 12971,
+          "astId": 12949,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "consensus",
           "offset": 0,
@@ -555,7 +555,7 @@
           "type": "t_enum(ConsensusType)5079"
         },
         {
-          "astId": 12974,
+          "astId": 12952,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "bootstrapped",
           "offset": 1,
@@ -563,7 +563,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 12977,
+          "astId": 12955,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "killed",
           "offset": 2,
@@ -571,31 +571,31 @@
           "type": "t_bool"
         },
         {
-          "astId": 12981,
+          "astId": 12959,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "validatorSet",
           "offset": 0,
           "slot": "14",
-          "type": "t_struct(ValidatorSet)15442_storage"
+          "type": "t_struct(ValidatorSet)15420_storage"
         },
         {
-          "astId": 12985,
+          "astId": 12963,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "changeSet",
           "offset": 0,
           "slot": "23",
-          "type": "t_struct(StakingChangeLog)15386_storage"
+          "type": "t_struct(StakingChangeLog)15364_storage"
         },
         {
-          "astId": 12989,
+          "astId": 12967,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "releaseQueue",
           "offset": 0,
           "slot": "25",
-          "type": "t_struct(StakingReleaseQueue)15413_storage"
+          "type": "t_struct(StakingReleaseQueue)15391_storage"
         },
         {
-          "astId": 12992,
+          "astId": 12970,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "powerScale",
           "offset": 0,
@@ -603,7 +603,7 @@
           "type": "t_int8"
         },
         {
-          "astId": 12997,
+          "astId": 12975,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "relayerRewards",
           "offset": 0,
@@ -611,7 +611,7 @@
           "type": "t_mapping(t_address,t_uint256)"
         },
         {
-          "astId": 13003,
+          "astId": 12981,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "rewardedRelayers",
           "offset": 0,
@@ -619,7 +619,7 @@
           "type": "t_mapping(t_uint64,t_struct(AddressSet)3420_storage)"
         },
         {
-          "astId": 13008,
+          "astId": 12986,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "bootstrapNodes",
           "offset": 0,
@@ -627,7 +627,7 @@
           "type": "t_mapping(t_address,t_string_storage)"
         },
         {
-          "astId": 13012,
+          "astId": 12990,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "bootstrapOwners",
           "offset": 0,
@@ -637,12 +637,12 @@
       ],
       "numberOfBytes": "1056"
     },
-    "t_struct(SubnetID)15338_storage": {
+    "t_struct(SubnetID)15316_storage": {
       "encoding": "inplace",
       "label": "struct SubnetID",
       "members": [
         {
-          "astId": 15333,
+          "astId": 15311,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "root",
           "offset": 0,
@@ -650,7 +650,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15337,
+          "astId": 15315,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "route",
           "offset": 0,
@@ -660,12 +660,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(Validator)15463_storage": {
+    "t_struct(Validator)15441_storage": {
       "encoding": "inplace",
       "label": "struct Validator",
       "members": [
         {
-          "astId": 15458,
+          "astId": 15436,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "weight",
           "offset": 0,
@@ -673,7 +673,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15460,
+          "astId": 15438,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "addr",
           "offset": 0,
@@ -681,7 +681,7 @@
           "type": "t_address"
         },
         {
-          "astId": 15462,
+          "astId": 15440,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "metadata",
           "offset": 0,
@@ -691,12 +691,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorInfo)15421_storage": {
+    "t_struct(ValidatorInfo)15399_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorInfo",
       "members": [
         {
-          "astId": 15415,
+          "astId": 15393,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "confirmedCollateral",
           "offset": 0,
@@ -704,7 +704,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15417,
+          "astId": 15395,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "totalCollateral",
           "offset": 0,
@@ -712,7 +712,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15420,
+          "astId": 15398,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "metadata",
           "offset": 0,
@@ -722,12 +722,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorSet)15442_storage": {
+    "t_struct(ValidatorSet)15420_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorSet",
       "members": [
         {
-          "astId": 15424,
+          "astId": 15402,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "activeLimit",
           "offset": 0,
@@ -735,7 +735,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 15427,
+          "astId": 15405,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "totalConfirmedCollateral",
           "offset": 0,
@@ -743,28 +743,28 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15433,
+          "astId": 15411,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "validators",
           "offset": 0,
           "slot": "2",
-          "type": "t_mapping(t_address,t_struct(ValidatorInfo)15421_storage)"
+          "type": "t_mapping(t_address,t_struct(ValidatorInfo)15399_storage)"
         },
         {
-          "astId": 15437,
+          "astId": 15415,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "activeValidators",
           "offset": 0,
           "slot": "3",
-          "type": "t_struct(MinPQ)14389_storage"
+          "type": "t_struct(MinPQ)14367_storage"
         },
         {
-          "astId": 15441,
+          "astId": 15419,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "waitingValidators",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(MaxPQ)13770_storage"
+          "type": "t_struct(MaxPQ)13748_storage"
         }
       ],
       "numberOfBytes": "288"

--- a/.storage-layouts/SubnetActorModifiers.json
+++ b/.storage-layouts/SubnetActorModifiers.json
@@ -1,12 +1,12 @@
 {
   "storage": [
     {
-      "astId": 13005,
+      "astId": 13095,
       "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
       "label": "s",
       "offset": 0,
       "slot": "0",
-      "type": "t_struct(SubnetActorStorage)12991_storage"
+      "type": "t_struct(SubnetActorStorage)13081_storage"
     }
   ],
   "types": {
@@ -27,8 +27,8 @@
       "label": "bytes32[]",
       "numberOfBytes": "32"
     },
-    "t_array(t_struct(Validator)15441_storage)dyn_storage": {
-      "base": "t_struct(Validator)15441_storage",
+    "t_array(t_struct(Validator)15531_storage)dyn_storage": {
+      "base": "t_struct(Validator)15531_storage",
       "encoding": "dynamic_array",
       "label": "struct Validator[]",
       "numberOfBytes": "32"
@@ -53,7 +53,7 @@
       "label": "enum ConsensusType",
       "numberOfBytes": "1"
     },
-    "t_enum(StakingOperation)15337": {
+    "t_enum(StakingOperation)15427": {
       "encoding": "inplace",
       "label": "enum StakingOperation",
       "numberOfBytes": "1"
@@ -70,19 +70,19 @@
       "numberOfBytes": "32",
       "value": "t_string_storage"
     },
-    "t_mapping(t_address,t_struct(AddressStakingReleases)15381_storage)": {
+    "t_mapping(t_address,t_struct(AddressStakingReleases)15471_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct AddressStakingReleases)",
       "numberOfBytes": "32",
-      "value": "t_struct(AddressStakingReleases)15381_storage"
+      "value": "t_struct(AddressStakingReleases)15471_storage"
     },
-    "t_mapping(t_address,t_struct(ValidatorInfo)15399_storage)": {
+    "t_mapping(t_address,t_struct(ValidatorInfo)15489_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct ValidatorInfo)",
       "numberOfBytes": "32",
-      "value": "t_struct(ValidatorInfo)15399_storage"
+      "value": "t_struct(ValidatorInfo)15489_storage"
     },
     "t_mapping(t_address,t_uint16)": {
       "encoding": "mapping",
@@ -112,12 +112,12 @@
       "numberOfBytes": "32",
       "value": "t_address"
     },
-    "t_mapping(t_uint16,t_struct(StakingRelease)15371_storage)": {
+    "t_mapping(t_uint16,t_struct(StakingRelease)15461_storage)": {
       "encoding": "mapping",
       "key": "t_uint16",
       "label": "mapping(uint16 => struct StakingRelease)",
       "numberOfBytes": "32",
-      "value": "t_struct(StakingRelease)15371_storage"
+      "value": "t_struct(StakingRelease)15461_storage"
     },
     "t_mapping(t_uint64,t_struct(AddressSet)3420_storage)": {
       "encoding": "mapping",
@@ -126,19 +126,19 @@
       "numberOfBytes": "32",
       "value": "t_struct(AddressSet)3420_storage"
     },
-    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15240_storage)": {
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15330_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct BottomUpCheckpoint)",
       "numberOfBytes": "32",
-      "value": "t_struct(BottomUpCheckpoint)15240_storage"
+      "value": "t_struct(BottomUpCheckpoint)15330_storage"
     },
-    "t_mapping(t_uint64,t_struct(StakingChange)15345_storage)": {
+    "t_mapping(t_uint64,t_struct(StakingChange)15435_storage)": {
       "encoding": "mapping",
       "key": "t_uint64",
       "label": "mapping(uint64 => struct StakingChange)",
       "numberOfBytes": "32",
-      "value": "t_struct(StakingChange)15345_storage"
+      "value": "t_struct(StakingChange)15435_storage"
     },
     "t_string_storage": {
       "encoding": "bytes",
@@ -160,12 +160,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(AddressStakingReleases)15381_storage": {
+    "t_struct(AddressStakingReleases)15471_storage": {
       "encoding": "inplace",
       "label": "struct AddressStakingReleases",
       "members": [
         {
-          "astId": 15373,
+          "astId": 15463,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "length",
           "offset": 0,
@@ -173,7 +173,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 15375,
+          "astId": 15465,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "startIdx",
           "offset": 2,
@@ -181,30 +181,30 @@
           "type": "t_uint16"
         },
         {
-          "astId": 15380,
+          "astId": 15470,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "releases",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_uint16,t_struct(StakingRelease)15371_storage)"
+          "type": "t_mapping(t_uint16,t_struct(StakingRelease)15461_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(BottomUpCheckpoint)15240_storage": {
+    "t_struct(BottomUpCheckpoint)15330_storage": {
       "encoding": "inplace",
       "label": "struct BottomUpCheckpoint",
       "members": [
         {
-          "astId": 15227,
+          "astId": 15317,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "subnetID",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(SubnetID)15316_storage"
+          "type": "t_struct(SubnetID)15406_storage"
         },
         {
-          "astId": 15230,
+          "astId": 15320,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "blockHeight",
           "offset": 0,
@@ -212,7 +212,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15233,
+          "astId": 15323,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "blockHash",
           "offset": 0,
@@ -220,7 +220,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 15236,
+          "astId": 15326,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -228,7 +228,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15239,
+          "astId": 15329,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "crossMessagesHash",
           "offset": 0,
@@ -238,42 +238,42 @@
       ],
       "numberOfBytes": "192"
     },
-    "t_struct(MaxPQ)13748_storage": {
+    "t_struct(MaxPQ)13838_storage": {
       "encoding": "inplace",
       "label": "struct MaxPQ",
       "members": [
         {
-          "astId": 13747,
+          "astId": 13837,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)14997_storage"
+          "type": "t_struct(PQ)15087_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(MinPQ)14367_storage": {
+    "t_struct(MinPQ)14457_storage": {
       "encoding": "inplace",
       "label": "struct MinPQ",
       "members": [
         {
-          "astId": 14366,
+          "astId": 14456,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "inner",
           "offset": 0,
           "slot": "0",
-          "type": "t_struct(PQ)14997_storage"
+          "type": "t_struct(PQ)15087_storage"
         }
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(PQ)14997_storage": {
+    "t_struct(PQ)15087_storage": {
       "encoding": "inplace",
       "label": "struct PQ",
       "members": [
         {
-          "astId": 14986,
+          "astId": 15076,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "size",
           "offset": 0,
@@ -281,7 +281,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 14991,
+          "astId": 15081,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "addressToPos",
           "offset": 0,
@@ -289,7 +289,7 @@
           "type": "t_mapping(t_address,t_uint16)"
         },
         {
-          "astId": 14996,
+          "astId": 15086,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "posToAddress",
           "offset": 0,
@@ -322,20 +322,20 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingChange)15345_storage": {
+    "t_struct(StakingChange)15435_storage": {
       "encoding": "inplace",
       "label": "struct StakingChange",
       "members": [
         {
-          "astId": 15340,
+          "astId": 15430,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "op",
           "offset": 0,
           "slot": "0",
-          "type": "t_enum(StakingOperation)15337"
+          "type": "t_enum(StakingOperation)15427"
         },
         {
-          "astId": 15342,
+          "astId": 15432,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "payload",
           "offset": 0,
@@ -343,7 +343,7 @@
           "type": "t_bytes_storage"
         },
         {
-          "astId": 15344,
+          "astId": 15434,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "validator",
           "offset": 0,
@@ -353,12 +353,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(StakingChangeLog)15364_storage": {
+    "t_struct(StakingChangeLog)15454_storage": {
       "encoding": "inplace",
       "label": "struct StakingChangeLog",
       "members": [
         {
-          "astId": 15354,
+          "astId": 15444,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "nextConfigurationNumber",
           "offset": 0,
@@ -366,7 +366,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15357,
+          "astId": 15447,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "startConfigurationNumber",
           "offset": 8,
@@ -374,22 +374,22 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15363,
+          "astId": 15453,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "changes",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_uint64,t_struct(StakingChange)15345_storage)"
+          "type": "t_mapping(t_uint64,t_struct(StakingChange)15435_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingRelease)15371_storage": {
+    "t_struct(StakingRelease)15461_storage": {
       "encoding": "inplace",
       "label": "struct StakingRelease",
       "members": [
         {
-          "astId": 15367,
+          "astId": 15457,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "releaseAt",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15370,
+          "astId": 15460,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "amount",
           "offset": 0,
@@ -407,12 +407,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(StakingReleaseQueue)15391_storage": {
+    "t_struct(StakingReleaseQueue)15481_storage": {
       "encoding": "inplace",
       "label": "struct StakingReleaseQueue",
       "members": [
         {
-          "astId": 15384,
+          "astId": 15474,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "lockingDuration",
           "offset": 0,
@@ -420,38 +420,38 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15390,
+          "astId": 15480,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "releases",
           "offset": 0,
           "slot": "1",
-          "type": "t_mapping(t_address,t_struct(AddressStakingReleases)15381_storage)"
+          "type": "t_mapping(t_address,t_struct(AddressStakingReleases)15471_storage)"
         }
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(SubnetActorStorage)12991_storage": {
+    "t_struct(SubnetActorStorage)13081_storage": {
       "encoding": "inplace",
       "label": "struct SubnetActorStorage",
       "members": [
         {
-          "astId": 12901,
+          "astId": 12991,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "committedCheckpoints",
           "offset": 0,
           "slot": "0",
-          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15240_storage)"
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15330_storage)"
         },
         {
-          "astId": 12906,
+          "astId": 12996,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "genesisValidators",
           "offset": 0,
           "slot": "1",
-          "type": "t_array(t_struct(Validator)15441_storage)dyn_storage"
+          "type": "t_array(t_struct(Validator)15531_storage)dyn_storage"
         },
         {
-          "astId": 12909,
+          "astId": 12999,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "genesisCircSupply",
           "offset": 0,
@@ -459,7 +459,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 12914,
+          "astId": 13004,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "genesisBalance",
           "offset": 0,
@@ -467,7 +467,7 @@
           "type": "t_mapping(t_address,t_uint256)"
         },
         {
-          "astId": 12918,
+          "astId": 13008,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "genesisBalanceKeys",
           "offset": 0,
@@ -475,7 +475,7 @@
           "type": "t_array(t_address)dyn_storage"
         },
         {
-          "astId": 12921,
+          "astId": 13011,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "lastBottomUpCheckpointHeight",
           "offset": 0,
@@ -483,7 +483,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 12924,
+          "astId": 13014,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "minActivationCollateral",
           "offset": 0,
@@ -491,7 +491,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 12927,
+          "astId": 13017,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "bottomUpCheckPeriod",
           "offset": 0,
@@ -499,7 +499,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 12930,
+          "astId": 13020,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "minValidators",
           "offset": 8,
@@ -507,7 +507,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 12932,
+          "astId": 13022,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "currentSubnetHash",
           "offset": 0,
@@ -515,7 +515,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 12935,
+          "astId": 13025,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "ipcGatewayAddr",
           "offset": 0,
@@ -523,7 +523,7 @@
           "type": "t_address"
         },
         {
-          "astId": 12938,
+          "astId": 13028,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "majorityPercentage",
           "offset": 20,
@@ -531,7 +531,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 12941,
+          "astId": 13031,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "minCrossMsgFee",
           "offset": 0,
@@ -539,15 +539,15 @@
           "type": "t_uint256"
         },
         {
-          "astId": 12945,
+          "astId": 13035,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "parentId",
           "offset": 0,
           "slot": "11",
-          "type": "t_struct(SubnetID)15316_storage"
+          "type": "t_struct(SubnetID)15406_storage"
         },
         {
-          "astId": 12949,
+          "astId": 13039,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "consensus",
           "offset": 0,
@@ -555,7 +555,7 @@
           "type": "t_enum(ConsensusType)5079"
         },
         {
-          "astId": 12952,
+          "astId": 13042,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "bootstrapped",
           "offset": 1,
@@ -563,7 +563,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 12955,
+          "astId": 13045,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "killed",
           "offset": 2,
@@ -571,31 +571,31 @@
           "type": "t_bool"
         },
         {
-          "astId": 12959,
+          "astId": 13049,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "validatorSet",
           "offset": 0,
           "slot": "14",
-          "type": "t_struct(ValidatorSet)15420_storage"
+          "type": "t_struct(ValidatorSet)15510_storage"
         },
         {
-          "astId": 12963,
+          "astId": 13053,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "changeSet",
           "offset": 0,
           "slot": "23",
-          "type": "t_struct(StakingChangeLog)15364_storage"
+          "type": "t_struct(StakingChangeLog)15454_storage"
         },
         {
-          "astId": 12967,
+          "astId": 13057,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "releaseQueue",
           "offset": 0,
           "slot": "25",
-          "type": "t_struct(StakingReleaseQueue)15391_storage"
+          "type": "t_struct(StakingReleaseQueue)15481_storage"
         },
         {
-          "astId": 12970,
+          "astId": 13060,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "powerScale",
           "offset": 0,
@@ -603,7 +603,7 @@
           "type": "t_int8"
         },
         {
-          "astId": 12975,
+          "astId": 13065,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "relayerRewards",
           "offset": 0,
@@ -611,7 +611,7 @@
           "type": "t_mapping(t_address,t_uint256)"
         },
         {
-          "astId": 12981,
+          "astId": 13071,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "rewardedRelayers",
           "offset": 0,
@@ -619,7 +619,7 @@
           "type": "t_mapping(t_uint64,t_struct(AddressSet)3420_storage)"
         },
         {
-          "astId": 12986,
+          "astId": 13076,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "bootstrapNodes",
           "offset": 0,
@@ -627,7 +627,7 @@
           "type": "t_mapping(t_address,t_string_storage)"
         },
         {
-          "astId": 12990,
+          "astId": 13080,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "bootstrapOwners",
           "offset": 0,
@@ -637,12 +637,12 @@
       ],
       "numberOfBytes": "1056"
     },
-    "t_struct(SubnetID)15316_storage": {
+    "t_struct(SubnetID)15406_storage": {
       "encoding": "inplace",
       "label": "struct SubnetID",
       "members": [
         {
-          "astId": 15311,
+          "astId": 15401,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "root",
           "offset": 0,
@@ -650,7 +650,7 @@
           "type": "t_uint64"
         },
         {
-          "astId": 15315,
+          "astId": 15405,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "route",
           "offset": 0,
@@ -660,12 +660,12 @@
       ],
       "numberOfBytes": "64"
     },
-    "t_struct(Validator)15441_storage": {
+    "t_struct(Validator)15531_storage": {
       "encoding": "inplace",
       "label": "struct Validator",
       "members": [
         {
-          "astId": 15436,
+          "astId": 15526,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "weight",
           "offset": 0,
@@ -673,7 +673,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15438,
+          "astId": 15528,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "addr",
           "offset": 0,
@@ -681,7 +681,7 @@
           "type": "t_address"
         },
         {
-          "astId": 15440,
+          "astId": 15530,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "metadata",
           "offset": 0,
@@ -691,12 +691,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorInfo)15399_storage": {
+    "t_struct(ValidatorInfo)15489_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorInfo",
       "members": [
         {
-          "astId": 15393,
+          "astId": 15483,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "confirmedCollateral",
           "offset": 0,
@@ -704,7 +704,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15395,
+          "astId": 15485,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "totalCollateral",
           "offset": 0,
@@ -712,7 +712,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15398,
+          "astId": 15488,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "metadata",
           "offset": 0,
@@ -722,12 +722,12 @@
       ],
       "numberOfBytes": "96"
     },
-    "t_struct(ValidatorSet)15420_storage": {
+    "t_struct(ValidatorSet)15510_storage": {
       "encoding": "inplace",
       "label": "struct ValidatorSet",
       "members": [
         {
-          "astId": 15402,
+          "astId": 15492,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "activeLimit",
           "offset": 0,
@@ -735,7 +735,7 @@
           "type": "t_uint16"
         },
         {
-          "astId": 15405,
+          "astId": 15495,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "totalConfirmedCollateral",
           "offset": 0,
@@ -743,28 +743,28 @@
           "type": "t_uint256"
         },
         {
-          "astId": 15411,
+          "astId": 15501,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "validators",
           "offset": 0,
           "slot": "2",
-          "type": "t_mapping(t_address,t_struct(ValidatorInfo)15399_storage)"
+          "type": "t_mapping(t_address,t_struct(ValidatorInfo)15489_storage)"
         },
         {
-          "astId": 15415,
+          "astId": 15505,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "activeValidators",
           "offset": 0,
           "slot": "3",
-          "type": "t_struct(MinPQ)14367_storage"
+          "type": "t_struct(MinPQ)14457_storage"
         },
         {
-          "astId": 15419,
+          "astId": 15509,
           "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
           "label": "waitingValidators",
           "offset": 0,
           "slot": "6",
-          "type": "t_struct(MaxPQ)13748_storage"
+          "type": "t_struct(MaxPQ)13838_storage"
         }
       ],
       "numberOfBytes": "288"

--- a/src/errors/IPCErrors.sol
+++ b/src/errors/IPCErrors.sol
@@ -9,7 +9,6 @@ error CannotSendCrossMsgToItself();
 error CheckpointAlreadyExists();
 error CheckpointAlreadyProcessed();
 error CheckpointInfoAlreadyExists();
-error CheckpointMembershipNotCreated();
 error CheckpointNotCreated();
 error CollateralIsZero();
 error EmptyAddress();


### PR DESCRIPTION
Remove the check on `checkpointInfo.threshold` due to:
- 0 threshold is also valid threshold.
- Checkpoint info is created together with checkpoint, as long as checkpoint is created, checkpoint info will be created. Checking checkpoint should be enough.