### PR TITLE
CI: Pass OUTPUT in rust-bindings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ commit-abi:
 	./ops/commit-abi.sh $(OUTPUT)
 
 rust-binding:
-	BUILD_BINDINGS=1 cargo build --locked --release --manifest-path ./binding/Cargo.toml -p ipc_actors_abis
+	OUTPUT=$(OUTPUT) BUILD_BINDINGS=1 cargo build --locked --release --manifest-path ./binding/Cargo.toml -p ipc_actors_abis
 
 commit-rust-binding:
 	./ops/commit-rust-binding.sh

--- a/binding/build.rs
+++ b/binding/build.rs
@@ -11,12 +11,13 @@ use std::path::{Path, PathBuf};
 fn main() {
     // Run with `cargo build -vv` to see output from any `eprintln!` or `println!`.
 
-    let output_dir = std::env::var("OUTPUT").ok().unwrap_or(".abi".to_string());
-
     // We are not building anything, could be imported as crate.
     if std::env::var("BUILD_BINDINGS").ok().is_none() {
         return;
     }
+
+    // Where are the Solidity artifacts.
+    let output_dir = std::env::var("OUTPUT").expect("OUTPUT env var missing");
 
     let ipc_actors_dir = workspace_dir()
         .parent()


### PR DESCRIPTION
Forgot to pass `$OUTPUT` to the bindings build.