### PR TITLE
IPC-304: add permissioned flag to disable validator changes

### DIFF
--- a/.storage-layouts/GatewayActorModifiers.json
+++ b/.storage-layouts/GatewayActorModifiers.json
@@ -1,1063 +1,1063 @@
 {
-    "storage": [
-        {
-            "astId": 10262,
-            "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-            "label": "s",
-            "offset": 0,
-            "slot": "0",
-            "type": "t_struct(GatewayActorStorage)10248_storage"
-        }
-    ],
-    "types": {
-        "t_address": {
-            "encoding": "inplace",
-            "label": "address",
-            "numberOfBytes": "20"
-        },
-        "t_array(t_address)dyn_storage": {
-            "base": "t_address",
-            "encoding": "dynamic_array",
-            "label": "address[]",
-            "numberOfBytes": "32"
-        },
-        "t_array(t_bytes32)dyn_storage": {
-            "base": "t_bytes32",
-            "encoding": "dynamic_array",
-            "label": "bytes32[]",
-            "numberOfBytes": "32"
-        },
-        "t_array(t_struct(CrossMsg)15268_storage)dyn_storage": {
-            "base": "t_struct(CrossMsg)15268_storage",
-            "encoding": "dynamic_array",
-            "label": "struct CrossMsg[]",
-            "numberOfBytes": "32"
-        },
-        "t_array(t_struct(Validator)15447_storage)dyn_storage": {
-            "base": "t_struct(Validator)15447_storage",
-            "encoding": "dynamic_array",
-            "label": "struct Validator[]",
-            "numberOfBytes": "32"
-        },
-        "t_bool": {
-            "encoding": "inplace",
-            "label": "bool",
-            "numberOfBytes": "1"
-        },
-        "t_bytes32": {
-            "encoding": "inplace",
-            "label": "bytes32",
-            "numberOfBytes": "32"
-        },
-        "t_bytes4": {
-            "encoding": "inplace",
-            "label": "bytes4",
-            "numberOfBytes": "4"
-        },
-        "t_bytes_storage": {
-            "encoding": "bytes",
-            "label": "bytes",
-            "numberOfBytes": "32"
-        },
-        "t_enum(StakingOperation)15343": {
-            "encoding": "inplace",
-            "label": "enum StakingOperation",
-            "numberOfBytes": "1"
-        },
-        "t_enum(Status)5075": {
-            "encoding": "inplace",
-            "label": "enum Status",
-            "numberOfBytes": "1"
-        },
-        "t_mapping(t_address,t_bytes_storage)": {
-            "encoding": "mapping",
-            "key": "t_address",
-            "label": "mapping(address => bytes)",
-            "numberOfBytes": "32",
-            "value": "t_bytes_storage"
-        },
-        "t_mapping(t_address,t_struct(ValidatorInfo)15405_storage)": {
-            "encoding": "mapping",
-            "key": "t_address",
-            "label": "mapping(address => struct ValidatorInfo)",
-            "numberOfBytes": "32",
-            "value": "t_struct(ValidatorInfo)15405_storage"
-        },
-        "t_mapping(t_address,t_uint16)": {
-            "encoding": "mapping",
-            "key": "t_address",
-            "label": "mapping(address => uint16)",
-            "numberOfBytes": "32",
-            "value": "t_uint16"
-        },
-        "t_mapping(t_bytes32,t_struct(CrossMsg)15268_storage)": {
-            "encoding": "mapping",
-            "key": "t_bytes32",
-            "label": "mapping(bytes32 => struct CrossMsg)",
-            "numberOfBytes": "32",
-            "value": "t_struct(CrossMsg)15268_storage"
-        },
-        "t_mapping(t_bytes32,t_struct(Subnet)15339_storage)": {
-            "encoding": "mapping",
-            "key": "t_bytes32",
-            "label": "mapping(bytes32 => struct Subnet)",
-            "numberOfBytes": "32",
-            "value": "t_struct(Subnet)15339_storage"
-        },
-        "t_mapping(t_bytes32,t_uint256)": {
-            "encoding": "mapping",
-            "key": "t_bytes32",
-            "label": "mapping(bytes32 => uint256)",
-            "numberOfBytes": "32",
-            "value": "t_uint256"
-        },
-        "t_mapping(t_uint16,t_address)": {
-            "encoding": "mapping",
-            "key": "t_uint16",
-            "label": "mapping(uint16 => address)",
-            "numberOfBytes": "32",
-            "value": "t_address"
-        },
-        "t_mapping(t_uint256,t_struct(ParentFinality)15229_storage)": {
-            "encoding": "mapping",
-            "key": "t_uint256",
-            "label": "mapping(uint256 => struct ParentFinality)",
-            "numberOfBytes": "32",
-            "value": "t_struct(ParentFinality)15229_storage"
-        },
-        "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15268_storage)dyn_storage)": {
-            "encoding": "mapping",
-            "key": "t_uint64",
-            "label": "mapping(uint64 => struct CrossMsg[])",
-            "numberOfBytes": "32",
-            "value": "t_array(t_struct(CrossMsg)15268_storage)dyn_storage"
-        },
-        "t_mapping(t_uint64,t_mapping(t_address,t_bytes_storage))": {
-            "encoding": "mapping",
-            "key": "t_uint64",
-            "label": "mapping(uint64 => mapping(address => bytes))",
-            "numberOfBytes": "32",
-            "value": "t_mapping(t_address,t_bytes_storage)"
-        },
-        "t_mapping(t_uint64,t_mapping(t_bytes32,t_uint256))": {
-            "encoding": "mapping",
-            "key": "t_uint64",
-            "label": "mapping(uint64 => mapping(bytes32 => uint256))",
-            "numberOfBytes": "32",
-            "value": "t_mapping(t_bytes32,t_uint256)"
-        },
-        "t_mapping(t_uint64,t_struct(AddressSet)3351_storage)": {
-            "encoding": "mapping",
-            "key": "t_uint64",
-            "label": "mapping(uint64 => struct EnumerableSet.AddressSet)",
-            "numberOfBytes": "32",
-            "value": "t_struct(AddressSet)3351_storage"
-        },
-        "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15246_storage)": {
-            "encoding": "mapping",
-            "key": "t_uint64",
-            "label": "mapping(uint64 => struct BottomUpCheckpoint)",
-            "numberOfBytes": "32",
-            "value": "t_struct(BottomUpCheckpoint)15246_storage"
-        },
-        "t_mapping(t_uint64,t_struct(CheckpointInfo)15262_storage)": {
-            "encoding": "mapping",
-            "key": "t_uint64",
-            "label": "mapping(uint64 => struct CheckpointInfo)",
-            "numberOfBytes": "32",
-            "value": "t_struct(CheckpointInfo)15262_storage"
-        },
-        "t_mapping(t_uint64,t_struct(StakingChange)15351_storage)": {
-            "encoding": "mapping",
-            "key": "t_uint64",
-            "label": "mapping(uint64 => struct StakingChange)",
-            "numberOfBytes": "32",
-            "value": "t_struct(StakingChange)15351_storage"
-        },
-        "t_struct(AddressSet)3351_storage": {
-            "encoding": "inplace",
-            "label": "struct EnumerableSet.AddressSet",
-            "members": [
-                {
-                    "astId": 3350,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "_inner",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(Set)3036_storage"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(BottomUpCheckpoint)15246_storage": {
-            "encoding": "inplace",
-            "label": "struct BottomUpCheckpoint",
-            "members": [
-                {
-                    "astId": 15233,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "subnetID",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(SubnetID)15322_storage"
-                },
-                {
-                    "astId": 15236,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "blockHeight",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15239,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "blockHash",
-                    "offset": 0,
-                    "slot": "3",
-                    "type": "t_bytes32"
-                },
-                {
-                    "astId": 15242,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "nextConfigurationNumber",
-                    "offset": 0,
-                    "slot": "4",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15245,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "crossMessagesHash",
-                    "offset": 0,
-                    "slot": "5",
-                    "type": "t_bytes32"
-                }
-            ],
-            "numberOfBytes": "192"
-        },
-        "t_struct(CheckpointInfo)15262_storage": {
-            "encoding": "inplace",
-            "label": "struct CheckpointInfo",
-            "members": [
-                {
-                    "astId": 15249,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "hash",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_bytes32"
-                },
-                {
-                    "astId": 15252,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "rootHash",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_bytes32"
-                },
-                {
-                    "astId": 15255,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "threshold",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15258,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "currentWeight",
-                    "offset": 0,
-                    "slot": "3",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15261,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "reached",
-                    "offset": 0,
-                    "slot": "4",
-                    "type": "t_bool"
-                }
-            ],
-            "numberOfBytes": "160"
-        },
-        "t_struct(CrossMsg)15268_storage": {
-            "encoding": "inplace",
-            "label": "struct CrossMsg",
-            "members": [
-                {
-                    "astId": 15265,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "message",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(StorableMsg)15285_storage"
-                },
-                {
-                    "astId": 15267,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "wrapped",
-                    "offset": 0,
-                    "slot": "12",
-                    "type": "t_bool"
-                }
-            ],
-            "numberOfBytes": "416"
-        },
-        "t_struct(FvmAddress)15292_storage": {
-            "encoding": "inplace",
-            "label": "struct FvmAddress",
-            "members": [
-                {
-                    "astId": 15289,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "addrType",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint8"
-                },
-                {
-                    "astId": 15291,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "payload",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_bytes_storage"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(GatewayActorStorage)10248_storage": {
-            "encoding": "inplace",
-            "label": "struct GatewayActorStorage",
-            "members": [
-                {
-                    "astId": 10146,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "subnets",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_mapping(t_bytes32,t_struct(Subnet)15339_storage)"
-                },
-                {
-                    "astId": 10152,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "finalitiesMap",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_mapping(t_uint256,t_struct(ParentFinality)15229_storage)"
-                },
-                {
-                    "astId": 10155,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "latestParentHeight",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 10161,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "postbox",
-                    "offset": 0,
-                    "slot": "3",
-                    "type": "t_mapping(t_bytes32,t_struct(CrossMsg)15268_storage)"
-                },
-                {
-                    "astId": 10168,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "validatorSetWeights",
-                    "offset": 0,
-                    "slot": "4",
-                    "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_uint256))"
-                },
-                {
-                    "astId": 10172,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "currentMembership",
-                    "offset": 0,
-                    "slot": "5",
-                    "type": "t_struct(Membership)15454_storage"
-                },
-                {
-                    "astId": 10176,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "lastMembership",
-                    "offset": 0,
-                    "slot": "7",
-                    "type": "t_struct(Membership)15454_storage"
-                },
-                {
-                    "astId": 10182,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "bottomUpCheckpoints",
-                    "offset": 0,
-                    "slot": "9",
-                    "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15246_storage)"
-                },
-                {
-                    "astId": 10188,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "bottomUpCheckpointInfo",
-                    "offset": 0,
-                    "slot": "10",
-                    "type": "t_mapping(t_uint64,t_struct(CheckpointInfo)15262_storage)"
-                },
-                {
-                    "astId": 10195,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "bottomUpMessages",
-                    "offset": 0,
-                    "slot": "11",
-                    "type": "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15268_storage)dyn_storage)"
-                },
-                {
-                    "astId": 10198,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "bottomUpCheckpointRetentionHeight",
-                    "offset": 0,
-                    "slot": "12",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 10202,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "incompleteCheckpoints",
-                    "offset": 0,
-                    "slot": "13",
-                    "type": "t_struct(UintSet)3508_storage"
-                },
-                {
-                    "astId": 10208,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "bottomUpSignatureSenders",
-                    "offset": 0,
-                    "slot": "15",
-                    "type": "t_mapping(t_uint64,t_struct(AddressSet)3351_storage)"
-                },
-                {
-                    "astId": 10215,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "bottomUpSignatures",
-                    "offset": 0,
-                    "slot": "16",
-                    "type": "t_mapping(t_uint64,t_mapping(t_address,t_bytes_storage))"
-                },
-                {
-                    "astId": 10219,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "subnetKeys",
-                    "offset": 0,
-                    "slot": "17",
-                    "type": "t_array(t_bytes32)dyn_storage"
-                },
-                {
-                    "astId": 10223,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "networkName",
-                    "offset": 0,
-                    "slot": "18",
-                    "type": "t_struct(SubnetID)15322_storage"
-                },
-                {
-                    "astId": 10226,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "minStake",
-                    "offset": 0,
-                    "slot": "20",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 10229,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "minCrossMsgFee",
-                    "offset": 0,
-                    "slot": "21",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 10232,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "majorityPercentage",
-                    "offset": 0,
-                    "slot": "22",
-                    "type": "t_uint8"
-                },
-                {
-                    "astId": 10235,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "bottomUpNonce",
-                    "offset": 1,
-                    "slot": "22",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 10238,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "appliedTopDownNonce",
-                    "offset": 9,
-                    "slot": "22",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 10241,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "totalSubnets",
-                    "offset": 17,
-                    "slot": "22",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 10243,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "bottomUpCheckPeriod",
-                    "offset": 0,
-                    "slot": "23",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 10247,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "validatorsTracker",
-                    "offset": 0,
-                    "slot": "24",
-                    "type": "t_struct(ParentValidatorsTracker)15433_storage"
-                }
-            ],
-            "numberOfBytes": "1120"
-        },
-        "t_struct(IPCAddress)15440_storage": {
-            "encoding": "inplace",
-            "label": "struct IPCAddress",
-            "members": [
-                {
-                    "astId": 15436,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "subnetId",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(SubnetID)15322_storage"
-                },
-                {
-                    "astId": 15439,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "rawAddress",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_struct(FvmAddress)15292_storage"
-                }
-            ],
-            "numberOfBytes": "128"
-        },
-        "t_struct(MaxPQ)13754_storage": {
-            "encoding": "inplace",
-            "label": "struct MaxPQ",
-            "members": [
-                {
-                    "astId": 13753,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "inner",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(PQ)15003_storage"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(Membership)15454_storage": {
-            "encoding": "inplace",
-            "label": "struct Membership",
-            "members": [
-                {
-                    "astId": 15451,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "validators",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_array(t_struct(Validator)15447_storage)dyn_storage"
-                },
-                {
-                    "astId": 15453,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "configurationNumber",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_uint64"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(MinPQ)14373_storage": {
-            "encoding": "inplace",
-            "label": "struct MinPQ",
-            "members": [
-                {
-                    "astId": 14372,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "inner",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(PQ)15003_storage"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(PQ)15003_storage": {
-            "encoding": "inplace",
-            "label": "struct PQ",
-            "members": [
-                {
-                    "astId": 14992,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "size",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint16"
-                },
-                {
-                    "astId": 14997,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "addressToPos",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_mapping(t_address,t_uint16)"
-                },
-                {
-                    "astId": 15002,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "posToAddress",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_mapping(t_uint16,t_address)"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(ParentFinality)15229_storage": {
-            "encoding": "inplace",
-            "label": "struct ParentFinality",
-            "members": [
-                {
-                    "astId": 15226,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "height",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15228,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "blockHash",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_bytes32"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(ParentValidatorsTracker)15433_storage": {
-            "encoding": "inplace",
-            "label": "struct ParentValidatorsTracker",
-            "members": [
-                {
-                    "astId": 15429,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "validators",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(ValidatorSet)15426_storage"
-                },
-                {
-                    "astId": 15432,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "changes",
-                    "offset": 0,
-                    "slot": "9",
-                    "type": "t_struct(StakingChangeLog)15370_storage"
-                }
-            ],
-            "numberOfBytes": "352"
-        },
-        "t_struct(Set)3036_storage": {
-            "encoding": "inplace",
-            "label": "struct EnumerableSet.Set",
-            "members": [
-                {
-                    "astId": 3031,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "_values",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_array(t_bytes32)dyn_storage"
-                },
-                {
-                    "astId": 3035,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "_indexes",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_mapping(t_bytes32,t_uint256)"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(StakingChange)15351_storage": {
-            "encoding": "inplace",
-            "label": "struct StakingChange",
-            "members": [
-                {
-                    "astId": 15346,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "op",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_enum(StakingOperation)15343"
-                },
-                {
-                    "astId": 15348,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "payload",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_bytes_storage"
-                },
-                {
-                    "astId": 15350,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "validator",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_address"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(StakingChangeLog)15370_storage": {
-            "encoding": "inplace",
-            "label": "struct StakingChangeLog",
-            "members": [
-                {
-                    "astId": 15360,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "nextConfigurationNumber",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15363,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "startConfigurationNumber",
-                    "offset": 8,
-                    "slot": "0",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15369,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "changes",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_mapping(t_uint64,t_struct(StakingChange)15351_storage)"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(StorableMsg)15285_storage": {
-            "encoding": "inplace",
-            "label": "struct StorableMsg",
-            "members": [
-                {
-                    "astId": 15271,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "from",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(IPCAddress)15440_storage"
-                },
-                {
-                    "astId": 15274,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "to",
-                    "offset": 0,
-                    "slot": "4",
-                    "type": "t_struct(IPCAddress)15440_storage"
-                },
-                {
-                    "astId": 15276,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "value",
-                    "offset": 0,
-                    "slot": "8",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15278,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "nonce",
-                    "offset": 0,
-                    "slot": "9",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15280,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "method",
-                    "offset": 8,
-                    "slot": "9",
-                    "type": "t_bytes4"
-                },
-                {
-                    "astId": 15282,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "params",
-                    "offset": 0,
-                    "slot": "10",
-                    "type": "t_bytes_storage"
-                },
-                {
-                    "astId": 15284,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "fee",
-                    "offset": 0,
-                    "slot": "11",
-                    "type": "t_uint256"
-                }
-            ],
-            "numberOfBytes": "384"
-        },
-        "t_struct(Subnet)15339_storage": {
-            "encoding": "inplace",
-            "label": "struct Subnet",
-            "members": [
-                {
-                    "astId": 15324,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "stake",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15326,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "genesisEpoch",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15328,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "circSupply",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15330,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "topDownNonce",
-                    "offset": 0,
-                    "slot": "3",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15332,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "appliedBottomUpNonce",
-                    "offset": 8,
-                    "slot": "3",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15335,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "status",
-                    "offset": 16,
-                    "slot": "3",
-                    "type": "t_enum(Status)5075"
-                },
-                {
-                    "astId": 15338,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "id",
-                    "offset": 0,
-                    "slot": "4",
-                    "type": "t_struct(SubnetID)15322_storage"
-                }
-            ],
-            "numberOfBytes": "192"
-        },
-        "t_struct(SubnetID)15322_storage": {
-            "encoding": "inplace",
-            "label": "struct SubnetID",
-            "members": [
-                {
-                    "astId": 15317,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "root",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15321,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "route",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_array(t_address)dyn_storage"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(UintSet)3508_storage": {
-            "encoding": "inplace",
-            "label": "struct EnumerableSet.UintSet",
-            "members": [
-                {
-                    "astId": 3507,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "_inner",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(Set)3036_storage"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(Validator)15447_storage": {
-            "encoding": "inplace",
-            "label": "struct Validator",
-            "members": [
-                {
-                    "astId": 15442,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "weight",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15444,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "addr",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_address"
-                },
-                {
-                    "astId": 15446,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "metadata",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_bytes_storage"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(ValidatorInfo)15405_storage": {
-            "encoding": "inplace",
-            "label": "struct ValidatorInfo",
-            "members": [
-                {
-                    "astId": 15399,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "confirmedCollateral",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15401,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "totalCollateral",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15404,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "metadata",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_bytes_storage"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(ValidatorSet)15426_storage": {
-            "encoding": "inplace",
-            "label": "struct ValidatorSet",
-            "members": [
-                {
-                    "astId": 15408,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "activeLimit",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint16"
-                },
-                {
-                    "astId": 15411,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "totalConfirmedCollateral",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15417,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "validators",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_mapping(t_address,t_struct(ValidatorInfo)15405_storage)"
-                },
-                {
-                    "astId": 15421,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "activeValidators",
-                    "offset": 0,
-                    "slot": "3",
-                    "type": "t_struct(MinPQ)14373_storage"
-                },
-                {
-                    "astId": 15425,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "waitingValidators",
-                    "offset": 0,
-                    "slot": "6",
-                    "type": "t_struct(MaxPQ)13754_storage"
-                }
-            ],
-            "numberOfBytes": "288"
-        },
-        "t_uint16": {
-            "encoding": "inplace",
-            "label": "uint16",
-            "numberOfBytes": "2"
-        },
-        "t_uint256": {
-            "encoding": "inplace",
-            "label": "uint256",
-            "numberOfBytes": "32"
-        },
-        "t_uint64": {
-            "encoding": "inplace",
-            "label": "uint64",
-            "numberOfBytes": "8"
-        },
-        "t_uint8": {
-            "encoding": "inplace",
-            "label": "uint8",
-            "numberOfBytes": "1"
-        }
+  "storage": [
+    {
+      "astId": 10204,
+      "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+      "label": "s",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_struct(GatewayActorStorage)10190_storage"
     }
+  ],
+  "types": {
+    "t_address": {
+      "encoding": "inplace",
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "base": "t_address",
+      "encoding": "dynamic_array",
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_bytes32)dyn_storage": {
+      "base": "t_bytes32",
+      "encoding": "dynamic_array",
+      "label": "bytes32[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_struct(CrossMsg)15198_storage)dyn_storage": {
+      "base": "t_struct(CrossMsg)15198_storage",
+      "encoding": "dynamic_array",
+      "label": "struct CrossMsg[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_struct(Validator)15377_storage)dyn_storage": {
+      "base": "t_struct(Validator)15377_storage",
+      "encoding": "dynamic_array",
+      "label": "struct Validator[]",
+      "numberOfBytes": "32"
+    },
+    "t_bool": {
+      "encoding": "inplace",
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_bytes32": {
+      "encoding": "inplace",
+      "label": "bytes32",
+      "numberOfBytes": "32"
+    },
+    "t_bytes4": {
+      "encoding": "inplace",
+      "label": "bytes4",
+      "numberOfBytes": "4"
+    },
+    "t_bytes_storage": {
+      "encoding": "bytes",
+      "label": "bytes",
+      "numberOfBytes": "32"
+    },
+    "t_enum(StakingOperation)15273": {
+      "encoding": "inplace",
+      "label": "enum StakingOperation",
+      "numberOfBytes": "1"
+    },
+    "t_enum(Status)5083": {
+      "encoding": "inplace",
+      "label": "enum Status",
+      "numberOfBytes": "1"
+    },
+    "t_mapping(t_address,t_bytes_storage)": {
+      "encoding": "mapping",
+      "key": "t_address",
+      "label": "mapping(address => bytes)",
+      "numberOfBytes": "32",
+      "value": "t_bytes_storage"
+    },
+    "t_mapping(t_address,t_struct(ValidatorInfo)15335_storage)": {
+      "encoding": "mapping",
+      "key": "t_address",
+      "label": "mapping(address => struct ValidatorInfo)",
+      "numberOfBytes": "32",
+      "value": "t_struct(ValidatorInfo)15335_storage"
+    },
+    "t_mapping(t_address,t_uint16)": {
+      "encoding": "mapping",
+      "key": "t_address",
+      "label": "mapping(address => uint16)",
+      "numberOfBytes": "32",
+      "value": "t_uint16"
+    },
+    "t_mapping(t_bytes32,t_struct(CrossMsg)15198_storage)": {
+      "encoding": "mapping",
+      "key": "t_bytes32",
+      "label": "mapping(bytes32 => struct CrossMsg)",
+      "numberOfBytes": "32",
+      "value": "t_struct(CrossMsg)15198_storage"
+    },
+    "t_mapping(t_bytes32,t_struct(Subnet)15269_storage)": {
+      "encoding": "mapping",
+      "key": "t_bytes32",
+      "label": "mapping(bytes32 => struct Subnet)",
+      "numberOfBytes": "32",
+      "value": "t_struct(Subnet)15269_storage"
+    },
+    "t_mapping(t_bytes32,t_uint256)": {
+      "encoding": "mapping",
+      "key": "t_bytes32",
+      "label": "mapping(bytes32 => uint256)",
+      "numberOfBytes": "32",
+      "value": "t_uint256"
+    },
+    "t_mapping(t_uint16,t_address)": {
+      "encoding": "mapping",
+      "key": "t_uint16",
+      "label": "mapping(uint16 => address)",
+      "numberOfBytes": "32",
+      "value": "t_address"
+    },
+    "t_mapping(t_uint256,t_struct(ParentFinality)15159_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint256",
+      "label": "mapping(uint256 => struct ParentFinality)",
+      "numberOfBytes": "32",
+      "value": "t_struct(ParentFinality)15159_storage"
+    },
+    "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15198_storage)dyn_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint64",
+      "label": "mapping(uint64 => struct CrossMsg[])",
+      "numberOfBytes": "32",
+      "value": "t_array(t_struct(CrossMsg)15198_storage)dyn_storage"
+    },
+    "t_mapping(t_uint64,t_mapping(t_address,t_bytes_storage))": {
+      "encoding": "mapping",
+      "key": "t_uint64",
+      "label": "mapping(uint64 => mapping(address => bytes))",
+      "numberOfBytes": "32",
+      "value": "t_mapping(t_address,t_bytes_storage)"
+    },
+    "t_mapping(t_uint64,t_mapping(t_bytes32,t_uint256))": {
+      "encoding": "mapping",
+      "key": "t_uint64",
+      "label": "mapping(uint64 => mapping(bytes32 => uint256))",
+      "numberOfBytes": "32",
+      "value": "t_mapping(t_bytes32,t_uint256)"
+    },
+    "t_mapping(t_uint64,t_struct(AddressSet)3351_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint64",
+      "label": "mapping(uint64 => struct EnumerableSet.AddressSet)",
+      "numberOfBytes": "32",
+      "value": "t_struct(AddressSet)3351_storage"
+    },
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15176_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint64",
+      "label": "mapping(uint64 => struct BottomUpCheckpoint)",
+      "numberOfBytes": "32",
+      "value": "t_struct(BottomUpCheckpoint)15176_storage"
+    },
+    "t_mapping(t_uint64,t_struct(CheckpointInfo)15192_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint64",
+      "label": "mapping(uint64 => struct CheckpointInfo)",
+      "numberOfBytes": "32",
+      "value": "t_struct(CheckpointInfo)15192_storage"
+    },
+    "t_mapping(t_uint64,t_struct(StakingChange)15281_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint64",
+      "label": "mapping(uint64 => struct StakingChange)",
+      "numberOfBytes": "32",
+      "value": "t_struct(StakingChange)15281_storage"
+    },
+    "t_struct(AddressSet)3351_storage": {
+      "encoding": "inplace",
+      "label": "struct EnumerableSet.AddressSet",
+      "members": [
+        {
+          "astId": 3350,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "_inner",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(Set)3036_storage"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(BottomUpCheckpoint)15176_storage": {
+      "encoding": "inplace",
+      "label": "struct BottomUpCheckpoint",
+      "members": [
+        {
+          "astId": 15163,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "subnetID",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(SubnetID)15252_storage"
+        },
+        {
+          "astId": 15166,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "blockHeight",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15169,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "blockHash",
+          "offset": 0,
+          "slot": "3",
+          "type": "t_bytes32"
+        },
+        {
+          "astId": 15172,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "nextConfigurationNumber",
+          "offset": 0,
+          "slot": "4",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15175,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "crossMessagesHash",
+          "offset": 0,
+          "slot": "5",
+          "type": "t_bytes32"
+        }
+      ],
+      "numberOfBytes": "192"
+    },
+    "t_struct(CheckpointInfo)15192_storage": {
+      "encoding": "inplace",
+      "label": "struct CheckpointInfo",
+      "members": [
+        {
+          "astId": 15179,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "hash",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_bytes32"
+        },
+        {
+          "astId": 15182,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "rootHash",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_bytes32"
+        },
+        {
+          "astId": 15185,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "threshold",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15188,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "currentWeight",
+          "offset": 0,
+          "slot": "3",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15191,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "reached",
+          "offset": 0,
+          "slot": "4",
+          "type": "t_bool"
+        }
+      ],
+      "numberOfBytes": "160"
+    },
+    "t_struct(CrossMsg)15198_storage": {
+      "encoding": "inplace",
+      "label": "struct CrossMsg",
+      "members": [
+        {
+          "astId": 15195,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "message",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(StorableMsg)15215_storage"
+        },
+        {
+          "astId": 15197,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "wrapped",
+          "offset": 0,
+          "slot": "12",
+          "type": "t_bool"
+        }
+      ],
+      "numberOfBytes": "416"
+    },
+    "t_struct(FvmAddress)15222_storage": {
+      "encoding": "inplace",
+      "label": "struct FvmAddress",
+      "members": [
+        {
+          "astId": 15219,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "addrType",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint8"
+        },
+        {
+          "astId": 15221,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "payload",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_bytes_storage"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(GatewayActorStorage)10190_storage": {
+      "encoding": "inplace",
+      "label": "struct GatewayActorStorage",
+      "members": [
+        {
+          "astId": 10088,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "subnets",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_mapping(t_bytes32,t_struct(Subnet)15269_storage)"
+        },
+        {
+          "astId": 10094,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "finalitiesMap",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_mapping(t_uint256,t_struct(ParentFinality)15159_storage)"
+        },
+        {
+          "astId": 10097,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "latestParentHeight",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 10103,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "postbox",
+          "offset": 0,
+          "slot": "3",
+          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)15198_storage)"
+        },
+        {
+          "astId": 10110,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "validatorSetWeights",
+          "offset": 0,
+          "slot": "4",
+          "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_uint256))"
+        },
+        {
+          "astId": 10114,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "currentMembership",
+          "offset": 0,
+          "slot": "5",
+          "type": "t_struct(Membership)15384_storage"
+        },
+        {
+          "astId": 10118,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "lastMembership",
+          "offset": 0,
+          "slot": "7",
+          "type": "t_struct(Membership)15384_storage"
+        },
+        {
+          "astId": 10124,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "bottomUpCheckpoints",
+          "offset": 0,
+          "slot": "9",
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15176_storage)"
+        },
+        {
+          "astId": 10130,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "bottomUpCheckpointInfo",
+          "offset": 0,
+          "slot": "10",
+          "type": "t_mapping(t_uint64,t_struct(CheckpointInfo)15192_storage)"
+        },
+        {
+          "astId": 10137,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "bottomUpMessages",
+          "offset": 0,
+          "slot": "11",
+          "type": "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15198_storage)dyn_storage)"
+        },
+        {
+          "astId": 10140,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "bottomUpCheckpointRetentionHeight",
+          "offset": 0,
+          "slot": "12",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 10144,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "incompleteCheckpoints",
+          "offset": 0,
+          "slot": "13",
+          "type": "t_struct(UintSet)3508_storage"
+        },
+        {
+          "astId": 10150,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "bottomUpSignatureSenders",
+          "offset": 0,
+          "slot": "15",
+          "type": "t_mapping(t_uint64,t_struct(AddressSet)3351_storage)"
+        },
+        {
+          "astId": 10157,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "bottomUpSignatures",
+          "offset": 0,
+          "slot": "16",
+          "type": "t_mapping(t_uint64,t_mapping(t_address,t_bytes_storage))"
+        },
+        {
+          "astId": 10161,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "subnetKeys",
+          "offset": 0,
+          "slot": "17",
+          "type": "t_array(t_bytes32)dyn_storage"
+        },
+        {
+          "astId": 10165,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "networkName",
+          "offset": 0,
+          "slot": "18",
+          "type": "t_struct(SubnetID)15252_storage"
+        },
+        {
+          "astId": 10168,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "minStake",
+          "offset": 0,
+          "slot": "20",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 10171,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "minCrossMsgFee",
+          "offset": 0,
+          "slot": "21",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 10174,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "majorityPercentage",
+          "offset": 0,
+          "slot": "22",
+          "type": "t_uint8"
+        },
+        {
+          "astId": 10177,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "bottomUpNonce",
+          "offset": 1,
+          "slot": "22",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 10180,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "appliedTopDownNonce",
+          "offset": 9,
+          "slot": "22",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 10183,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "totalSubnets",
+          "offset": 17,
+          "slot": "22",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 10185,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "bottomUpCheckPeriod",
+          "offset": 0,
+          "slot": "23",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 10189,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "validatorsTracker",
+          "offset": 0,
+          "slot": "24",
+          "type": "t_struct(ParentValidatorsTracker)15363_storage"
+        }
+      ],
+      "numberOfBytes": "1120"
+    },
+    "t_struct(IPCAddress)15370_storage": {
+      "encoding": "inplace",
+      "label": "struct IPCAddress",
+      "members": [
+        {
+          "astId": 15366,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "subnetId",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(SubnetID)15252_storage"
+        },
+        {
+          "astId": 15369,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "rawAddress",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_struct(FvmAddress)15222_storage"
+        }
+      ],
+      "numberOfBytes": "128"
+    },
+    "t_struct(MaxPQ)13686_storage": {
+      "encoding": "inplace",
+      "label": "struct MaxPQ",
+      "members": [
+        {
+          "astId": 13685,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "inner",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(PQ)14933_storage"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(Membership)15384_storage": {
+      "encoding": "inplace",
+      "label": "struct Membership",
+      "members": [
+        {
+          "astId": 15381,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "validators",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_array(t_struct(Validator)15377_storage)dyn_storage"
+        },
+        {
+          "astId": 15383,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "configurationNumber",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_uint64"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(MinPQ)14304_storage": {
+      "encoding": "inplace",
+      "label": "struct MinPQ",
+      "members": [
+        {
+          "astId": 14303,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "inner",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(PQ)14933_storage"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(PQ)14933_storage": {
+      "encoding": "inplace",
+      "label": "struct PQ",
+      "members": [
+        {
+          "astId": 14922,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "size",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint16"
+        },
+        {
+          "astId": 14927,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "addressToPos",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_mapping(t_address,t_uint16)"
+        },
+        {
+          "astId": 14932,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "posToAddress",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_mapping(t_uint16,t_address)"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(ParentFinality)15159_storage": {
+      "encoding": "inplace",
+      "label": "struct ParentFinality",
+      "members": [
+        {
+          "astId": 15156,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "height",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15158,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "blockHash",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_bytes32"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(ParentValidatorsTracker)15363_storage": {
+      "encoding": "inplace",
+      "label": "struct ParentValidatorsTracker",
+      "members": [
+        {
+          "astId": 15359,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "validators",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(ValidatorSet)15356_storage"
+        },
+        {
+          "astId": 15362,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "changes",
+          "offset": 0,
+          "slot": "9",
+          "type": "t_struct(StakingChangeLog)15300_storage"
+        }
+      ],
+      "numberOfBytes": "352"
+    },
+    "t_struct(Set)3036_storage": {
+      "encoding": "inplace",
+      "label": "struct EnumerableSet.Set",
+      "members": [
+        {
+          "astId": 3031,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "_values",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_array(t_bytes32)dyn_storage"
+        },
+        {
+          "astId": 3035,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "_indexes",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_mapping(t_bytes32,t_uint256)"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(StakingChange)15281_storage": {
+      "encoding": "inplace",
+      "label": "struct StakingChange",
+      "members": [
+        {
+          "astId": 15276,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "op",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_enum(StakingOperation)15273"
+        },
+        {
+          "astId": 15278,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "payload",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_bytes_storage"
+        },
+        {
+          "astId": 15280,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "validator",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_address"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(StakingChangeLog)15300_storage": {
+      "encoding": "inplace",
+      "label": "struct StakingChangeLog",
+      "members": [
+        {
+          "astId": 15290,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "nextConfigurationNumber",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15293,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "startConfigurationNumber",
+          "offset": 8,
+          "slot": "0",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15299,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "changes",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_mapping(t_uint64,t_struct(StakingChange)15281_storage)"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(StorableMsg)15215_storage": {
+      "encoding": "inplace",
+      "label": "struct StorableMsg",
+      "members": [
+        {
+          "astId": 15201,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "from",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(IPCAddress)15370_storage"
+        },
+        {
+          "astId": 15204,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "to",
+          "offset": 0,
+          "slot": "4",
+          "type": "t_struct(IPCAddress)15370_storage"
+        },
+        {
+          "astId": 15206,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "value",
+          "offset": 0,
+          "slot": "8",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15208,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "nonce",
+          "offset": 0,
+          "slot": "9",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15210,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "method",
+          "offset": 8,
+          "slot": "9",
+          "type": "t_bytes4"
+        },
+        {
+          "astId": 15212,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "params",
+          "offset": 0,
+          "slot": "10",
+          "type": "t_bytes_storage"
+        },
+        {
+          "astId": 15214,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "fee",
+          "offset": 0,
+          "slot": "11",
+          "type": "t_uint256"
+        }
+      ],
+      "numberOfBytes": "384"
+    },
+    "t_struct(Subnet)15269_storage": {
+      "encoding": "inplace",
+      "label": "struct Subnet",
+      "members": [
+        {
+          "astId": 15254,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "stake",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15256,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "genesisEpoch",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15258,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "circSupply",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15260,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "topDownNonce",
+          "offset": 0,
+          "slot": "3",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15262,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "appliedBottomUpNonce",
+          "offset": 8,
+          "slot": "3",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15265,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "status",
+          "offset": 16,
+          "slot": "3",
+          "type": "t_enum(Status)5083"
+        },
+        {
+          "astId": 15268,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "id",
+          "offset": 0,
+          "slot": "4",
+          "type": "t_struct(SubnetID)15252_storage"
+        }
+      ],
+      "numberOfBytes": "192"
+    },
+    "t_struct(SubnetID)15252_storage": {
+      "encoding": "inplace",
+      "label": "struct SubnetID",
+      "members": [
+        {
+          "astId": 15247,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "root",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15251,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "route",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_array(t_address)dyn_storage"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(UintSet)3508_storage": {
+      "encoding": "inplace",
+      "label": "struct EnumerableSet.UintSet",
+      "members": [
+        {
+          "astId": 3507,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "_inner",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(Set)3036_storage"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(Validator)15377_storage": {
+      "encoding": "inplace",
+      "label": "struct Validator",
+      "members": [
+        {
+          "astId": 15372,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "weight",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15374,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "addr",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_address"
+        },
+        {
+          "astId": 15376,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "metadata",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_bytes_storage"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(ValidatorInfo)15335_storage": {
+      "encoding": "inplace",
+      "label": "struct ValidatorInfo",
+      "members": [
+        {
+          "astId": 15329,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "confirmedCollateral",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15331,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "totalCollateral",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15334,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "metadata",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_bytes_storage"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(ValidatorSet)15356_storage": {
+      "encoding": "inplace",
+      "label": "struct ValidatorSet",
+      "members": [
+        {
+          "astId": 15338,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "activeLimit",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint16"
+        },
+        {
+          "astId": 15341,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "totalConfirmedCollateral",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15347,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "validators",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_mapping(t_address,t_struct(ValidatorInfo)15335_storage)"
+        },
+        {
+          "astId": 15351,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "activeValidators",
+          "offset": 0,
+          "slot": "3",
+          "type": "t_struct(MinPQ)14304_storage"
+        },
+        {
+          "astId": 15355,
+          "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+          "label": "waitingValidators",
+          "offset": 0,
+          "slot": "6",
+          "type": "t_struct(MaxPQ)13686_storage"
+        }
+      ],
+      "numberOfBytes": "288"
+    },
+    "t_uint16": {
+      "encoding": "inplace",
+      "label": "uint16",
+      "numberOfBytes": "2"
+    },
+    "t_uint256": {
+      "encoding": "inplace",
+      "label": "uint256",
+      "numberOfBytes": "32"
+    },
+    "t_uint64": {
+      "encoding": "inplace",
+      "label": "uint64",
+      "numberOfBytes": "8"
+    },
+    "t_uint8": {
+      "encoding": "inplace",
+      "label": "uint8",
+      "numberOfBytes": "1"
+    }
+  }
 }

--- a/.storage-layouts/GatewayDiamond.json
+++ b/.storage-layouts/GatewayDiamond.json
@@ -1,1063 +1,1063 @@
 {
-    "storage": [
-        {
-            "astId": 3674,
-            "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-            "label": "s",
-            "offset": 0,
-            "slot": "0",
-            "type": "t_struct(GatewayActorStorage)10248_storage"
-        }
-    ],
-    "types": {
-        "t_address": {
-            "encoding": "inplace",
-            "label": "address",
-            "numberOfBytes": "20"
-        },
-        "t_array(t_address)dyn_storage": {
-            "base": "t_address",
-            "encoding": "dynamic_array",
-            "label": "address[]",
-            "numberOfBytes": "32"
-        },
-        "t_array(t_bytes32)dyn_storage": {
-            "base": "t_bytes32",
-            "encoding": "dynamic_array",
-            "label": "bytes32[]",
-            "numberOfBytes": "32"
-        },
-        "t_array(t_struct(CrossMsg)15268_storage)dyn_storage": {
-            "base": "t_struct(CrossMsg)15268_storage",
-            "encoding": "dynamic_array",
-            "label": "struct CrossMsg[]",
-            "numberOfBytes": "32"
-        },
-        "t_array(t_struct(Validator)15447_storage)dyn_storage": {
-            "base": "t_struct(Validator)15447_storage",
-            "encoding": "dynamic_array",
-            "label": "struct Validator[]",
-            "numberOfBytes": "32"
-        },
-        "t_bool": {
-            "encoding": "inplace",
-            "label": "bool",
-            "numberOfBytes": "1"
-        },
-        "t_bytes32": {
-            "encoding": "inplace",
-            "label": "bytes32",
-            "numberOfBytes": "32"
-        },
-        "t_bytes4": {
-            "encoding": "inplace",
-            "label": "bytes4",
-            "numberOfBytes": "4"
-        },
-        "t_bytes_storage": {
-            "encoding": "bytes",
-            "label": "bytes",
-            "numberOfBytes": "32"
-        },
-        "t_enum(StakingOperation)15343": {
-            "encoding": "inplace",
-            "label": "enum StakingOperation",
-            "numberOfBytes": "1"
-        },
-        "t_enum(Status)5075": {
-            "encoding": "inplace",
-            "label": "enum Status",
-            "numberOfBytes": "1"
-        },
-        "t_mapping(t_address,t_bytes_storage)": {
-            "encoding": "mapping",
-            "key": "t_address",
-            "label": "mapping(address => bytes)",
-            "numberOfBytes": "32",
-            "value": "t_bytes_storage"
-        },
-        "t_mapping(t_address,t_struct(ValidatorInfo)15405_storage)": {
-            "encoding": "mapping",
-            "key": "t_address",
-            "label": "mapping(address => struct ValidatorInfo)",
-            "numberOfBytes": "32",
-            "value": "t_struct(ValidatorInfo)15405_storage"
-        },
-        "t_mapping(t_address,t_uint16)": {
-            "encoding": "mapping",
-            "key": "t_address",
-            "label": "mapping(address => uint16)",
-            "numberOfBytes": "32",
-            "value": "t_uint16"
-        },
-        "t_mapping(t_bytes32,t_struct(CrossMsg)15268_storage)": {
-            "encoding": "mapping",
-            "key": "t_bytes32",
-            "label": "mapping(bytes32 => struct CrossMsg)",
-            "numberOfBytes": "32",
-            "value": "t_struct(CrossMsg)15268_storage"
-        },
-        "t_mapping(t_bytes32,t_struct(Subnet)15339_storage)": {
-            "encoding": "mapping",
-            "key": "t_bytes32",
-            "label": "mapping(bytes32 => struct Subnet)",
-            "numberOfBytes": "32",
-            "value": "t_struct(Subnet)15339_storage"
-        },
-        "t_mapping(t_bytes32,t_uint256)": {
-            "encoding": "mapping",
-            "key": "t_bytes32",
-            "label": "mapping(bytes32 => uint256)",
-            "numberOfBytes": "32",
-            "value": "t_uint256"
-        },
-        "t_mapping(t_uint16,t_address)": {
-            "encoding": "mapping",
-            "key": "t_uint16",
-            "label": "mapping(uint16 => address)",
-            "numberOfBytes": "32",
-            "value": "t_address"
-        },
-        "t_mapping(t_uint256,t_struct(ParentFinality)15229_storage)": {
-            "encoding": "mapping",
-            "key": "t_uint256",
-            "label": "mapping(uint256 => struct ParentFinality)",
-            "numberOfBytes": "32",
-            "value": "t_struct(ParentFinality)15229_storage"
-        },
-        "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15268_storage)dyn_storage)": {
-            "encoding": "mapping",
-            "key": "t_uint64",
-            "label": "mapping(uint64 => struct CrossMsg[])",
-            "numberOfBytes": "32",
-            "value": "t_array(t_struct(CrossMsg)15268_storage)dyn_storage"
-        },
-        "t_mapping(t_uint64,t_mapping(t_address,t_bytes_storage))": {
-            "encoding": "mapping",
-            "key": "t_uint64",
-            "label": "mapping(uint64 => mapping(address => bytes))",
-            "numberOfBytes": "32",
-            "value": "t_mapping(t_address,t_bytes_storage)"
-        },
-        "t_mapping(t_uint64,t_mapping(t_bytes32,t_uint256))": {
-            "encoding": "mapping",
-            "key": "t_uint64",
-            "label": "mapping(uint64 => mapping(bytes32 => uint256))",
-            "numberOfBytes": "32",
-            "value": "t_mapping(t_bytes32,t_uint256)"
-        },
-        "t_mapping(t_uint64,t_struct(AddressSet)3351_storage)": {
-            "encoding": "mapping",
-            "key": "t_uint64",
-            "label": "mapping(uint64 => struct EnumerableSet.AddressSet)",
-            "numberOfBytes": "32",
-            "value": "t_struct(AddressSet)3351_storage"
-        },
-        "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15246_storage)": {
-            "encoding": "mapping",
-            "key": "t_uint64",
-            "label": "mapping(uint64 => struct BottomUpCheckpoint)",
-            "numberOfBytes": "32",
-            "value": "t_struct(BottomUpCheckpoint)15246_storage"
-        },
-        "t_mapping(t_uint64,t_struct(CheckpointInfo)15262_storage)": {
-            "encoding": "mapping",
-            "key": "t_uint64",
-            "label": "mapping(uint64 => struct CheckpointInfo)",
-            "numberOfBytes": "32",
-            "value": "t_struct(CheckpointInfo)15262_storage"
-        },
-        "t_mapping(t_uint64,t_struct(StakingChange)15351_storage)": {
-            "encoding": "mapping",
-            "key": "t_uint64",
-            "label": "mapping(uint64 => struct StakingChange)",
-            "numberOfBytes": "32",
-            "value": "t_struct(StakingChange)15351_storage"
-        },
-        "t_struct(AddressSet)3351_storage": {
-            "encoding": "inplace",
-            "label": "struct EnumerableSet.AddressSet",
-            "members": [
-                {
-                    "astId": 3350,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "_inner",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(Set)3036_storage"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(BottomUpCheckpoint)15246_storage": {
-            "encoding": "inplace",
-            "label": "struct BottomUpCheckpoint",
-            "members": [
-                {
-                    "astId": 15233,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "subnetID",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(SubnetID)15322_storage"
-                },
-                {
-                    "astId": 15236,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "blockHeight",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15239,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "blockHash",
-                    "offset": 0,
-                    "slot": "3",
-                    "type": "t_bytes32"
-                },
-                {
-                    "astId": 15242,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "nextConfigurationNumber",
-                    "offset": 0,
-                    "slot": "4",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15245,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "crossMessagesHash",
-                    "offset": 0,
-                    "slot": "5",
-                    "type": "t_bytes32"
-                }
-            ],
-            "numberOfBytes": "192"
-        },
-        "t_struct(CheckpointInfo)15262_storage": {
-            "encoding": "inplace",
-            "label": "struct CheckpointInfo",
-            "members": [
-                {
-                    "astId": 15249,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "hash",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_bytes32"
-                },
-                {
-                    "astId": 15252,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "rootHash",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_bytes32"
-                },
-                {
-                    "astId": 15255,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "threshold",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15258,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "currentWeight",
-                    "offset": 0,
-                    "slot": "3",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15261,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "reached",
-                    "offset": 0,
-                    "slot": "4",
-                    "type": "t_bool"
-                }
-            ],
-            "numberOfBytes": "160"
-        },
-        "t_struct(CrossMsg)15268_storage": {
-            "encoding": "inplace",
-            "label": "struct CrossMsg",
-            "members": [
-                {
-                    "astId": 15265,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "message",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(StorableMsg)15285_storage"
-                },
-                {
-                    "astId": 15267,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "wrapped",
-                    "offset": 0,
-                    "slot": "12",
-                    "type": "t_bool"
-                }
-            ],
-            "numberOfBytes": "416"
-        },
-        "t_struct(FvmAddress)15292_storage": {
-            "encoding": "inplace",
-            "label": "struct FvmAddress",
-            "members": [
-                {
-                    "astId": 15289,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "addrType",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint8"
-                },
-                {
-                    "astId": 15291,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "payload",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_bytes_storage"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(GatewayActorStorage)10248_storage": {
-            "encoding": "inplace",
-            "label": "struct GatewayActorStorage",
-            "members": [
-                {
-                    "astId": 10146,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "subnets",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_mapping(t_bytes32,t_struct(Subnet)15339_storage)"
-                },
-                {
-                    "astId": 10152,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "finalitiesMap",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_mapping(t_uint256,t_struct(ParentFinality)15229_storage)"
-                },
-                {
-                    "astId": 10155,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "latestParentHeight",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 10161,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "postbox",
-                    "offset": 0,
-                    "slot": "3",
-                    "type": "t_mapping(t_bytes32,t_struct(CrossMsg)15268_storage)"
-                },
-                {
-                    "astId": 10168,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "validatorSetWeights",
-                    "offset": 0,
-                    "slot": "4",
-                    "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_uint256))"
-                },
-                {
-                    "astId": 10172,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "currentMembership",
-                    "offset": 0,
-                    "slot": "5",
-                    "type": "t_struct(Membership)15454_storage"
-                },
-                {
-                    "astId": 10176,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "lastMembership",
-                    "offset": 0,
-                    "slot": "7",
-                    "type": "t_struct(Membership)15454_storage"
-                },
-                {
-                    "astId": 10182,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "bottomUpCheckpoints",
-                    "offset": 0,
-                    "slot": "9",
-                    "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15246_storage)"
-                },
-                {
-                    "astId": 10188,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "bottomUpCheckpointInfo",
-                    "offset": 0,
-                    "slot": "10",
-                    "type": "t_mapping(t_uint64,t_struct(CheckpointInfo)15262_storage)"
-                },
-                {
-                    "astId": 10195,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "bottomUpMessages",
-                    "offset": 0,
-                    "slot": "11",
-                    "type": "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15268_storage)dyn_storage)"
-                },
-                {
-                    "astId": 10198,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "bottomUpCheckpointRetentionHeight",
-                    "offset": 0,
-                    "slot": "12",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 10202,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "incompleteCheckpoints",
-                    "offset": 0,
-                    "slot": "13",
-                    "type": "t_struct(UintSet)3508_storage"
-                },
-                {
-                    "astId": 10208,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "bottomUpSignatureSenders",
-                    "offset": 0,
-                    "slot": "15",
-                    "type": "t_mapping(t_uint64,t_struct(AddressSet)3351_storage)"
-                },
-                {
-                    "astId": 10215,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "bottomUpSignatures",
-                    "offset": 0,
-                    "slot": "16",
-                    "type": "t_mapping(t_uint64,t_mapping(t_address,t_bytes_storage))"
-                },
-                {
-                    "astId": 10219,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "subnetKeys",
-                    "offset": 0,
-                    "slot": "17",
-                    "type": "t_array(t_bytes32)dyn_storage"
-                },
-                {
-                    "astId": 10223,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "networkName",
-                    "offset": 0,
-                    "slot": "18",
-                    "type": "t_struct(SubnetID)15322_storage"
-                },
-                {
-                    "astId": 10226,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "minStake",
-                    "offset": 0,
-                    "slot": "20",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 10229,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "minCrossMsgFee",
-                    "offset": 0,
-                    "slot": "21",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 10232,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "majorityPercentage",
-                    "offset": 0,
-                    "slot": "22",
-                    "type": "t_uint8"
-                },
-                {
-                    "astId": 10235,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "bottomUpNonce",
-                    "offset": 1,
-                    "slot": "22",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 10238,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "appliedTopDownNonce",
-                    "offset": 9,
-                    "slot": "22",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 10241,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "totalSubnets",
-                    "offset": 17,
-                    "slot": "22",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 10243,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "bottomUpCheckPeriod",
-                    "offset": 0,
-                    "slot": "23",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 10247,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "validatorsTracker",
-                    "offset": 0,
-                    "slot": "24",
-                    "type": "t_struct(ParentValidatorsTracker)15433_storage"
-                }
-            ],
-            "numberOfBytes": "1120"
-        },
-        "t_struct(IPCAddress)15440_storage": {
-            "encoding": "inplace",
-            "label": "struct IPCAddress",
-            "members": [
-                {
-                    "astId": 15436,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "subnetId",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(SubnetID)15322_storage"
-                },
-                {
-                    "astId": 15439,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "rawAddress",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_struct(FvmAddress)15292_storage"
-                }
-            ],
-            "numberOfBytes": "128"
-        },
-        "t_struct(MaxPQ)13754_storage": {
-            "encoding": "inplace",
-            "label": "struct MaxPQ",
-            "members": [
-                {
-                    "astId": 13753,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "inner",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(PQ)15003_storage"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(Membership)15454_storage": {
-            "encoding": "inplace",
-            "label": "struct Membership",
-            "members": [
-                {
-                    "astId": 15451,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "validators",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_array(t_struct(Validator)15447_storage)dyn_storage"
-                },
-                {
-                    "astId": 15453,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "configurationNumber",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_uint64"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(MinPQ)14373_storage": {
-            "encoding": "inplace",
-            "label": "struct MinPQ",
-            "members": [
-                {
-                    "astId": 14372,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "inner",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(PQ)15003_storage"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(PQ)15003_storage": {
-            "encoding": "inplace",
-            "label": "struct PQ",
-            "members": [
-                {
-                    "astId": 14992,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "size",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint16"
-                },
-                {
-                    "astId": 14997,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "addressToPos",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_mapping(t_address,t_uint16)"
-                },
-                {
-                    "astId": 15002,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "posToAddress",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_mapping(t_uint16,t_address)"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(ParentFinality)15229_storage": {
-            "encoding": "inplace",
-            "label": "struct ParentFinality",
-            "members": [
-                {
-                    "astId": 15226,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "height",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15228,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "blockHash",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_bytes32"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(ParentValidatorsTracker)15433_storage": {
-            "encoding": "inplace",
-            "label": "struct ParentValidatorsTracker",
-            "members": [
-                {
-                    "astId": 15429,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "validators",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(ValidatorSet)15426_storage"
-                },
-                {
-                    "astId": 15432,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "changes",
-                    "offset": 0,
-                    "slot": "9",
-                    "type": "t_struct(StakingChangeLog)15370_storage"
-                }
-            ],
-            "numberOfBytes": "352"
-        },
-        "t_struct(Set)3036_storage": {
-            "encoding": "inplace",
-            "label": "struct EnumerableSet.Set",
-            "members": [
-                {
-                    "astId": 3031,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "_values",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_array(t_bytes32)dyn_storage"
-                },
-                {
-                    "astId": 3035,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "_indexes",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_mapping(t_bytes32,t_uint256)"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(StakingChange)15351_storage": {
-            "encoding": "inplace",
-            "label": "struct StakingChange",
-            "members": [
-                {
-                    "astId": 15346,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "op",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_enum(StakingOperation)15343"
-                },
-                {
-                    "astId": 15348,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "payload",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_bytes_storage"
-                },
-                {
-                    "astId": 15350,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "validator",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_address"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(StakingChangeLog)15370_storage": {
-            "encoding": "inplace",
-            "label": "struct StakingChangeLog",
-            "members": [
-                {
-                    "astId": 15360,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "nextConfigurationNumber",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15363,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "startConfigurationNumber",
-                    "offset": 8,
-                    "slot": "0",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15369,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "changes",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_mapping(t_uint64,t_struct(StakingChange)15351_storage)"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(StorableMsg)15285_storage": {
-            "encoding": "inplace",
-            "label": "struct StorableMsg",
-            "members": [
-                {
-                    "astId": 15271,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "from",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(IPCAddress)15440_storage"
-                },
-                {
-                    "astId": 15274,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "to",
-                    "offset": 0,
-                    "slot": "4",
-                    "type": "t_struct(IPCAddress)15440_storage"
-                },
-                {
-                    "astId": 15276,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "value",
-                    "offset": 0,
-                    "slot": "8",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15278,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "nonce",
-                    "offset": 0,
-                    "slot": "9",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15280,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "method",
-                    "offset": 8,
-                    "slot": "9",
-                    "type": "t_bytes4"
-                },
-                {
-                    "astId": 15282,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "params",
-                    "offset": 0,
-                    "slot": "10",
-                    "type": "t_bytes_storage"
-                },
-                {
-                    "astId": 15284,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "fee",
-                    "offset": 0,
-                    "slot": "11",
-                    "type": "t_uint256"
-                }
-            ],
-            "numberOfBytes": "384"
-        },
-        "t_struct(Subnet)15339_storage": {
-            "encoding": "inplace",
-            "label": "struct Subnet",
-            "members": [
-                {
-                    "astId": 15324,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "stake",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15326,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "genesisEpoch",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15328,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "circSupply",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15330,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "topDownNonce",
-                    "offset": 0,
-                    "slot": "3",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15332,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "appliedBottomUpNonce",
-                    "offset": 8,
-                    "slot": "3",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15335,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "status",
-                    "offset": 16,
-                    "slot": "3",
-                    "type": "t_enum(Status)5075"
-                },
-                {
-                    "astId": 15338,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "id",
-                    "offset": 0,
-                    "slot": "4",
-                    "type": "t_struct(SubnetID)15322_storage"
-                }
-            ],
-            "numberOfBytes": "192"
-        },
-        "t_struct(SubnetID)15322_storage": {
-            "encoding": "inplace",
-            "label": "struct SubnetID",
-            "members": [
-                {
-                    "astId": 15317,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "root",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15321,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "route",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_array(t_address)dyn_storage"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(UintSet)3508_storage": {
-            "encoding": "inplace",
-            "label": "struct EnumerableSet.UintSet",
-            "members": [
-                {
-                    "astId": 3507,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "_inner",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(Set)3036_storage"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(Validator)15447_storage": {
-            "encoding": "inplace",
-            "label": "struct Validator",
-            "members": [
-                {
-                    "astId": 15442,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "weight",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15444,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "addr",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_address"
-                },
-                {
-                    "astId": 15446,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "metadata",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_bytes_storage"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(ValidatorInfo)15405_storage": {
-            "encoding": "inplace",
-            "label": "struct ValidatorInfo",
-            "members": [
-                {
-                    "astId": 15399,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "confirmedCollateral",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15401,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "totalCollateral",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15404,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "metadata",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_bytes_storage"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(ValidatorSet)15426_storage": {
-            "encoding": "inplace",
-            "label": "struct ValidatorSet",
-            "members": [
-                {
-                    "astId": 15408,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "activeLimit",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint16"
-                },
-                {
-                    "astId": 15411,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "totalConfirmedCollateral",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15417,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "validators",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_mapping(t_address,t_struct(ValidatorInfo)15405_storage)"
-                },
-                {
-                    "astId": 15421,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "activeValidators",
-                    "offset": 0,
-                    "slot": "3",
-                    "type": "t_struct(MinPQ)14373_storage"
-                },
-                {
-                    "astId": 15425,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "waitingValidators",
-                    "offset": 0,
-                    "slot": "6",
-                    "type": "t_struct(MaxPQ)13754_storage"
-                }
-            ],
-            "numberOfBytes": "288"
-        },
-        "t_uint16": {
-            "encoding": "inplace",
-            "label": "uint16",
-            "numberOfBytes": "2"
-        },
-        "t_uint256": {
-            "encoding": "inplace",
-            "label": "uint256",
-            "numberOfBytes": "32"
-        },
-        "t_uint64": {
-            "encoding": "inplace",
-            "label": "uint64",
-            "numberOfBytes": "8"
-        },
-        "t_uint8": {
-            "encoding": "inplace",
-            "label": "uint8",
-            "numberOfBytes": "1"
-        }
+  "storage": [
+    {
+      "astId": 3674,
+      "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+      "label": "s",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_struct(GatewayActorStorage)10190_storage"
     }
+  ],
+  "types": {
+    "t_address": {
+      "encoding": "inplace",
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "base": "t_address",
+      "encoding": "dynamic_array",
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_bytes32)dyn_storage": {
+      "base": "t_bytes32",
+      "encoding": "dynamic_array",
+      "label": "bytes32[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_struct(CrossMsg)15198_storage)dyn_storage": {
+      "base": "t_struct(CrossMsg)15198_storage",
+      "encoding": "dynamic_array",
+      "label": "struct CrossMsg[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_struct(Validator)15377_storage)dyn_storage": {
+      "base": "t_struct(Validator)15377_storage",
+      "encoding": "dynamic_array",
+      "label": "struct Validator[]",
+      "numberOfBytes": "32"
+    },
+    "t_bool": {
+      "encoding": "inplace",
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_bytes32": {
+      "encoding": "inplace",
+      "label": "bytes32",
+      "numberOfBytes": "32"
+    },
+    "t_bytes4": {
+      "encoding": "inplace",
+      "label": "bytes4",
+      "numberOfBytes": "4"
+    },
+    "t_bytes_storage": {
+      "encoding": "bytes",
+      "label": "bytes",
+      "numberOfBytes": "32"
+    },
+    "t_enum(StakingOperation)15273": {
+      "encoding": "inplace",
+      "label": "enum StakingOperation",
+      "numberOfBytes": "1"
+    },
+    "t_enum(Status)5083": {
+      "encoding": "inplace",
+      "label": "enum Status",
+      "numberOfBytes": "1"
+    },
+    "t_mapping(t_address,t_bytes_storage)": {
+      "encoding": "mapping",
+      "key": "t_address",
+      "label": "mapping(address => bytes)",
+      "numberOfBytes": "32",
+      "value": "t_bytes_storage"
+    },
+    "t_mapping(t_address,t_struct(ValidatorInfo)15335_storage)": {
+      "encoding": "mapping",
+      "key": "t_address",
+      "label": "mapping(address => struct ValidatorInfo)",
+      "numberOfBytes": "32",
+      "value": "t_struct(ValidatorInfo)15335_storage"
+    },
+    "t_mapping(t_address,t_uint16)": {
+      "encoding": "mapping",
+      "key": "t_address",
+      "label": "mapping(address => uint16)",
+      "numberOfBytes": "32",
+      "value": "t_uint16"
+    },
+    "t_mapping(t_bytes32,t_struct(CrossMsg)15198_storage)": {
+      "encoding": "mapping",
+      "key": "t_bytes32",
+      "label": "mapping(bytes32 => struct CrossMsg)",
+      "numberOfBytes": "32",
+      "value": "t_struct(CrossMsg)15198_storage"
+    },
+    "t_mapping(t_bytes32,t_struct(Subnet)15269_storage)": {
+      "encoding": "mapping",
+      "key": "t_bytes32",
+      "label": "mapping(bytes32 => struct Subnet)",
+      "numberOfBytes": "32",
+      "value": "t_struct(Subnet)15269_storage"
+    },
+    "t_mapping(t_bytes32,t_uint256)": {
+      "encoding": "mapping",
+      "key": "t_bytes32",
+      "label": "mapping(bytes32 => uint256)",
+      "numberOfBytes": "32",
+      "value": "t_uint256"
+    },
+    "t_mapping(t_uint16,t_address)": {
+      "encoding": "mapping",
+      "key": "t_uint16",
+      "label": "mapping(uint16 => address)",
+      "numberOfBytes": "32",
+      "value": "t_address"
+    },
+    "t_mapping(t_uint256,t_struct(ParentFinality)15159_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint256",
+      "label": "mapping(uint256 => struct ParentFinality)",
+      "numberOfBytes": "32",
+      "value": "t_struct(ParentFinality)15159_storage"
+    },
+    "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15198_storage)dyn_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint64",
+      "label": "mapping(uint64 => struct CrossMsg[])",
+      "numberOfBytes": "32",
+      "value": "t_array(t_struct(CrossMsg)15198_storage)dyn_storage"
+    },
+    "t_mapping(t_uint64,t_mapping(t_address,t_bytes_storage))": {
+      "encoding": "mapping",
+      "key": "t_uint64",
+      "label": "mapping(uint64 => mapping(address => bytes))",
+      "numberOfBytes": "32",
+      "value": "t_mapping(t_address,t_bytes_storage)"
+    },
+    "t_mapping(t_uint64,t_mapping(t_bytes32,t_uint256))": {
+      "encoding": "mapping",
+      "key": "t_uint64",
+      "label": "mapping(uint64 => mapping(bytes32 => uint256))",
+      "numberOfBytes": "32",
+      "value": "t_mapping(t_bytes32,t_uint256)"
+    },
+    "t_mapping(t_uint64,t_struct(AddressSet)3351_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint64",
+      "label": "mapping(uint64 => struct EnumerableSet.AddressSet)",
+      "numberOfBytes": "32",
+      "value": "t_struct(AddressSet)3351_storage"
+    },
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15176_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint64",
+      "label": "mapping(uint64 => struct BottomUpCheckpoint)",
+      "numberOfBytes": "32",
+      "value": "t_struct(BottomUpCheckpoint)15176_storage"
+    },
+    "t_mapping(t_uint64,t_struct(CheckpointInfo)15192_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint64",
+      "label": "mapping(uint64 => struct CheckpointInfo)",
+      "numberOfBytes": "32",
+      "value": "t_struct(CheckpointInfo)15192_storage"
+    },
+    "t_mapping(t_uint64,t_struct(StakingChange)15281_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint64",
+      "label": "mapping(uint64 => struct StakingChange)",
+      "numberOfBytes": "32",
+      "value": "t_struct(StakingChange)15281_storage"
+    },
+    "t_struct(AddressSet)3351_storage": {
+      "encoding": "inplace",
+      "label": "struct EnumerableSet.AddressSet",
+      "members": [
+        {
+          "astId": 3350,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "_inner",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(Set)3036_storage"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(BottomUpCheckpoint)15176_storage": {
+      "encoding": "inplace",
+      "label": "struct BottomUpCheckpoint",
+      "members": [
+        {
+          "astId": 15163,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "subnetID",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(SubnetID)15252_storage"
+        },
+        {
+          "astId": 15166,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "blockHeight",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15169,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "blockHash",
+          "offset": 0,
+          "slot": "3",
+          "type": "t_bytes32"
+        },
+        {
+          "astId": 15172,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "nextConfigurationNumber",
+          "offset": 0,
+          "slot": "4",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15175,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "crossMessagesHash",
+          "offset": 0,
+          "slot": "5",
+          "type": "t_bytes32"
+        }
+      ],
+      "numberOfBytes": "192"
+    },
+    "t_struct(CheckpointInfo)15192_storage": {
+      "encoding": "inplace",
+      "label": "struct CheckpointInfo",
+      "members": [
+        {
+          "astId": 15179,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "hash",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_bytes32"
+        },
+        {
+          "astId": 15182,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "rootHash",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_bytes32"
+        },
+        {
+          "astId": 15185,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "threshold",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15188,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "currentWeight",
+          "offset": 0,
+          "slot": "3",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15191,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "reached",
+          "offset": 0,
+          "slot": "4",
+          "type": "t_bool"
+        }
+      ],
+      "numberOfBytes": "160"
+    },
+    "t_struct(CrossMsg)15198_storage": {
+      "encoding": "inplace",
+      "label": "struct CrossMsg",
+      "members": [
+        {
+          "astId": 15195,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "message",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(StorableMsg)15215_storage"
+        },
+        {
+          "astId": 15197,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "wrapped",
+          "offset": 0,
+          "slot": "12",
+          "type": "t_bool"
+        }
+      ],
+      "numberOfBytes": "416"
+    },
+    "t_struct(FvmAddress)15222_storage": {
+      "encoding": "inplace",
+      "label": "struct FvmAddress",
+      "members": [
+        {
+          "astId": 15219,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "addrType",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint8"
+        },
+        {
+          "astId": 15221,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "payload",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_bytes_storage"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(GatewayActorStorage)10190_storage": {
+      "encoding": "inplace",
+      "label": "struct GatewayActorStorage",
+      "members": [
+        {
+          "astId": 10088,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "subnets",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_mapping(t_bytes32,t_struct(Subnet)15269_storage)"
+        },
+        {
+          "astId": 10094,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "finalitiesMap",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_mapping(t_uint256,t_struct(ParentFinality)15159_storage)"
+        },
+        {
+          "astId": 10097,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "latestParentHeight",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 10103,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "postbox",
+          "offset": 0,
+          "slot": "3",
+          "type": "t_mapping(t_bytes32,t_struct(CrossMsg)15198_storage)"
+        },
+        {
+          "astId": 10110,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "validatorSetWeights",
+          "offset": 0,
+          "slot": "4",
+          "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_uint256))"
+        },
+        {
+          "astId": 10114,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "currentMembership",
+          "offset": 0,
+          "slot": "5",
+          "type": "t_struct(Membership)15384_storage"
+        },
+        {
+          "astId": 10118,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "lastMembership",
+          "offset": 0,
+          "slot": "7",
+          "type": "t_struct(Membership)15384_storage"
+        },
+        {
+          "astId": 10124,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "bottomUpCheckpoints",
+          "offset": 0,
+          "slot": "9",
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15176_storage)"
+        },
+        {
+          "astId": 10130,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "bottomUpCheckpointInfo",
+          "offset": 0,
+          "slot": "10",
+          "type": "t_mapping(t_uint64,t_struct(CheckpointInfo)15192_storage)"
+        },
+        {
+          "astId": 10137,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "bottomUpMessages",
+          "offset": 0,
+          "slot": "11",
+          "type": "t_mapping(t_uint64,t_array(t_struct(CrossMsg)15198_storage)dyn_storage)"
+        },
+        {
+          "astId": 10140,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "bottomUpCheckpointRetentionHeight",
+          "offset": 0,
+          "slot": "12",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 10144,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "incompleteCheckpoints",
+          "offset": 0,
+          "slot": "13",
+          "type": "t_struct(UintSet)3508_storage"
+        },
+        {
+          "astId": 10150,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "bottomUpSignatureSenders",
+          "offset": 0,
+          "slot": "15",
+          "type": "t_mapping(t_uint64,t_struct(AddressSet)3351_storage)"
+        },
+        {
+          "astId": 10157,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "bottomUpSignatures",
+          "offset": 0,
+          "slot": "16",
+          "type": "t_mapping(t_uint64,t_mapping(t_address,t_bytes_storage))"
+        },
+        {
+          "astId": 10161,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "subnetKeys",
+          "offset": 0,
+          "slot": "17",
+          "type": "t_array(t_bytes32)dyn_storage"
+        },
+        {
+          "astId": 10165,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "networkName",
+          "offset": 0,
+          "slot": "18",
+          "type": "t_struct(SubnetID)15252_storage"
+        },
+        {
+          "astId": 10168,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "minStake",
+          "offset": 0,
+          "slot": "20",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 10171,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "minCrossMsgFee",
+          "offset": 0,
+          "slot": "21",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 10174,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "majorityPercentage",
+          "offset": 0,
+          "slot": "22",
+          "type": "t_uint8"
+        },
+        {
+          "astId": 10177,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "bottomUpNonce",
+          "offset": 1,
+          "slot": "22",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 10180,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "appliedTopDownNonce",
+          "offset": 9,
+          "slot": "22",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 10183,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "totalSubnets",
+          "offset": 17,
+          "slot": "22",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 10185,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "bottomUpCheckPeriod",
+          "offset": 0,
+          "slot": "23",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 10189,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "validatorsTracker",
+          "offset": 0,
+          "slot": "24",
+          "type": "t_struct(ParentValidatorsTracker)15363_storage"
+        }
+      ],
+      "numberOfBytes": "1120"
+    },
+    "t_struct(IPCAddress)15370_storage": {
+      "encoding": "inplace",
+      "label": "struct IPCAddress",
+      "members": [
+        {
+          "astId": 15366,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "subnetId",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(SubnetID)15252_storage"
+        },
+        {
+          "astId": 15369,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "rawAddress",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_struct(FvmAddress)15222_storage"
+        }
+      ],
+      "numberOfBytes": "128"
+    },
+    "t_struct(MaxPQ)13686_storage": {
+      "encoding": "inplace",
+      "label": "struct MaxPQ",
+      "members": [
+        {
+          "astId": 13685,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "inner",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(PQ)14933_storage"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(Membership)15384_storage": {
+      "encoding": "inplace",
+      "label": "struct Membership",
+      "members": [
+        {
+          "astId": 15381,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "validators",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_array(t_struct(Validator)15377_storage)dyn_storage"
+        },
+        {
+          "astId": 15383,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "configurationNumber",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_uint64"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(MinPQ)14304_storage": {
+      "encoding": "inplace",
+      "label": "struct MinPQ",
+      "members": [
+        {
+          "astId": 14303,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "inner",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(PQ)14933_storage"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(PQ)14933_storage": {
+      "encoding": "inplace",
+      "label": "struct PQ",
+      "members": [
+        {
+          "astId": 14922,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "size",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint16"
+        },
+        {
+          "astId": 14927,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "addressToPos",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_mapping(t_address,t_uint16)"
+        },
+        {
+          "astId": 14932,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "posToAddress",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_mapping(t_uint16,t_address)"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(ParentFinality)15159_storage": {
+      "encoding": "inplace",
+      "label": "struct ParentFinality",
+      "members": [
+        {
+          "astId": 15156,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "height",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15158,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "blockHash",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_bytes32"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(ParentValidatorsTracker)15363_storage": {
+      "encoding": "inplace",
+      "label": "struct ParentValidatorsTracker",
+      "members": [
+        {
+          "astId": 15359,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "validators",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(ValidatorSet)15356_storage"
+        },
+        {
+          "astId": 15362,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "changes",
+          "offset": 0,
+          "slot": "9",
+          "type": "t_struct(StakingChangeLog)15300_storage"
+        }
+      ],
+      "numberOfBytes": "352"
+    },
+    "t_struct(Set)3036_storage": {
+      "encoding": "inplace",
+      "label": "struct EnumerableSet.Set",
+      "members": [
+        {
+          "astId": 3031,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "_values",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_array(t_bytes32)dyn_storage"
+        },
+        {
+          "astId": 3035,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "_indexes",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_mapping(t_bytes32,t_uint256)"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(StakingChange)15281_storage": {
+      "encoding": "inplace",
+      "label": "struct StakingChange",
+      "members": [
+        {
+          "astId": 15276,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "op",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_enum(StakingOperation)15273"
+        },
+        {
+          "astId": 15278,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "payload",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_bytes_storage"
+        },
+        {
+          "astId": 15280,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "validator",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_address"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(StakingChangeLog)15300_storage": {
+      "encoding": "inplace",
+      "label": "struct StakingChangeLog",
+      "members": [
+        {
+          "astId": 15290,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "nextConfigurationNumber",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15293,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "startConfigurationNumber",
+          "offset": 8,
+          "slot": "0",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15299,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "changes",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_mapping(t_uint64,t_struct(StakingChange)15281_storage)"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(StorableMsg)15215_storage": {
+      "encoding": "inplace",
+      "label": "struct StorableMsg",
+      "members": [
+        {
+          "astId": 15201,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "from",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(IPCAddress)15370_storage"
+        },
+        {
+          "astId": 15204,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "to",
+          "offset": 0,
+          "slot": "4",
+          "type": "t_struct(IPCAddress)15370_storage"
+        },
+        {
+          "astId": 15206,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "value",
+          "offset": 0,
+          "slot": "8",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15208,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "nonce",
+          "offset": 0,
+          "slot": "9",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15210,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "method",
+          "offset": 8,
+          "slot": "9",
+          "type": "t_bytes4"
+        },
+        {
+          "astId": 15212,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "params",
+          "offset": 0,
+          "slot": "10",
+          "type": "t_bytes_storage"
+        },
+        {
+          "astId": 15214,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "fee",
+          "offset": 0,
+          "slot": "11",
+          "type": "t_uint256"
+        }
+      ],
+      "numberOfBytes": "384"
+    },
+    "t_struct(Subnet)15269_storage": {
+      "encoding": "inplace",
+      "label": "struct Subnet",
+      "members": [
+        {
+          "astId": 15254,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "stake",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15256,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "genesisEpoch",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15258,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "circSupply",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15260,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "topDownNonce",
+          "offset": 0,
+          "slot": "3",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15262,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "appliedBottomUpNonce",
+          "offset": 8,
+          "slot": "3",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15265,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "status",
+          "offset": 16,
+          "slot": "3",
+          "type": "t_enum(Status)5083"
+        },
+        {
+          "astId": 15268,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "id",
+          "offset": 0,
+          "slot": "4",
+          "type": "t_struct(SubnetID)15252_storage"
+        }
+      ],
+      "numberOfBytes": "192"
+    },
+    "t_struct(SubnetID)15252_storage": {
+      "encoding": "inplace",
+      "label": "struct SubnetID",
+      "members": [
+        {
+          "astId": 15247,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "root",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15251,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "route",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_array(t_address)dyn_storage"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(UintSet)3508_storage": {
+      "encoding": "inplace",
+      "label": "struct EnumerableSet.UintSet",
+      "members": [
+        {
+          "astId": 3507,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "_inner",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(Set)3036_storage"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(Validator)15377_storage": {
+      "encoding": "inplace",
+      "label": "struct Validator",
+      "members": [
+        {
+          "astId": 15372,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "weight",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15374,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "addr",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_address"
+        },
+        {
+          "astId": 15376,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "metadata",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_bytes_storage"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(ValidatorInfo)15335_storage": {
+      "encoding": "inplace",
+      "label": "struct ValidatorInfo",
+      "members": [
+        {
+          "astId": 15329,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "confirmedCollateral",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15331,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "totalCollateral",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15334,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "metadata",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_bytes_storage"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(ValidatorSet)15356_storage": {
+      "encoding": "inplace",
+      "label": "struct ValidatorSet",
+      "members": [
+        {
+          "astId": 15338,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "activeLimit",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint16"
+        },
+        {
+          "astId": 15341,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "totalConfirmedCollateral",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15347,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "validators",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_mapping(t_address,t_struct(ValidatorInfo)15335_storage)"
+        },
+        {
+          "astId": 15351,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "activeValidators",
+          "offset": 0,
+          "slot": "3",
+          "type": "t_struct(MinPQ)14304_storage"
+        },
+        {
+          "astId": 15355,
+          "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+          "label": "waitingValidators",
+          "offset": 0,
+          "slot": "6",
+          "type": "t_struct(MaxPQ)13686_storage"
+        }
+      ],
+      "numberOfBytes": "288"
+    },
+    "t_uint16": {
+      "encoding": "inplace",
+      "label": "uint16",
+      "numberOfBytes": "2"
+    },
+    "t_uint256": {
+      "encoding": "inplace",
+      "label": "uint256",
+      "numberOfBytes": "32"
+    },
+    "t_uint64": {
+      "encoding": "inplace",
+      "label": "uint64",
+      "numberOfBytes": "8"
+    },
+    "t_uint8": {
+      "encoding": "inplace",
+      "label": "uint8",
+      "numberOfBytes": "1"
+    }
+  }
 }

--- a/.storage-layouts/SubnetActorDiamond.json
+++ b/.storage-layouts/SubnetActorDiamond.json
@@ -1,793 +1,801 @@
 {
-    "storage": [
-        {
-            "astId": 3979,
-            "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-            "label": "s",
-            "offset": 0,
-            "slot": "0",
-            "type": "t_struct(SubnetActorStorage)12943_storage"
-        }
-    ],
-    "types": {
-        "t_address": {
-            "encoding": "inplace",
-            "label": "address",
-            "numberOfBytes": "20"
-        },
-        "t_array(t_address)dyn_storage": {
-            "base": "t_address",
-            "encoding": "dynamic_array",
-            "label": "address[]",
-            "numberOfBytes": "32"
-        },
-        "t_array(t_bytes32)dyn_storage": {
-            "base": "t_bytes32",
-            "encoding": "dynamic_array",
-            "label": "bytes32[]",
-            "numberOfBytes": "32"
-        },
-        "t_array(t_struct(Validator)15447_storage)dyn_storage": {
-            "base": "t_struct(Validator)15447_storage",
-            "encoding": "dynamic_array",
-            "label": "struct Validator[]",
-            "numberOfBytes": "32"
-        },
-        "t_bool": {
-            "encoding": "inplace",
-            "label": "bool",
-            "numberOfBytes": "1"
-        },
-        "t_bytes32": {
-            "encoding": "inplace",
-            "label": "bytes32",
-            "numberOfBytes": "32"
-        },
-        "t_bytes_storage": {
-            "encoding": "bytes",
-            "label": "bytes",
-            "numberOfBytes": "32"
-        },
-        "t_enum(ConsensusType)5061": {
-            "encoding": "inplace",
-            "label": "enum ConsensusType",
-            "numberOfBytes": "1"
-        },
-        "t_enum(StakingOperation)15343": {
-            "encoding": "inplace",
-            "label": "enum StakingOperation",
-            "numberOfBytes": "1"
-        },
-        "t_int8": {
-            "encoding": "inplace",
-            "label": "int8",
-            "numberOfBytes": "1"
-        },
-        "t_mapping(t_address,t_string_storage)": {
-            "encoding": "mapping",
-            "key": "t_address",
-            "label": "mapping(address => string)",
-            "numberOfBytes": "32",
-            "value": "t_string_storage"
-        },
-        "t_mapping(t_address,t_struct(AddressStakingReleases)15387_storage)": {
-            "encoding": "mapping",
-            "key": "t_address",
-            "label": "mapping(address => struct AddressStakingReleases)",
-            "numberOfBytes": "32",
-            "value": "t_struct(AddressStakingReleases)15387_storage"
-        },
-        "t_mapping(t_address,t_struct(ValidatorInfo)15405_storage)": {
-            "encoding": "mapping",
-            "key": "t_address",
-            "label": "mapping(address => struct ValidatorInfo)",
-            "numberOfBytes": "32",
-            "value": "t_struct(ValidatorInfo)15405_storage"
-        },
-        "t_mapping(t_address,t_uint16)": {
-            "encoding": "mapping",
-            "key": "t_address",
-            "label": "mapping(address => uint16)",
-            "numberOfBytes": "32",
-            "value": "t_uint16"
-        },
-        "t_mapping(t_address,t_uint256)": {
-            "encoding": "mapping",
-            "key": "t_address",
-            "label": "mapping(address => uint256)",
-            "numberOfBytes": "32",
-            "value": "t_uint256"
-        },
-        "t_mapping(t_bytes32,t_uint256)": {
-            "encoding": "mapping",
-            "key": "t_bytes32",
-            "label": "mapping(bytes32 => uint256)",
-            "numberOfBytes": "32",
-            "value": "t_uint256"
-        },
-        "t_mapping(t_uint16,t_address)": {
-            "encoding": "mapping",
-            "key": "t_uint16",
-            "label": "mapping(uint16 => address)",
-            "numberOfBytes": "32",
-            "value": "t_address"
-        },
-        "t_mapping(t_uint16,t_struct(StakingRelease)15377_storage)": {
-            "encoding": "mapping",
-            "key": "t_uint16",
-            "label": "mapping(uint16 => struct StakingRelease)",
-            "numberOfBytes": "32",
-            "value": "t_struct(StakingRelease)15377_storage"
-        },
-        "t_mapping(t_uint64,t_struct(AddressSet)3351_storage)": {
-            "encoding": "mapping",
-            "key": "t_uint64",
-            "label": "mapping(uint64 => struct EnumerableSet.AddressSet)",
-            "numberOfBytes": "32",
-            "value": "t_struct(AddressSet)3351_storage"
-        },
-        "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15246_storage)": {
-            "encoding": "mapping",
-            "key": "t_uint64",
-            "label": "mapping(uint64 => struct BottomUpCheckpoint)",
-            "numberOfBytes": "32",
-            "value": "t_struct(BottomUpCheckpoint)15246_storage"
-        },
-        "t_mapping(t_uint64,t_struct(StakingChange)15351_storage)": {
-            "encoding": "mapping",
-            "key": "t_uint64",
-            "label": "mapping(uint64 => struct StakingChange)",
-            "numberOfBytes": "32",
-            "value": "t_struct(StakingChange)15351_storage"
-        },
-        "t_string_storage": {
-            "encoding": "bytes",
-            "label": "string",
-            "numberOfBytes": "32"
-        },
-        "t_struct(AddressSet)3351_storage": {
-            "encoding": "inplace",
-            "label": "struct EnumerableSet.AddressSet",
-            "members": [
-                {
-                    "astId": 3350,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "_inner",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(Set)3036_storage"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(AddressStakingReleases)15387_storage": {
-            "encoding": "inplace",
-            "label": "struct AddressStakingReleases",
-            "members": [
-                {
-                    "astId": 15379,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "length",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint16"
-                },
-                {
-                    "astId": 15381,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "startIdx",
-                    "offset": 2,
-                    "slot": "0",
-                    "type": "t_uint16"
-                },
-                {
-                    "astId": 15386,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "releases",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_mapping(t_uint16,t_struct(StakingRelease)15377_storage)"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(BottomUpCheckpoint)15246_storage": {
-            "encoding": "inplace",
-            "label": "struct BottomUpCheckpoint",
-            "members": [
-                {
-                    "astId": 15233,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "subnetID",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(SubnetID)15322_storage"
-                },
-                {
-                    "astId": 15236,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "blockHeight",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15239,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "blockHash",
-                    "offset": 0,
-                    "slot": "3",
-                    "type": "t_bytes32"
-                },
-                {
-                    "astId": 15242,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "nextConfigurationNumber",
-                    "offset": 0,
-                    "slot": "4",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15245,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "crossMessagesHash",
-                    "offset": 0,
-                    "slot": "5",
-                    "type": "t_bytes32"
-                }
-            ],
-            "numberOfBytes": "192"
-        },
-        "t_struct(MaxPQ)13754_storage": {
-            "encoding": "inplace",
-            "label": "struct MaxPQ",
-            "members": [
-                {
-                    "astId": 13753,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "inner",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(PQ)15003_storage"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(MinPQ)14373_storage": {
-            "encoding": "inplace",
-            "label": "struct MinPQ",
-            "members": [
-                {
-                    "astId": 14372,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "inner",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(PQ)15003_storage"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(PQ)15003_storage": {
-            "encoding": "inplace",
-            "label": "struct PQ",
-            "members": [
-                {
-                    "astId": 14992,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "size",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint16"
-                },
-                {
-                    "astId": 14997,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "addressToPos",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_mapping(t_address,t_uint16)"
-                },
-                {
-                    "astId": 15002,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "posToAddress",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_mapping(t_uint16,t_address)"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(Set)3036_storage": {
-            "encoding": "inplace",
-            "label": "struct EnumerableSet.Set",
-            "members": [
-                {
-                    "astId": 3031,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "_values",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_array(t_bytes32)dyn_storage"
-                },
-                {
-                    "astId": 3035,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "_indexes",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_mapping(t_bytes32,t_uint256)"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(StakingChange)15351_storage": {
-            "encoding": "inplace",
-            "label": "struct StakingChange",
-            "members": [
-                {
-                    "astId": 15346,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "op",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_enum(StakingOperation)15343"
-                },
-                {
-                    "astId": 15348,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "payload",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_bytes_storage"
-                },
-                {
-                    "astId": 15350,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "validator",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_address"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(StakingChangeLog)15370_storage": {
-            "encoding": "inplace",
-            "label": "struct StakingChangeLog",
-            "members": [
-                {
-                    "astId": 15360,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "nextConfigurationNumber",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15363,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "startConfigurationNumber",
-                    "offset": 8,
-                    "slot": "0",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15369,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "changes",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_mapping(t_uint64,t_struct(StakingChange)15351_storage)"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(StakingRelease)15377_storage": {
-            "encoding": "inplace",
-            "label": "struct StakingRelease",
-            "members": [
-                {
-                    "astId": 15373,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "releaseAt",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15376,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "amount",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_uint256"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(StakingReleaseQueue)15397_storage": {
-            "encoding": "inplace",
-            "label": "struct StakingReleaseQueue",
-            "members": [
-                {
-                    "astId": 15390,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "lockingDuration",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15396,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "releases",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_mapping(t_address,t_struct(AddressStakingReleases)15387_storage)"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(SubnetActorStorage)12943_storage": {
-            "encoding": "inplace",
-            "label": "struct SubnetActorStorage",
-            "members": [
-                {
-                    "astId": 12853,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "committedCheckpoints",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15246_storage)"
-                },
-                {
-                    "astId": 12858,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "genesisValidators",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_array(t_struct(Validator)15447_storage)dyn_storage"
-                },
-                {
-                    "astId": 12861,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "genesisCircSupply",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 12866,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "genesisBalance",
-                    "offset": 0,
-                    "slot": "3",
-                    "type": "t_mapping(t_address,t_uint256)"
-                },
-                {
-                    "astId": 12870,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "genesisBalanceKeys",
-                    "offset": 0,
-                    "slot": "4",
-                    "type": "t_array(t_address)dyn_storage"
-                },
-                {
-                    "astId": 12873,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "lastBottomUpCheckpointHeight",
-                    "offset": 0,
-                    "slot": "5",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 12876,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "minActivationCollateral",
-                    "offset": 0,
-                    "slot": "6",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 12879,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "bottomUpCheckPeriod",
-                    "offset": 0,
-                    "slot": "7",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 12882,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "minValidators",
-                    "offset": 8,
-                    "slot": "7",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 12884,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "currentSubnetHash",
-                    "offset": 0,
-                    "slot": "8",
-                    "type": "t_bytes32"
-                },
-                {
-                    "astId": 12887,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "ipcGatewayAddr",
-                    "offset": 0,
-                    "slot": "9",
-                    "type": "t_address"
-                },
-                {
-                    "astId": 12890,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "majorityPercentage",
-                    "offset": 20,
-                    "slot": "9",
-                    "type": "t_uint8"
-                },
-                {
-                    "astId": 12893,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "minCrossMsgFee",
-                    "offset": 0,
-                    "slot": "10",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 12897,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "parentId",
-                    "offset": 0,
-                    "slot": "11",
-                    "type": "t_struct(SubnetID)15322_storage"
-                },
-                {
-                    "astId": 12901,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "consensus",
-                    "offset": 0,
-                    "slot": "13",
-                    "type": "t_enum(ConsensusType)5061"
-                },
-                {
-                    "astId": 12904,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "bootstrapped",
-                    "offset": 1,
-                    "slot": "13",
-                    "type": "t_bool"
-                },
-                {
-                    "astId": 12907,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "killed",
-                    "offset": 2,
-                    "slot": "13",
-                    "type": "t_bool"
-                },
-                {
-                    "astId": 12911,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "validatorSet",
-                    "offset": 0,
-                    "slot": "14",
-                    "type": "t_struct(ValidatorSet)15426_storage"
-                },
-                {
-                    "astId": 12915,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "changeSet",
-                    "offset": 0,
-                    "slot": "23",
-                    "type": "t_struct(StakingChangeLog)15370_storage"
-                },
-                {
-                    "astId": 12919,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "releaseQueue",
-                    "offset": 0,
-                    "slot": "25",
-                    "type": "t_struct(StakingReleaseQueue)15397_storage"
-                },
-                {
-                    "astId": 12922,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "powerScale",
-                    "offset": 0,
-                    "slot": "27",
-                    "type": "t_int8"
-                },
-                {
-                    "astId": 12927,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "relayerRewards",
-                    "offset": 0,
-                    "slot": "28",
-                    "type": "t_mapping(t_address,t_uint256)"
-                },
-                {
-                    "astId": 12933,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "rewardedRelayers",
-                    "offset": 0,
-                    "slot": "29",
-                    "type": "t_mapping(t_uint64,t_struct(AddressSet)3351_storage)"
-                },
-                {
-                    "astId": 12938,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "bootstrapNodes",
-                    "offset": 0,
-                    "slot": "30",
-                    "type": "t_mapping(t_address,t_string_storage)"
-                },
-                {
-                    "astId": 12942,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "bootstrapOwners",
-                    "offset": 0,
-                    "slot": "31",
-                    "type": "t_struct(AddressSet)3351_storage"
-                }
-            ],
-            "numberOfBytes": "1056"
-        },
-        "t_struct(SubnetID)15322_storage": {
-            "encoding": "inplace",
-            "label": "struct SubnetID",
-            "members": [
-                {
-                    "astId": 15317,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "root",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15321,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "route",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_array(t_address)dyn_storage"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(Validator)15447_storage": {
-            "encoding": "inplace",
-            "label": "struct Validator",
-            "members": [
-                {
-                    "astId": 15442,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "weight",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15444,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "addr",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_address"
-                },
-                {
-                    "astId": 15446,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "metadata",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_bytes_storage"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(ValidatorInfo)15405_storage": {
-            "encoding": "inplace",
-            "label": "struct ValidatorInfo",
-            "members": [
-                {
-                    "astId": 15399,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "confirmedCollateral",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15401,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "totalCollateral",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15404,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "metadata",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_bytes_storage"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(ValidatorSet)15426_storage": {
-            "encoding": "inplace",
-            "label": "struct ValidatorSet",
-            "members": [
-                {
-                    "astId": 15408,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "activeLimit",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint16"
-                },
-                {
-                    "astId": 15411,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "totalConfirmedCollateral",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15417,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "validators",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_mapping(t_address,t_struct(ValidatorInfo)15405_storage)"
-                },
-                {
-                    "astId": 15421,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "activeValidators",
-                    "offset": 0,
-                    "slot": "3",
-                    "type": "t_struct(MinPQ)14373_storage"
-                },
-                {
-                    "astId": 15425,
-                    "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
-                    "label": "waitingValidators",
-                    "offset": 0,
-                    "slot": "6",
-                    "type": "t_struct(MaxPQ)13754_storage"
-                }
-            ],
-            "numberOfBytes": "288"
-        },
-        "t_uint16": {
-            "encoding": "inplace",
-            "label": "uint16",
-            "numberOfBytes": "2"
-        },
-        "t_uint256": {
-            "encoding": "inplace",
-            "label": "uint256",
-            "numberOfBytes": "32"
-        },
-        "t_uint64": {
-            "encoding": "inplace",
-            "label": "uint64",
-            "numberOfBytes": "8"
-        },
-        "t_uint8": {
-            "encoding": "inplace",
-            "label": "uint8",
-            "numberOfBytes": "1"
-        }
+  "storage": [
+    {
+      "astId": 3979,
+      "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+      "label": "s",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_struct(SubnetActorStorage)12882_storage"
     }
+  ],
+  "types": {
+    "t_address": {
+      "encoding": "inplace",
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "base": "t_address",
+      "encoding": "dynamic_array",
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_bytes32)dyn_storage": {
+      "base": "t_bytes32",
+      "encoding": "dynamic_array",
+      "label": "bytes32[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_struct(Validator)15377_storage)dyn_storage": {
+      "base": "t_struct(Validator)15377_storage",
+      "encoding": "dynamic_array",
+      "label": "struct Validator[]",
+      "numberOfBytes": "32"
+    },
+    "t_bool": {
+      "encoding": "inplace",
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_bytes32": {
+      "encoding": "inplace",
+      "label": "bytes32",
+      "numberOfBytes": "32"
+    },
+    "t_bytes_storage": {
+      "encoding": "bytes",
+      "label": "bytes",
+      "numberOfBytes": "32"
+    },
+    "t_enum(ConsensusType)5069": {
+      "encoding": "inplace",
+      "label": "enum ConsensusType",
+      "numberOfBytes": "1"
+    },
+    "t_enum(StakingOperation)15273": {
+      "encoding": "inplace",
+      "label": "enum StakingOperation",
+      "numberOfBytes": "1"
+    },
+    "t_int8": {
+      "encoding": "inplace",
+      "label": "int8",
+      "numberOfBytes": "1"
+    },
+    "t_mapping(t_address,t_string_storage)": {
+      "encoding": "mapping",
+      "key": "t_address",
+      "label": "mapping(address => string)",
+      "numberOfBytes": "32",
+      "value": "t_string_storage"
+    },
+    "t_mapping(t_address,t_struct(AddressStakingReleases)15317_storage)": {
+      "encoding": "mapping",
+      "key": "t_address",
+      "label": "mapping(address => struct AddressStakingReleases)",
+      "numberOfBytes": "32",
+      "value": "t_struct(AddressStakingReleases)15317_storage"
+    },
+    "t_mapping(t_address,t_struct(ValidatorInfo)15335_storage)": {
+      "encoding": "mapping",
+      "key": "t_address",
+      "label": "mapping(address => struct ValidatorInfo)",
+      "numberOfBytes": "32",
+      "value": "t_struct(ValidatorInfo)15335_storage"
+    },
+    "t_mapping(t_address,t_uint16)": {
+      "encoding": "mapping",
+      "key": "t_address",
+      "label": "mapping(address => uint16)",
+      "numberOfBytes": "32",
+      "value": "t_uint16"
+    },
+    "t_mapping(t_address,t_uint256)": {
+      "encoding": "mapping",
+      "key": "t_address",
+      "label": "mapping(address => uint256)",
+      "numberOfBytes": "32",
+      "value": "t_uint256"
+    },
+    "t_mapping(t_bytes32,t_uint256)": {
+      "encoding": "mapping",
+      "key": "t_bytes32",
+      "label": "mapping(bytes32 => uint256)",
+      "numberOfBytes": "32",
+      "value": "t_uint256"
+    },
+    "t_mapping(t_uint16,t_address)": {
+      "encoding": "mapping",
+      "key": "t_uint16",
+      "label": "mapping(uint16 => address)",
+      "numberOfBytes": "32",
+      "value": "t_address"
+    },
+    "t_mapping(t_uint16,t_struct(StakingRelease)15307_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint16",
+      "label": "mapping(uint16 => struct StakingRelease)",
+      "numberOfBytes": "32",
+      "value": "t_struct(StakingRelease)15307_storage"
+    },
+    "t_mapping(t_uint64,t_struct(AddressSet)3351_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint64",
+      "label": "mapping(uint64 => struct EnumerableSet.AddressSet)",
+      "numberOfBytes": "32",
+      "value": "t_struct(AddressSet)3351_storage"
+    },
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15176_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint64",
+      "label": "mapping(uint64 => struct BottomUpCheckpoint)",
+      "numberOfBytes": "32",
+      "value": "t_struct(BottomUpCheckpoint)15176_storage"
+    },
+    "t_mapping(t_uint64,t_struct(StakingChange)15281_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint64",
+      "label": "mapping(uint64 => struct StakingChange)",
+      "numberOfBytes": "32",
+      "value": "t_struct(StakingChange)15281_storage"
+    },
+    "t_string_storage": {
+      "encoding": "bytes",
+      "label": "string",
+      "numberOfBytes": "32"
+    },
+    "t_struct(AddressSet)3351_storage": {
+      "encoding": "inplace",
+      "label": "struct EnumerableSet.AddressSet",
+      "members": [
+        {
+          "astId": 3350,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "_inner",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(Set)3036_storage"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(AddressStakingReleases)15317_storage": {
+      "encoding": "inplace",
+      "label": "struct AddressStakingReleases",
+      "members": [
+        {
+          "astId": 15309,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "length",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint16"
+        },
+        {
+          "astId": 15311,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "startIdx",
+          "offset": 2,
+          "slot": "0",
+          "type": "t_uint16"
+        },
+        {
+          "astId": 15316,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "releases",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_mapping(t_uint16,t_struct(StakingRelease)15307_storage)"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(BottomUpCheckpoint)15176_storage": {
+      "encoding": "inplace",
+      "label": "struct BottomUpCheckpoint",
+      "members": [
+        {
+          "astId": 15163,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "subnetID",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(SubnetID)15252_storage"
+        },
+        {
+          "astId": 15166,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "blockHeight",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15169,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "blockHash",
+          "offset": 0,
+          "slot": "3",
+          "type": "t_bytes32"
+        },
+        {
+          "astId": 15172,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "nextConfigurationNumber",
+          "offset": 0,
+          "slot": "4",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15175,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "crossMessagesHash",
+          "offset": 0,
+          "slot": "5",
+          "type": "t_bytes32"
+        }
+      ],
+      "numberOfBytes": "192"
+    },
+    "t_struct(MaxPQ)13686_storage": {
+      "encoding": "inplace",
+      "label": "struct MaxPQ",
+      "members": [
+        {
+          "astId": 13685,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "inner",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(PQ)14933_storage"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(MinPQ)14304_storage": {
+      "encoding": "inplace",
+      "label": "struct MinPQ",
+      "members": [
+        {
+          "astId": 14303,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "inner",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(PQ)14933_storage"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(PQ)14933_storage": {
+      "encoding": "inplace",
+      "label": "struct PQ",
+      "members": [
+        {
+          "astId": 14922,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "size",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint16"
+        },
+        {
+          "astId": 14927,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "addressToPos",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_mapping(t_address,t_uint16)"
+        },
+        {
+          "astId": 14932,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "posToAddress",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_mapping(t_uint16,t_address)"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(Set)3036_storage": {
+      "encoding": "inplace",
+      "label": "struct EnumerableSet.Set",
+      "members": [
+        {
+          "astId": 3031,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "_values",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_array(t_bytes32)dyn_storage"
+        },
+        {
+          "astId": 3035,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "_indexes",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_mapping(t_bytes32,t_uint256)"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(StakingChange)15281_storage": {
+      "encoding": "inplace",
+      "label": "struct StakingChange",
+      "members": [
+        {
+          "astId": 15276,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "op",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_enum(StakingOperation)15273"
+        },
+        {
+          "astId": 15278,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "payload",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_bytes_storage"
+        },
+        {
+          "astId": 15280,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "validator",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_address"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(StakingChangeLog)15300_storage": {
+      "encoding": "inplace",
+      "label": "struct StakingChangeLog",
+      "members": [
+        {
+          "astId": 15290,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "nextConfigurationNumber",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15293,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "startConfigurationNumber",
+          "offset": 8,
+          "slot": "0",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15299,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "changes",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_mapping(t_uint64,t_struct(StakingChange)15281_storage)"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(StakingRelease)15307_storage": {
+      "encoding": "inplace",
+      "label": "struct StakingRelease",
+      "members": [
+        {
+          "astId": 15303,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "releaseAt",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15306,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "amount",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_uint256"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(StakingReleaseQueue)15327_storage": {
+      "encoding": "inplace",
+      "label": "struct StakingReleaseQueue",
+      "members": [
+        {
+          "astId": 15320,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "lockingDuration",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15326,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "releases",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_mapping(t_address,t_struct(AddressStakingReleases)15317_storage)"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(SubnetActorStorage)12882_storage": {
+      "encoding": "inplace",
+      "label": "struct SubnetActorStorage",
+      "members": [
+        {
+          "astId": 12789,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "committedCheckpoints",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15176_storage)"
+        },
+        {
+          "astId": 12794,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "genesisValidators",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_array(t_struct(Validator)15377_storage)dyn_storage"
+        },
+        {
+          "astId": 12797,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "genesisCircSupply",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 12802,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "genesisBalance",
+          "offset": 0,
+          "slot": "3",
+          "type": "t_mapping(t_address,t_uint256)"
+        },
+        {
+          "astId": 12806,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "genesisBalanceKeys",
+          "offset": 0,
+          "slot": "4",
+          "type": "t_array(t_address)dyn_storage"
+        },
+        {
+          "astId": 12809,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "lastBottomUpCheckpointHeight",
+          "offset": 0,
+          "slot": "5",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 12812,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "minActivationCollateral",
+          "offset": 0,
+          "slot": "6",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 12815,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "bottomUpCheckPeriod",
+          "offset": 0,
+          "slot": "7",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 12818,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "minValidators",
+          "offset": 8,
+          "slot": "7",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 12820,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "currentSubnetHash",
+          "offset": 0,
+          "slot": "8",
+          "type": "t_bytes32"
+        },
+        {
+          "astId": 12823,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "ipcGatewayAddr",
+          "offset": 0,
+          "slot": "9",
+          "type": "t_address"
+        },
+        {
+          "astId": 12826,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "majorityPercentage",
+          "offset": 20,
+          "slot": "9",
+          "type": "t_uint8"
+        },
+        {
+          "astId": 12829,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "minCrossMsgFee",
+          "offset": 0,
+          "slot": "10",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 12833,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "parentId",
+          "offset": 0,
+          "slot": "11",
+          "type": "t_struct(SubnetID)15252_storage"
+        },
+        {
+          "astId": 12837,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "consensus",
+          "offset": 0,
+          "slot": "13",
+          "type": "t_enum(ConsensusType)5069"
+        },
+        {
+          "astId": 12840,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "bootstrapped",
+          "offset": 1,
+          "slot": "13",
+          "type": "t_bool"
+        },
+        {
+          "astId": 12843,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "permissioned",
+          "offset": 2,
+          "slot": "13",
+          "type": "t_bool"
+        },
+        {
+          "astId": 12846,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "killed",
+          "offset": 3,
+          "slot": "13",
+          "type": "t_bool"
+        },
+        {
+          "astId": 12850,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "validatorSet",
+          "offset": 0,
+          "slot": "14",
+          "type": "t_struct(ValidatorSet)15356_storage"
+        },
+        {
+          "astId": 12854,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "changeSet",
+          "offset": 0,
+          "slot": "23",
+          "type": "t_struct(StakingChangeLog)15300_storage"
+        },
+        {
+          "astId": 12858,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "releaseQueue",
+          "offset": 0,
+          "slot": "25",
+          "type": "t_struct(StakingReleaseQueue)15327_storage"
+        },
+        {
+          "astId": 12861,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "powerScale",
+          "offset": 0,
+          "slot": "27",
+          "type": "t_int8"
+        },
+        {
+          "astId": 12866,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "relayerRewards",
+          "offset": 0,
+          "slot": "28",
+          "type": "t_mapping(t_address,t_uint256)"
+        },
+        {
+          "astId": 12872,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "rewardedRelayers",
+          "offset": 0,
+          "slot": "29",
+          "type": "t_mapping(t_uint64,t_struct(AddressSet)3351_storage)"
+        },
+        {
+          "astId": 12877,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "bootstrapNodes",
+          "offset": 0,
+          "slot": "30",
+          "type": "t_mapping(t_address,t_string_storage)"
+        },
+        {
+          "astId": 12881,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "bootstrapOwners",
+          "offset": 0,
+          "slot": "31",
+          "type": "t_struct(AddressSet)3351_storage"
+        }
+      ],
+      "numberOfBytes": "1056"
+    },
+    "t_struct(SubnetID)15252_storage": {
+      "encoding": "inplace",
+      "label": "struct SubnetID",
+      "members": [
+        {
+          "astId": 15247,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "root",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15251,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "route",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_array(t_address)dyn_storage"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(Validator)15377_storage": {
+      "encoding": "inplace",
+      "label": "struct Validator",
+      "members": [
+        {
+          "astId": 15372,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "weight",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15374,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "addr",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_address"
+        },
+        {
+          "astId": 15376,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "metadata",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_bytes_storage"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(ValidatorInfo)15335_storage": {
+      "encoding": "inplace",
+      "label": "struct ValidatorInfo",
+      "members": [
+        {
+          "astId": 15329,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "confirmedCollateral",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15331,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "totalCollateral",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15334,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "metadata",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_bytes_storage"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(ValidatorSet)15356_storage": {
+      "encoding": "inplace",
+      "label": "struct ValidatorSet",
+      "members": [
+        {
+          "astId": 15338,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "activeLimit",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint16"
+        },
+        {
+          "astId": 15341,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "totalConfirmedCollateral",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15347,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "validators",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_mapping(t_address,t_struct(ValidatorInfo)15335_storage)"
+        },
+        {
+          "astId": 15351,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "activeValidators",
+          "offset": 0,
+          "slot": "3",
+          "type": "t_struct(MinPQ)14304_storage"
+        },
+        {
+          "astId": 15355,
+          "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
+          "label": "waitingValidators",
+          "offset": 0,
+          "slot": "6",
+          "type": "t_struct(MaxPQ)13686_storage"
+        }
+      ],
+      "numberOfBytes": "288"
+    },
+    "t_uint16": {
+      "encoding": "inplace",
+      "label": "uint16",
+      "numberOfBytes": "2"
+    },
+    "t_uint256": {
+      "encoding": "inplace",
+      "label": "uint256",
+      "numberOfBytes": "32"
+    },
+    "t_uint64": {
+      "encoding": "inplace",
+      "label": "uint64",
+      "numberOfBytes": "8"
+    },
+    "t_uint8": {
+      "encoding": "inplace",
+      "label": "uint8",
+      "numberOfBytes": "1"
+    }
+  }
 }

--- a/.storage-layouts/SubnetActorModifiers.json
+++ b/.storage-layouts/SubnetActorModifiers.json
@@ -1,793 +1,801 @@
 {
-    "storage": [
-        {
-            "astId": 12957,
-            "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-            "label": "s",
-            "offset": 0,
-            "slot": "0",
-            "type": "t_struct(SubnetActorStorage)12943_storage"
-        }
-    ],
-    "types": {
-        "t_address": {
-            "encoding": "inplace",
-            "label": "address",
-            "numberOfBytes": "20"
-        },
-        "t_array(t_address)dyn_storage": {
-            "base": "t_address",
-            "encoding": "dynamic_array",
-            "label": "address[]",
-            "numberOfBytes": "32"
-        },
-        "t_array(t_bytes32)dyn_storage": {
-            "base": "t_bytes32",
-            "encoding": "dynamic_array",
-            "label": "bytes32[]",
-            "numberOfBytes": "32"
-        },
-        "t_array(t_struct(Validator)15447_storage)dyn_storage": {
-            "base": "t_struct(Validator)15447_storage",
-            "encoding": "dynamic_array",
-            "label": "struct Validator[]",
-            "numberOfBytes": "32"
-        },
-        "t_bool": {
-            "encoding": "inplace",
-            "label": "bool",
-            "numberOfBytes": "1"
-        },
-        "t_bytes32": {
-            "encoding": "inplace",
-            "label": "bytes32",
-            "numberOfBytes": "32"
-        },
-        "t_bytes_storage": {
-            "encoding": "bytes",
-            "label": "bytes",
-            "numberOfBytes": "32"
-        },
-        "t_enum(ConsensusType)5061": {
-            "encoding": "inplace",
-            "label": "enum ConsensusType",
-            "numberOfBytes": "1"
-        },
-        "t_enum(StakingOperation)15343": {
-            "encoding": "inplace",
-            "label": "enum StakingOperation",
-            "numberOfBytes": "1"
-        },
-        "t_int8": {
-            "encoding": "inplace",
-            "label": "int8",
-            "numberOfBytes": "1"
-        },
-        "t_mapping(t_address,t_string_storage)": {
-            "encoding": "mapping",
-            "key": "t_address",
-            "label": "mapping(address => string)",
-            "numberOfBytes": "32",
-            "value": "t_string_storage"
-        },
-        "t_mapping(t_address,t_struct(AddressStakingReleases)15387_storage)": {
-            "encoding": "mapping",
-            "key": "t_address",
-            "label": "mapping(address => struct AddressStakingReleases)",
-            "numberOfBytes": "32",
-            "value": "t_struct(AddressStakingReleases)15387_storage"
-        },
-        "t_mapping(t_address,t_struct(ValidatorInfo)15405_storage)": {
-            "encoding": "mapping",
-            "key": "t_address",
-            "label": "mapping(address => struct ValidatorInfo)",
-            "numberOfBytes": "32",
-            "value": "t_struct(ValidatorInfo)15405_storage"
-        },
-        "t_mapping(t_address,t_uint16)": {
-            "encoding": "mapping",
-            "key": "t_address",
-            "label": "mapping(address => uint16)",
-            "numberOfBytes": "32",
-            "value": "t_uint16"
-        },
-        "t_mapping(t_address,t_uint256)": {
-            "encoding": "mapping",
-            "key": "t_address",
-            "label": "mapping(address => uint256)",
-            "numberOfBytes": "32",
-            "value": "t_uint256"
-        },
-        "t_mapping(t_bytes32,t_uint256)": {
-            "encoding": "mapping",
-            "key": "t_bytes32",
-            "label": "mapping(bytes32 => uint256)",
-            "numberOfBytes": "32",
-            "value": "t_uint256"
-        },
-        "t_mapping(t_uint16,t_address)": {
-            "encoding": "mapping",
-            "key": "t_uint16",
-            "label": "mapping(uint16 => address)",
-            "numberOfBytes": "32",
-            "value": "t_address"
-        },
-        "t_mapping(t_uint16,t_struct(StakingRelease)15377_storage)": {
-            "encoding": "mapping",
-            "key": "t_uint16",
-            "label": "mapping(uint16 => struct StakingRelease)",
-            "numberOfBytes": "32",
-            "value": "t_struct(StakingRelease)15377_storage"
-        },
-        "t_mapping(t_uint64,t_struct(AddressSet)3351_storage)": {
-            "encoding": "mapping",
-            "key": "t_uint64",
-            "label": "mapping(uint64 => struct EnumerableSet.AddressSet)",
-            "numberOfBytes": "32",
-            "value": "t_struct(AddressSet)3351_storage"
-        },
-        "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15246_storage)": {
-            "encoding": "mapping",
-            "key": "t_uint64",
-            "label": "mapping(uint64 => struct BottomUpCheckpoint)",
-            "numberOfBytes": "32",
-            "value": "t_struct(BottomUpCheckpoint)15246_storage"
-        },
-        "t_mapping(t_uint64,t_struct(StakingChange)15351_storage)": {
-            "encoding": "mapping",
-            "key": "t_uint64",
-            "label": "mapping(uint64 => struct StakingChange)",
-            "numberOfBytes": "32",
-            "value": "t_struct(StakingChange)15351_storage"
-        },
-        "t_string_storage": {
-            "encoding": "bytes",
-            "label": "string",
-            "numberOfBytes": "32"
-        },
-        "t_struct(AddressSet)3351_storage": {
-            "encoding": "inplace",
-            "label": "struct EnumerableSet.AddressSet",
-            "members": [
-                {
-                    "astId": 3350,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "_inner",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(Set)3036_storage"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(AddressStakingReleases)15387_storage": {
-            "encoding": "inplace",
-            "label": "struct AddressStakingReleases",
-            "members": [
-                {
-                    "astId": 15379,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "length",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint16"
-                },
-                {
-                    "astId": 15381,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "startIdx",
-                    "offset": 2,
-                    "slot": "0",
-                    "type": "t_uint16"
-                },
-                {
-                    "astId": 15386,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "releases",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_mapping(t_uint16,t_struct(StakingRelease)15377_storage)"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(BottomUpCheckpoint)15246_storage": {
-            "encoding": "inplace",
-            "label": "struct BottomUpCheckpoint",
-            "members": [
-                {
-                    "astId": 15233,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "subnetID",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(SubnetID)15322_storage"
-                },
-                {
-                    "astId": 15236,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "blockHeight",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15239,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "blockHash",
-                    "offset": 0,
-                    "slot": "3",
-                    "type": "t_bytes32"
-                },
-                {
-                    "astId": 15242,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "nextConfigurationNumber",
-                    "offset": 0,
-                    "slot": "4",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15245,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "crossMessagesHash",
-                    "offset": 0,
-                    "slot": "5",
-                    "type": "t_bytes32"
-                }
-            ],
-            "numberOfBytes": "192"
-        },
-        "t_struct(MaxPQ)13754_storage": {
-            "encoding": "inplace",
-            "label": "struct MaxPQ",
-            "members": [
-                {
-                    "astId": 13753,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "inner",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(PQ)15003_storage"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(MinPQ)14373_storage": {
-            "encoding": "inplace",
-            "label": "struct MinPQ",
-            "members": [
-                {
-                    "astId": 14372,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "inner",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_struct(PQ)15003_storage"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(PQ)15003_storage": {
-            "encoding": "inplace",
-            "label": "struct PQ",
-            "members": [
-                {
-                    "astId": 14992,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "size",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint16"
-                },
-                {
-                    "astId": 14997,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "addressToPos",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_mapping(t_address,t_uint16)"
-                },
-                {
-                    "astId": 15002,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "posToAddress",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_mapping(t_uint16,t_address)"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(Set)3036_storage": {
-            "encoding": "inplace",
-            "label": "struct EnumerableSet.Set",
-            "members": [
-                {
-                    "astId": 3031,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "_values",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_array(t_bytes32)dyn_storage"
-                },
-                {
-                    "astId": 3035,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "_indexes",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_mapping(t_bytes32,t_uint256)"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(StakingChange)15351_storage": {
-            "encoding": "inplace",
-            "label": "struct StakingChange",
-            "members": [
-                {
-                    "astId": 15346,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "op",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_enum(StakingOperation)15343"
-                },
-                {
-                    "astId": 15348,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "payload",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_bytes_storage"
-                },
-                {
-                    "astId": 15350,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "validator",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_address"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(StakingChangeLog)15370_storage": {
-            "encoding": "inplace",
-            "label": "struct StakingChangeLog",
-            "members": [
-                {
-                    "astId": 15360,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "nextConfigurationNumber",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15363,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "startConfigurationNumber",
-                    "offset": 8,
-                    "slot": "0",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15369,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "changes",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_mapping(t_uint64,t_struct(StakingChange)15351_storage)"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(StakingRelease)15377_storage": {
-            "encoding": "inplace",
-            "label": "struct StakingRelease",
-            "members": [
-                {
-                    "astId": 15373,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "releaseAt",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15376,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "amount",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_uint256"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(StakingReleaseQueue)15397_storage": {
-            "encoding": "inplace",
-            "label": "struct StakingReleaseQueue",
-            "members": [
-                {
-                    "astId": 15390,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "lockingDuration",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15396,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "releases",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_mapping(t_address,t_struct(AddressStakingReleases)15387_storage)"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(SubnetActorStorage)12943_storage": {
-            "encoding": "inplace",
-            "label": "struct SubnetActorStorage",
-            "members": [
-                {
-                    "astId": 12853,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "committedCheckpoints",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15246_storage)"
-                },
-                {
-                    "astId": 12858,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "genesisValidators",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_array(t_struct(Validator)15447_storage)dyn_storage"
-                },
-                {
-                    "astId": 12861,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "genesisCircSupply",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 12866,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "genesisBalance",
-                    "offset": 0,
-                    "slot": "3",
-                    "type": "t_mapping(t_address,t_uint256)"
-                },
-                {
-                    "astId": 12870,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "genesisBalanceKeys",
-                    "offset": 0,
-                    "slot": "4",
-                    "type": "t_array(t_address)dyn_storage"
-                },
-                {
-                    "astId": 12873,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "lastBottomUpCheckpointHeight",
-                    "offset": 0,
-                    "slot": "5",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 12876,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "minActivationCollateral",
-                    "offset": 0,
-                    "slot": "6",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 12879,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "bottomUpCheckPeriod",
-                    "offset": 0,
-                    "slot": "7",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 12882,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "minValidators",
-                    "offset": 8,
-                    "slot": "7",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 12884,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "currentSubnetHash",
-                    "offset": 0,
-                    "slot": "8",
-                    "type": "t_bytes32"
-                },
-                {
-                    "astId": 12887,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "ipcGatewayAddr",
-                    "offset": 0,
-                    "slot": "9",
-                    "type": "t_address"
-                },
-                {
-                    "astId": 12890,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "majorityPercentage",
-                    "offset": 20,
-                    "slot": "9",
-                    "type": "t_uint8"
-                },
-                {
-                    "astId": 12893,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "minCrossMsgFee",
-                    "offset": 0,
-                    "slot": "10",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 12897,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "parentId",
-                    "offset": 0,
-                    "slot": "11",
-                    "type": "t_struct(SubnetID)15322_storage"
-                },
-                {
-                    "astId": 12901,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "consensus",
-                    "offset": 0,
-                    "slot": "13",
-                    "type": "t_enum(ConsensusType)5061"
-                },
-                {
-                    "astId": 12904,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "bootstrapped",
-                    "offset": 1,
-                    "slot": "13",
-                    "type": "t_bool"
-                },
-                {
-                    "astId": 12907,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "killed",
-                    "offset": 2,
-                    "slot": "13",
-                    "type": "t_bool"
-                },
-                {
-                    "astId": 12911,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "validatorSet",
-                    "offset": 0,
-                    "slot": "14",
-                    "type": "t_struct(ValidatorSet)15426_storage"
-                },
-                {
-                    "astId": 12915,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "changeSet",
-                    "offset": 0,
-                    "slot": "23",
-                    "type": "t_struct(StakingChangeLog)15370_storage"
-                },
-                {
-                    "astId": 12919,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "releaseQueue",
-                    "offset": 0,
-                    "slot": "25",
-                    "type": "t_struct(StakingReleaseQueue)15397_storage"
-                },
-                {
-                    "astId": 12922,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "powerScale",
-                    "offset": 0,
-                    "slot": "27",
-                    "type": "t_int8"
-                },
-                {
-                    "astId": 12927,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "relayerRewards",
-                    "offset": 0,
-                    "slot": "28",
-                    "type": "t_mapping(t_address,t_uint256)"
-                },
-                {
-                    "astId": 12933,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "rewardedRelayers",
-                    "offset": 0,
-                    "slot": "29",
-                    "type": "t_mapping(t_uint64,t_struct(AddressSet)3351_storage)"
-                },
-                {
-                    "astId": 12938,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "bootstrapNodes",
-                    "offset": 0,
-                    "slot": "30",
-                    "type": "t_mapping(t_address,t_string_storage)"
-                },
-                {
-                    "astId": 12942,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "bootstrapOwners",
-                    "offset": 0,
-                    "slot": "31",
-                    "type": "t_struct(AddressSet)3351_storage"
-                }
-            ],
-            "numberOfBytes": "1056"
-        },
-        "t_struct(SubnetID)15322_storage": {
-            "encoding": "inplace",
-            "label": "struct SubnetID",
-            "members": [
-                {
-                    "astId": 15317,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "root",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint64"
-                },
-                {
-                    "astId": 15321,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "route",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_array(t_address)dyn_storage"
-                }
-            ],
-            "numberOfBytes": "64"
-        },
-        "t_struct(Validator)15447_storage": {
-            "encoding": "inplace",
-            "label": "struct Validator",
-            "members": [
-                {
-                    "astId": 15442,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "weight",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15444,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "addr",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_address"
-                },
-                {
-                    "astId": 15446,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "metadata",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_bytes_storage"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(ValidatorInfo)15405_storage": {
-            "encoding": "inplace",
-            "label": "struct ValidatorInfo",
-            "members": [
-                {
-                    "astId": 15399,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "confirmedCollateral",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15401,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "totalCollateral",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15404,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "metadata",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_bytes_storage"
-                }
-            ],
-            "numberOfBytes": "96"
-        },
-        "t_struct(ValidatorSet)15426_storage": {
-            "encoding": "inplace",
-            "label": "struct ValidatorSet",
-            "members": [
-                {
-                    "astId": 15408,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "activeLimit",
-                    "offset": 0,
-                    "slot": "0",
-                    "type": "t_uint16"
-                },
-                {
-                    "astId": 15411,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "totalConfirmedCollateral",
-                    "offset": 0,
-                    "slot": "1",
-                    "type": "t_uint256"
-                },
-                {
-                    "astId": 15417,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "validators",
-                    "offset": 0,
-                    "slot": "2",
-                    "type": "t_mapping(t_address,t_struct(ValidatorInfo)15405_storage)"
-                },
-                {
-                    "astId": 15421,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "activeValidators",
-                    "offset": 0,
-                    "slot": "3",
-                    "type": "t_struct(MinPQ)14373_storage"
-                },
-                {
-                    "astId": 15425,
-                    "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
-                    "label": "waitingValidators",
-                    "offset": 0,
-                    "slot": "6",
-                    "type": "t_struct(MaxPQ)13754_storage"
-                }
-            ],
-            "numberOfBytes": "288"
-        },
-        "t_uint16": {
-            "encoding": "inplace",
-            "label": "uint16",
-            "numberOfBytes": "2"
-        },
-        "t_uint256": {
-            "encoding": "inplace",
-            "label": "uint256",
-            "numberOfBytes": "32"
-        },
-        "t_uint64": {
-            "encoding": "inplace",
-            "label": "uint64",
-            "numberOfBytes": "8"
-        },
-        "t_uint8": {
-            "encoding": "inplace",
-            "label": "uint8",
-            "numberOfBytes": "1"
-        }
+  "storage": [
+    {
+      "astId": 12896,
+      "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+      "label": "s",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_struct(SubnetActorStorage)12882_storage"
     }
+  ],
+  "types": {
+    "t_address": {
+      "encoding": "inplace",
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "base": "t_address",
+      "encoding": "dynamic_array",
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_bytes32)dyn_storage": {
+      "base": "t_bytes32",
+      "encoding": "dynamic_array",
+      "label": "bytes32[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_struct(Validator)15377_storage)dyn_storage": {
+      "base": "t_struct(Validator)15377_storage",
+      "encoding": "dynamic_array",
+      "label": "struct Validator[]",
+      "numberOfBytes": "32"
+    },
+    "t_bool": {
+      "encoding": "inplace",
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_bytes32": {
+      "encoding": "inplace",
+      "label": "bytes32",
+      "numberOfBytes": "32"
+    },
+    "t_bytes_storage": {
+      "encoding": "bytes",
+      "label": "bytes",
+      "numberOfBytes": "32"
+    },
+    "t_enum(ConsensusType)5069": {
+      "encoding": "inplace",
+      "label": "enum ConsensusType",
+      "numberOfBytes": "1"
+    },
+    "t_enum(StakingOperation)15273": {
+      "encoding": "inplace",
+      "label": "enum StakingOperation",
+      "numberOfBytes": "1"
+    },
+    "t_int8": {
+      "encoding": "inplace",
+      "label": "int8",
+      "numberOfBytes": "1"
+    },
+    "t_mapping(t_address,t_string_storage)": {
+      "encoding": "mapping",
+      "key": "t_address",
+      "label": "mapping(address => string)",
+      "numberOfBytes": "32",
+      "value": "t_string_storage"
+    },
+    "t_mapping(t_address,t_struct(AddressStakingReleases)15317_storage)": {
+      "encoding": "mapping",
+      "key": "t_address",
+      "label": "mapping(address => struct AddressStakingReleases)",
+      "numberOfBytes": "32",
+      "value": "t_struct(AddressStakingReleases)15317_storage"
+    },
+    "t_mapping(t_address,t_struct(ValidatorInfo)15335_storage)": {
+      "encoding": "mapping",
+      "key": "t_address",
+      "label": "mapping(address => struct ValidatorInfo)",
+      "numberOfBytes": "32",
+      "value": "t_struct(ValidatorInfo)15335_storage"
+    },
+    "t_mapping(t_address,t_uint16)": {
+      "encoding": "mapping",
+      "key": "t_address",
+      "label": "mapping(address => uint16)",
+      "numberOfBytes": "32",
+      "value": "t_uint16"
+    },
+    "t_mapping(t_address,t_uint256)": {
+      "encoding": "mapping",
+      "key": "t_address",
+      "label": "mapping(address => uint256)",
+      "numberOfBytes": "32",
+      "value": "t_uint256"
+    },
+    "t_mapping(t_bytes32,t_uint256)": {
+      "encoding": "mapping",
+      "key": "t_bytes32",
+      "label": "mapping(bytes32 => uint256)",
+      "numberOfBytes": "32",
+      "value": "t_uint256"
+    },
+    "t_mapping(t_uint16,t_address)": {
+      "encoding": "mapping",
+      "key": "t_uint16",
+      "label": "mapping(uint16 => address)",
+      "numberOfBytes": "32",
+      "value": "t_address"
+    },
+    "t_mapping(t_uint16,t_struct(StakingRelease)15307_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint16",
+      "label": "mapping(uint16 => struct StakingRelease)",
+      "numberOfBytes": "32",
+      "value": "t_struct(StakingRelease)15307_storage"
+    },
+    "t_mapping(t_uint64,t_struct(AddressSet)3351_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint64",
+      "label": "mapping(uint64 => struct EnumerableSet.AddressSet)",
+      "numberOfBytes": "32",
+      "value": "t_struct(AddressSet)3351_storage"
+    },
+    "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15176_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint64",
+      "label": "mapping(uint64 => struct BottomUpCheckpoint)",
+      "numberOfBytes": "32",
+      "value": "t_struct(BottomUpCheckpoint)15176_storage"
+    },
+    "t_mapping(t_uint64,t_struct(StakingChange)15281_storage)": {
+      "encoding": "mapping",
+      "key": "t_uint64",
+      "label": "mapping(uint64 => struct StakingChange)",
+      "numberOfBytes": "32",
+      "value": "t_struct(StakingChange)15281_storage"
+    },
+    "t_string_storage": {
+      "encoding": "bytes",
+      "label": "string",
+      "numberOfBytes": "32"
+    },
+    "t_struct(AddressSet)3351_storage": {
+      "encoding": "inplace",
+      "label": "struct EnumerableSet.AddressSet",
+      "members": [
+        {
+          "astId": 3350,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "_inner",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(Set)3036_storage"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(AddressStakingReleases)15317_storage": {
+      "encoding": "inplace",
+      "label": "struct AddressStakingReleases",
+      "members": [
+        {
+          "astId": 15309,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "length",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint16"
+        },
+        {
+          "astId": 15311,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "startIdx",
+          "offset": 2,
+          "slot": "0",
+          "type": "t_uint16"
+        },
+        {
+          "astId": 15316,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "releases",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_mapping(t_uint16,t_struct(StakingRelease)15307_storage)"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(BottomUpCheckpoint)15176_storage": {
+      "encoding": "inplace",
+      "label": "struct BottomUpCheckpoint",
+      "members": [
+        {
+          "astId": 15163,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "subnetID",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(SubnetID)15252_storage"
+        },
+        {
+          "astId": 15166,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "blockHeight",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15169,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "blockHash",
+          "offset": 0,
+          "slot": "3",
+          "type": "t_bytes32"
+        },
+        {
+          "astId": 15172,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "nextConfigurationNumber",
+          "offset": 0,
+          "slot": "4",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15175,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "crossMessagesHash",
+          "offset": 0,
+          "slot": "5",
+          "type": "t_bytes32"
+        }
+      ],
+      "numberOfBytes": "192"
+    },
+    "t_struct(MaxPQ)13686_storage": {
+      "encoding": "inplace",
+      "label": "struct MaxPQ",
+      "members": [
+        {
+          "astId": 13685,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "inner",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(PQ)14933_storage"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(MinPQ)14304_storage": {
+      "encoding": "inplace",
+      "label": "struct MinPQ",
+      "members": [
+        {
+          "astId": 14303,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "inner",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_struct(PQ)14933_storage"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(PQ)14933_storage": {
+      "encoding": "inplace",
+      "label": "struct PQ",
+      "members": [
+        {
+          "astId": 14922,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "size",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint16"
+        },
+        {
+          "astId": 14927,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "addressToPos",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_mapping(t_address,t_uint16)"
+        },
+        {
+          "astId": 14932,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "posToAddress",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_mapping(t_uint16,t_address)"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(Set)3036_storage": {
+      "encoding": "inplace",
+      "label": "struct EnumerableSet.Set",
+      "members": [
+        {
+          "astId": 3031,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "_values",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_array(t_bytes32)dyn_storage"
+        },
+        {
+          "astId": 3035,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "_indexes",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_mapping(t_bytes32,t_uint256)"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(StakingChange)15281_storage": {
+      "encoding": "inplace",
+      "label": "struct StakingChange",
+      "members": [
+        {
+          "astId": 15276,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "op",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_enum(StakingOperation)15273"
+        },
+        {
+          "astId": 15278,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "payload",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_bytes_storage"
+        },
+        {
+          "astId": 15280,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "validator",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_address"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(StakingChangeLog)15300_storage": {
+      "encoding": "inplace",
+      "label": "struct StakingChangeLog",
+      "members": [
+        {
+          "astId": 15290,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "nextConfigurationNumber",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15293,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "startConfigurationNumber",
+          "offset": 8,
+          "slot": "0",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15299,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "changes",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_mapping(t_uint64,t_struct(StakingChange)15281_storage)"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(StakingRelease)15307_storage": {
+      "encoding": "inplace",
+      "label": "struct StakingRelease",
+      "members": [
+        {
+          "astId": 15303,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "releaseAt",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15306,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "amount",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_uint256"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(StakingReleaseQueue)15327_storage": {
+      "encoding": "inplace",
+      "label": "struct StakingReleaseQueue",
+      "members": [
+        {
+          "astId": 15320,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "lockingDuration",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15326,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "releases",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_mapping(t_address,t_struct(AddressStakingReleases)15317_storage)"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(SubnetActorStorage)12882_storage": {
+      "encoding": "inplace",
+      "label": "struct SubnetActorStorage",
+      "members": [
+        {
+          "astId": 12789,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "committedCheckpoints",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_mapping(t_uint64,t_struct(BottomUpCheckpoint)15176_storage)"
+        },
+        {
+          "astId": 12794,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "genesisValidators",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_array(t_struct(Validator)15377_storage)dyn_storage"
+        },
+        {
+          "astId": 12797,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "genesisCircSupply",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 12802,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "genesisBalance",
+          "offset": 0,
+          "slot": "3",
+          "type": "t_mapping(t_address,t_uint256)"
+        },
+        {
+          "astId": 12806,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "genesisBalanceKeys",
+          "offset": 0,
+          "slot": "4",
+          "type": "t_array(t_address)dyn_storage"
+        },
+        {
+          "astId": 12809,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "lastBottomUpCheckpointHeight",
+          "offset": 0,
+          "slot": "5",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 12812,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "minActivationCollateral",
+          "offset": 0,
+          "slot": "6",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 12815,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "bottomUpCheckPeriod",
+          "offset": 0,
+          "slot": "7",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 12818,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "minValidators",
+          "offset": 8,
+          "slot": "7",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 12820,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "currentSubnetHash",
+          "offset": 0,
+          "slot": "8",
+          "type": "t_bytes32"
+        },
+        {
+          "astId": 12823,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "ipcGatewayAddr",
+          "offset": 0,
+          "slot": "9",
+          "type": "t_address"
+        },
+        {
+          "astId": 12826,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "majorityPercentage",
+          "offset": 20,
+          "slot": "9",
+          "type": "t_uint8"
+        },
+        {
+          "astId": 12829,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "minCrossMsgFee",
+          "offset": 0,
+          "slot": "10",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 12833,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "parentId",
+          "offset": 0,
+          "slot": "11",
+          "type": "t_struct(SubnetID)15252_storage"
+        },
+        {
+          "astId": 12837,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "consensus",
+          "offset": 0,
+          "slot": "13",
+          "type": "t_enum(ConsensusType)5069"
+        },
+        {
+          "astId": 12840,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "bootstrapped",
+          "offset": 1,
+          "slot": "13",
+          "type": "t_bool"
+        },
+        {
+          "astId": 12843,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "permissioned",
+          "offset": 2,
+          "slot": "13",
+          "type": "t_bool"
+        },
+        {
+          "astId": 12846,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "killed",
+          "offset": 3,
+          "slot": "13",
+          "type": "t_bool"
+        },
+        {
+          "astId": 12850,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "validatorSet",
+          "offset": 0,
+          "slot": "14",
+          "type": "t_struct(ValidatorSet)15356_storage"
+        },
+        {
+          "astId": 12854,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "changeSet",
+          "offset": 0,
+          "slot": "23",
+          "type": "t_struct(StakingChangeLog)15300_storage"
+        },
+        {
+          "astId": 12858,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "releaseQueue",
+          "offset": 0,
+          "slot": "25",
+          "type": "t_struct(StakingReleaseQueue)15327_storage"
+        },
+        {
+          "astId": 12861,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "powerScale",
+          "offset": 0,
+          "slot": "27",
+          "type": "t_int8"
+        },
+        {
+          "astId": 12866,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "relayerRewards",
+          "offset": 0,
+          "slot": "28",
+          "type": "t_mapping(t_address,t_uint256)"
+        },
+        {
+          "astId": 12872,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "rewardedRelayers",
+          "offset": 0,
+          "slot": "29",
+          "type": "t_mapping(t_uint64,t_struct(AddressSet)3351_storage)"
+        },
+        {
+          "astId": 12877,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "bootstrapNodes",
+          "offset": 0,
+          "slot": "30",
+          "type": "t_mapping(t_address,t_string_storage)"
+        },
+        {
+          "astId": 12881,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "bootstrapOwners",
+          "offset": 0,
+          "slot": "31",
+          "type": "t_struct(AddressSet)3351_storage"
+        }
+      ],
+      "numberOfBytes": "1056"
+    },
+    "t_struct(SubnetID)15252_storage": {
+      "encoding": "inplace",
+      "label": "struct SubnetID",
+      "members": [
+        {
+          "astId": 15247,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "root",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint64"
+        },
+        {
+          "astId": 15251,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "route",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_array(t_address)dyn_storage"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(Validator)15377_storage": {
+      "encoding": "inplace",
+      "label": "struct Validator",
+      "members": [
+        {
+          "astId": 15372,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "weight",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15374,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "addr",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_address"
+        },
+        {
+          "astId": 15376,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "metadata",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_bytes_storage"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(ValidatorInfo)15335_storage": {
+      "encoding": "inplace",
+      "label": "struct ValidatorInfo",
+      "members": [
+        {
+          "astId": 15329,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "confirmedCollateral",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15331,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "totalCollateral",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15334,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "metadata",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_bytes_storage"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_struct(ValidatorSet)15356_storage": {
+      "encoding": "inplace",
+      "label": "struct ValidatorSet",
+      "members": [
+        {
+          "astId": 15338,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "activeLimit",
+          "offset": 0,
+          "slot": "0",
+          "type": "t_uint16"
+        },
+        {
+          "astId": 15341,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "totalConfirmedCollateral",
+          "offset": 0,
+          "slot": "1",
+          "type": "t_uint256"
+        },
+        {
+          "astId": 15347,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "validators",
+          "offset": 0,
+          "slot": "2",
+          "type": "t_mapping(t_address,t_struct(ValidatorInfo)15335_storage)"
+        },
+        {
+          "astId": 15351,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "activeValidators",
+          "offset": 0,
+          "slot": "3",
+          "type": "t_struct(MinPQ)14304_storage"
+        },
+        {
+          "astId": 15355,
+          "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
+          "label": "waitingValidators",
+          "offset": 0,
+          "slot": "6",
+          "type": "t_struct(MaxPQ)13686_storage"
+        }
+      ],
+      "numberOfBytes": "288"
+    },
+    "t_uint16": {
+      "encoding": "inplace",
+      "label": "uint16",
+      "numberOfBytes": "2"
+    },
+    "t_uint256": {
+      "encoding": "inplace",
+      "label": "uint256",
+      "numberOfBytes": "32"
+    },
+    "t_uint64": {
+      "encoding": "inplace",
+      "label": "uint64",
+      "numberOfBytes": "8"
+    },
+    "t_uint8": {
+      "encoding": "inplace",
+      "label": "uint8",
+      "numberOfBytes": "1"
+    }
+  }
 }

--- a/src/SubnetActorDiamond.sol
+++ b/src/SubnetActorDiamond.sol
@@ -31,6 +31,7 @@ contract SubnetActorDiamond {
         uint16 activeValidatorsLimit;
         uint256 minCrossMsgFee;
         int8 powerScale;
+        bool permissioned;
     }
 
     constructor(IDiamond.FacetCut[] memory _diamondCut, ConstructorParams memory params) {
@@ -70,6 +71,7 @@ contract SubnetActorDiamond {
         s.powerScale = params.powerScale;
         s.minCrossMsgFee = params.minCrossMsgFee;
         s.currentSubnetHash = s.parentId.createSubnetId(address(this)).toHash();
+        s.permissioned = params.permissioned;
 
         s.validatorSet.activeLimit = params.activeValidatorsLimit;
         // Start the next configuration number from 1, 0 is reserved for no change and the genesis membership

--- a/src/errors/IPCErrors.sol
+++ b/src/errors/IPCErrors.sol
@@ -71,3 +71,4 @@ error FacetCannotBeZero();
 error WrongGateway();
 error CannotFindSubnet();
 error UnknownSubnet();
+error MethodNotAllowed();

--- a/src/lib/LibSubnetActorStorage.sol
+++ b/src/lib/LibSubnetActorStorage.sol
@@ -43,6 +43,8 @@ struct SubnetActorStorage {
     ConsensusType consensus;
     /// @notice Determines if the subnet has been bootstrapped (i.e. it has been activated)
     bool bootstrapped;
+    /// @notice Determines if the subnet is permissionless or not
+    bool permissioned;
     /// @notice Determines if the subnet has been successfully killed
     bool killed;
     // =========== Staking ===========

--- a/src/subnet/SubnetActorManagerFacet.sol
+++ b/src/subnet/SubnetActorManagerFacet.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {SubnetAlreadyBootstrapped, NotEnoughFunds, CollateralIsZero, CannotReleaseZero, NotOwnerOfPublicKey, EmptyAddress, NotEnoughBalance, NotEnoughBalanceForRewards, NotEnoughCollateral, NotValidator, NotAllValidatorsHaveLeft, NotStakedBefore, InvalidSignatureErr, InvalidCheckpointEpoch, InvalidCheckpointMessagesHash, InvalidPublicKeyLength} from "../errors/IPCErrors.sol";
+import {SubnetAlreadyBootstrapped, NotEnoughFunds, CollateralIsZero, CannotReleaseZero, NotOwnerOfPublicKey, EmptyAddress, NotEnoughBalance, NotEnoughBalanceForRewards, NotEnoughCollateral, NotValidator, NotAllValidatorsHaveLeft, NotStakedBefore, InvalidSignatureErr, InvalidCheckpointEpoch, InvalidCheckpointMessagesHash, InvalidPublicKeyLength, MethodNotAllowed} from "../errors/IPCErrors.sol";
 import {IGateway} from "../interfaces/IGateway.sol";
 import {ISubnetActor} from "../interfaces/ISubnetActor.sol";
 import {BottomUpCheckpoint, CrossMsg} from "../structs/Checkpoint.sol";
@@ -136,6 +136,12 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Reentran
     /// @notice method that allows a validator to join the subnet
     /// @param publicKey The off-chain 65 byte public key that should be associated with the validator
     function join(bytes calldata publicKey) external payable nonReentrant notKilled {
+        // adding this check to prevent new validators from joining
+        // after the subnet has been bootstrapped. We will increase the
+        // functionality in the future to support explicit permissioning.
+        if (s.bootstrapped && s.permissioned) {
+            revert MethodNotAllowed();
+        }
         if (msg.value == 0) {
             revert CollateralIsZero();
         }
@@ -180,6 +186,11 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Reentran
 
     /// @notice method that allows a validator to increase its stake
     function stake() external payable notKilled {
+        // disbling validator changes for permissioned subnets (at least for now
+        // until a more complex mechanism is implemented).
+        if (s.permissioned) {
+            revert MethodNotAllowed();
+        }
         if (msg.value == 0) {
             revert CollateralIsZero();
         }
@@ -199,6 +210,11 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Reentran
     /// @notice method that allows a validator to unstake a part of its collateral from a subnet
     /// @dev `leave` must be used to unstake the entire stake.
     function unstake(uint256 amount) external notKilled {
+        // disbling validator changes for permissioned subnets (at least for now
+        // until a more complex mechanism is implemented).
+        if (s.permissioned) {
+            revert MethodNotAllowed();
+        }
         if (amount == 0) {
             revert CannotReleaseZero();
         }
@@ -223,8 +239,16 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Reentran
     /// @dev it also return the validators initial balance if the
     /// subnet was not yet bootstrapped.
     function leave() external notKilled nonReentrant {
-        // remove bootstrap nodes added by this validator
+        // disbling validator changes for permissioned subnets (at least for now
+        // until a more complex mechanism is implemented).
+        // This means that initial validators won't be able to recover
+        // their collateral ever (worth noting in the docs if this ends
+        // up sticking around for a while).
+        if (s.permissioned) {
+            revert MethodNotAllowed();
+        }
 
+        // remove bootstrap nodes added by this validator
         uint256 amount = LibStaking.totalValidatorCollateral(msg.sender);
         if (amount == 0) {
             revert NotValidator(msg.sender);

--- a/test/GatewayDiamond.t.sol
+++ b/test/GatewayDiamond.t.sol
@@ -264,7 +264,8 @@ contract GatewayActorDiamondTest is StdInvariant, Test {
             majorityPercentage: DEFAULT_MAJORITY_PERCENTAGE,
             activeValidatorsLimit: 100,
             powerScale: 12,
-            minCrossMsgFee: CROSS_MSG_FEE
+            minCrossMsgFee: CROSS_MSG_FEE,
+            permissioned: false
         });
 
         saManager = new SubnetManagerTestUtil();

--- a/test/SubnetActorDiamond.t.sol
+++ b/test/SubnetActorDiamond.t.sol
@@ -449,6 +449,7 @@ contract SubnetActorDiamondTest is Test {
                 majorityPercentage: DEFAULT_MAJORITY_PERCENTAGE,
                 activeValidatorsLimit: 100,
                 powerScale: 12,
+                permissioned: false,
                 minCrossMsgFee: CROSS_MSG_FEE
             }),
             address(saDupGetterFaucet),
@@ -1332,6 +1333,7 @@ contract SubnetActorDiamondTest is Test {
                 majorityPercentage: _majorityPercentage,
                 activeValidatorsLimit: 100,
                 powerScale: 12,
+                permissioned: false,
                 minCrossMsgFee: CROSS_MSG_FEE
             })
         );

--- a/test/SubnetRegistry.t.sol
+++ b/test/SubnetRegistry.t.sol
@@ -267,6 +267,7 @@ contract SubnetRegistryTest is Test {
             majorityPercentage: DEFAULT_MAJORITY_PERCENTAGE,
             activeValidatorsLimit: 100,
             powerScale: DEFAULT_POWER_SCALE,
+            permissioned: false,
             minCrossMsgFee: CROSS_MSG_FEE
         });
         vm.expectRevert(WrongGateway.selector);
@@ -285,6 +286,7 @@ contract SubnetRegistryTest is Test {
             majorityPercentage: DEFAULT_MAJORITY_PERCENTAGE,
             activeValidatorsLimit: 100,
             powerScale: DEFAULT_POWER_SCALE,
+            permissioned: false,
             minCrossMsgFee: CROSS_MSG_FEE
         });
         registerSubnetFacet.newSubnetActor(params);
@@ -304,6 +306,7 @@ contract SubnetRegistryTest is Test {
             majorityPercentage: DEFAULT_MAJORITY_PERCENTAGE,
             activeValidatorsLimit: 100,
             powerScale: DEFAULT_POWER_SCALE,
+            permissioned: false,
             minCrossMsgFee: CROSS_MSG_FEE
         });
         registerSubnetFacet.newSubnetActor(params);
@@ -343,6 +346,7 @@ contract SubnetRegistryTest is Test {
             majorityPercentage: _majorityPercentage,
             activeValidatorsLimit: 100,
             powerScale: _powerScale,
+            permissioned: false,
             minCrossMsgFee: CROSS_MSG_FEE
         });
         registerSubnetFacet.newSubnetActor(params);


### PR DESCRIPTION
Fixes #304 

## Background
This is a first stage towards adding the option to make subnets permissioned. In this case, I included a `permissioned` flag that can be set in construction that determines if validator changes should be disabled or not.

Why using a construction flag? Ideally, I would've loved to use a compilation flag, so you can already compile a contract with the subset of features that you want, but Solidity doesn't have support for compilation flags, and there doesn't seem to be an easy way of getting an analogous behavior without a lot of redundant code. This approach also allows us to have this functionality without having to explicitly re-write or break any of our existing code. 

In the short-term, I expect validator changes to be disable for Mycelium and other public deployments, while in user child subnets we may want to leave them enabled so users can test the full-functionality of testnets. 

## Next steps
I wanted to double-check that everyone is OK with this approach before making further progress. If this is the case, the next steps is to: 
* Add a few unit tests covering the `permissioned` scenario. 
* Propagate the changes to the contract interface and storage to `ipc` and `fendermint` (I will open the corresponding issues).