### PR TITLE
ganache-core is deprecated for ganache

### DIFF
--- a/scripts/util.ts
+++ b/scripts/util.ts
@@ -1,7 +1,7 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { providers, Wallet, ContractFactory, Contract } from 'ethers'
 import { Contract, ethers } from 'hardhat'
-import ganache from 'ganache-core'
+import ganache from 'ganache'
 import * as linker from 'solc/linker'
 const { getSelectors, FacetCutAction } = require('./js/diamond.js')
 const fs = require('fs')


### PR DESCRIPTION
`make` on dev is currently failing and this fixes it. ganache-core was deprecated for ganache