### PR TITLE
CI: No bindings on push

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -1,13 +1,8 @@
 name: Bindings
 
 # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
-# * run it in case someone pushes to `dev` directly
-# * run it *after* successful merges
+# Run it after successful merges. Don't run on push or it will trigger itself recursively.
 on:
-  push:
-    branches:
-      - main
-      - dev
   pull_request:
     types:
       - closed
@@ -16,10 +11,7 @@ jobs:
   bindings:
     name: "Code Generation"
     runs-on: ubuntu-latest
-    if: >-
-      github.event.pull_request.merged == true ||
-      github.ref == 'refs/heads/main' ||
-      github.ref == 'refs/heads/dev'
+    if: github.event.pull_request.merged == true
     permissions:
       # Give the default GITHUB_TOKEN write permission to commit and push the
       # added or changed files to the repository.

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -1,8 +1,13 @@
 name: Bindings
 
 # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
-# Run it after successful merges. Don't run on push or it will trigger itself recursively.
+# * run it in case someone pushes to `dev` directly
+# * run it *after* successful merges
 on:
+  push:
+    branches:
+      - main
+      - dev
   pull_request:
     types:
       - closed
@@ -11,7 +16,10 @@ jobs:
   bindings:
     name: "Code Generation"
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
+    if: >-
+      github.event.pull_request.merged == true ||
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') &&
+      !contains(github.event.head_commit.message, 'GEN:')
     permissions:
       # Give the default GITHUB_TOKEN write permission to commit and push the
       # added or changed files to the repository.

--- a/ops/commit-abi.sh
+++ b/ops/commit-abi.sh
@@ -14,6 +14,6 @@ OUTPUT=$1
 if [[ `git status $OUTPUT --porcelain` ]]; then
     echo "********** NOT ALL ABI ARTIFACTS ARE COMMITTED, AUTO PUSH **********\n";
     git add $OUTPUT
-    git commit -m "commit ABI artifacts"
+    git commit -m "GEN: commit ABI artifacts"
     git push
 fi;

--- a/ops/commit-rust-binding.sh
+++ b/ops/commit-rust-binding.sh
@@ -4,6 +4,6 @@
 if [[ `git status ./binding --porcelain` ]]; then
     echo "********** NOT ALL RUST BINDINGS COMMITTED, AUTO PUSH **********\n";
     git add ./binding
-    git commit -m "commit rust binding"
+    git commit -m "GEN: commit rust binding"
     git push
 fi;


### PR DESCRIPTION
Not running the `bindings.yaml` workflow on `push` because it triggers itself recursively.