### PR TITLE
Add prettier formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,9 +1,11 @@
 # Ignore everything in the lib folder
-lib/
-tools/
-package.json
-package-lock.json
-out/
-scripts/deploy-registry.ts
-scripts/deploy-gateway.ts
 .out/
+.storage-layouts/
+binding/
+lib/
+out/
+package-lock.json
+package.json
+scripts/deploy-gateway.ts
+scripts/deploy-registry.ts
+tools/

--- a/.prettierrc
+++ b/.prettierrc
@@ -14,8 +14,13 @@
                 tabWidth: 4,
                 useTabs: false,
                 singleQuote: false,
-                bracketSpacing: false,
-            },
-        },
-    ],
+                bracketSpacing: true,
+                plugins: ["@trivago/prettier-plugin-sort-imports"],
+                importOrder: ["^openzeppelin/(.*)$","^~(.*)$", "^[./]"],
+                importOrderSeparation: true,
+                importOrderSortSpecifiers: true
+            }
+        }
+    ]
 }
+

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,14 +1,12 @@
-import { HardhatUserConfig, task } from 'hardhat/config'
-import '@typechain/hardhat'
-import 'hardhat-storage-layout-changes'
-
 import '@nomicfoundation/hardhat-foundry'
 import '@nomiclabs/hardhat-ethers'
-import 'hardhat-deploy'
-import 'hardhat-contract-sizer'
-
+import '@typechain/hardhat'
 import dotenv from 'dotenv'
 import fs from 'fs'
+import 'hardhat-contract-sizer'
+import 'hardhat-deploy'
+import 'hardhat-storage-layout-changes'
+import { HardhatUserConfig, task } from 'hardhat/config'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 
 dotenv.config()

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
             "version": "0.0.1",
             "license": "MIT OR Apache-2.0",
             "dependencies": {
-                "@openzeppelin/contracts": "^4.7.3",
                 "@solidity-parser/parser": "^0.16.2",
                 "diamond-util": "^1.1.1",
                 "ganache": "^7.9.1",
@@ -19,6 +18,7 @@
             "devDependencies": {
                 "@nomicfoundation/hardhat-foundry": "^1.0.1",
                 "@nomiclabs/hardhat-ethers": "^2.2.3",
+                "@trivago/prettier-plugin-sort-imports": "^4.3.0",
                 "@typechain/ethers-v5": "^7.0.1",
                 "@typechain/hardhat": "^2.1.2",
                 "dotenv": "^16.0.1",
@@ -50,6 +50,126 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@babel/generator": {
+            "version": "7.17.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+            "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.17.0",
+                "jsesc": "^2.5.1",
+                "source-map": "^0.5.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/generator/node_modules/source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@babel/helper-environment-visitor": {
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+            "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-function-name": {
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/template": "^7.22.15",
+                "@babel/types": "^7.23.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-function-name/node_modules/@babel/types": {
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+            "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.23.4",
+                "@babel/helper-validator-identifier": "^7.22.20",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-hoist-variables": {
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+            "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.22.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-hoist-variables/node_modules/@babel/types": {
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+            "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.23.4",
+                "@babel/helper-validator-identifier": "^7.22.20",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-split-export-declaration": {
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+            "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.22.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-split-export-declaration/node_modules/@babel/types": {
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+            "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.23.4",
+                "@babel/helper-validator-identifier": "^7.22.20",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.23.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+            "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-validator-identifier": {
             "version": "7.22.20",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
@@ -68,6 +188,119 @@
                 "@babel/helper-validator-identifier": "^7.22.20",
                 "chalk": "^2.4.2",
                 "js-tokens": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+            "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
+            "dev": true,
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/template": {
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+            "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.22.13",
+                "@babel/parser": "^7.22.15",
+                "@babel/types": "^7.22.15"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/template/node_modules/@babel/types": {
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+            "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.23.4",
+                "@babel/helper-validator-identifier": "^7.22.20",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse": {
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+            "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.22.13",
+                "@babel/generator": "^7.23.0",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-function-name": "^7.23.0",
+                "@babel/helper-hoist-variables": "^7.22.5",
+                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@babel/parser": "^7.23.0",
+                "@babel/types": "^7.23.0",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse/node_modules/@babel/generator": {
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+            "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.23.6",
+                "@jridgewell/gen-mapping": "^0.3.2",
+                "@jridgewell/trace-mapping": "^0.3.17",
+                "jsesc": "^2.5.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse/node_modules/@babel/types": {
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+            "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.23.4",
+                "@babel/helper-validator-identifier": "^7.22.20",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.20",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+            "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+            "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.16.7",
+                "to-fast-properties": "^2.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -797,11 +1030,34 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/trace-mapping": "^0.3.9"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
             "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
             "devOptional": true,
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/set-array": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "dev": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -1453,11 +1709,6 @@
                 "hardhat": "^2.0.0"
             }
         },
-        "node_modules/@openzeppelin/contracts": {
-            "version": "4.9.3",
-            "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.9.3.tgz",
-            "integrity": "sha512-He3LieZ1pP2TNt5JbkPA4PNT9WC3gOTOlDcFGJW4Le4QKqwmiNJCRt44APfxMxvq7OugU/cqYuPcSBzOw38DAg=="
-        },
         "node_modules/@scure/base": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.3.tgz",
@@ -1598,6 +1849,29 @@
             "integrity": "sha512-PI9NfoA3P8XK2VBkK5oIfRgKDsicwDZfkVq9ZTBCQYGOP1N2owgY2dyLGyU5/J/hQs8KRk55kdmvTLjy3Mu3vg==",
             "dependencies": {
                 "antlr4ts": "^0.5.0-alpha.4"
+            }
+        },
+        "node_modules/@trivago/prettier-plugin-sort-imports": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.3.0.tgz",
+            "integrity": "sha512-r3n0onD3BTOVUNPhR4lhVK4/pABGpbA7bW3eumZnYdKaHkf1qEC+Mag6DPbGNuuh0eG8AaYj+YqmVHSiGslaTQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/generator": "7.17.7",
+                "@babel/parser": "^7.20.5",
+                "@babel/traverse": "7.23.2",
+                "@babel/types": "7.17.0",
+                "javascript-natural-sort": "0.7.1",
+                "lodash": "^4.17.21"
+            },
+            "peerDependencies": {
+                "@vue/compiler-sfc": "3.x",
+                "prettier": "2.x - 3.x"
+            },
+            "peerDependenciesMeta": {
+                "@vue/compiler-sfc": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@tsconfig/node10": {
@@ -4703,6 +4977,9 @@
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
             "extraneous": true,
+            "os": [
+                "darwin"
+            ],
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
@@ -6966,6 +7243,15 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/globals": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/gopd": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -7697,6 +7983,12 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
         },
+        "node_modules/javascript-natural-sort": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+            "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+            "dev": true
+        },
         "node_modules/js-sdsl": {
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.2.tgz",
@@ -7726,6 +8018,18 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/jsesc": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true,
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/json-parse-even-better-errors": {
@@ -9643,6 +9947,15 @@
             },
             "engines": {
                 "node": ">=0.6.0"
+            }
+        },
+        "node_modules/to-fast-properties": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
         "solhint-plugin-prettier": "^0.0.5",
         "ts-node": "^10.9.1",
         "typechain": "^5.0.0",
-        "typescript": "^4.8.3"
+        "typescript": "^4.8.3",
+        "@trivago/prettier-plugin-sort-imports": "^4.3.0"
     },
     "dependencies": {
         "@solidity-parser/parser": "^0.16.2",

--- a/scripts/deploy-gateway.template.ts
+++ b/scripts/deploy-gateway.template.ts
@@ -1,8 +1,8 @@
 /* global ethers */
-/* eslint prefer-const: "off" */
 
-import hre, { ethers } from 'hardhat'
+/* eslint prefer-const: "off" */
 import { deployContractWithDeployer, getTransactionFees } from './util'
+import hre, { ethers } from 'hardhat'
 
 const { getSelectors, FacetCutAction } = require('./js/diamond.js')
 

--- a/scripts/deploy-libraries.ts
+++ b/scripts/deploy-libraries.ts
@@ -1,8 +1,8 @@
 /* global ethers */
-/* eslint prefer-const: "off" */
 
-import hre, { ethers } from 'hardhat'
+/* eslint prefer-const: "off" */
 import { deployContractWithDeployer, getTransactionFees } from './util'
+import hre, { ethers } from 'hardhat'
 
 export async function deploy() {
     await hre.run('compile')

--- a/scripts/deploy-registry.template.ts
+++ b/scripts/deploy-registry.template.ts
@@ -1,5 +1,5 @@
-import { ethers } from 'hardhat'
 import { deployContractWithDeployer, getTransactionFees } from './util'
+import { ethers } from 'hardhat'
 
 const { getSelectors, FacetCutAction } = require('./js/diamond.js')
 

--- a/scripts/deploy-sa-diamond.ts
+++ b/scripts/deploy-sa-diamond.ts
@@ -1,5 +1,5 @@
-import hre, { ethers } from 'hardhat'
 import { deployContractWithDeployer, getTransactionFees } from './util'
+import hre, { ethers } from 'hardhat'
 
 const { getSelectors, FacetCutAction } = require('./js/diamond.js')
 

--- a/scripts/deploy-subnet.ts
+++ b/scripts/deploy-subnet.ts
@@ -1,8 +1,8 @@
 /* global ethers */
-/* eslint prefer-const: "off" */
 
-import { hre, ethers } from 'hardhat'
+/* eslint prefer-const: "off" */
 import { deployContractWithDeployer, getTransactionFees } from './util'
+import { hre, ethers } from 'hardhat'
 
 export async function deploy(
     gatewayAddress: string,

--- a/scripts/upgrade-gw-diamond.ts
+++ b/scripts/upgrade-gw-diamond.ts
@@ -1,4 +1,3 @@
-import { ethers } from 'hardhat'
 import {
     getFacets,
     getBytecodeFromFacet,
@@ -7,6 +6,7 @@ import {
     upgradeFacet,
     logMissingFacetInfo,
 } from './util'
+import { ethers } from 'hardhat'
 
 /**
  * Upgrade the Gateway Actor Diamond.

--- a/scripts/upgrade-sa-diamond.ts
+++ b/scripts/upgrade-sa-diamond.ts
@@ -1,4 +1,3 @@
-import { ethers } from 'hardhat'
 import {
     getFacets,
     getBytecodeFromFacet,
@@ -7,6 +6,7 @@ import {
     upgradeFacet,
     logMissingFacetInfo,
 } from './util'
+import { ethers } from 'hardhat'
 
 /**
  * Upgrade the Subnet Actor Diamond.

--- a/scripts/upgrade-sr-diamond.ts
+++ b/scripts/upgrade-sr-diamond.ts
@@ -1,4 +1,3 @@
-import { ethers } from 'hardhat'
 import {
     getFacets,
     getBytecodeFromFacet,
@@ -7,6 +6,7 @@ import {
     upgradeFacet,
     logMissingFacetInfo,
 } from './util'
+import { ethers } from 'hardhat'
 
 /**
  * Upgrade the Subnet Registry Diamond.

--- a/scripts/util.ts
+++ b/scripts/util.ts
@@ -1,8 +1,9 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { providers, Wallet, ContractFactory, Contract } from 'ethers'
-import { Contract, ethers } from 'hardhat'
 import ganache from 'ganache'
+import { ethers } from 'hardhat'
 import * as linker from 'solc/linker'
+
 const { getSelectors, FacetCutAction } = require('./js/diamond.js')
 const fs = require('fs')
 

--- a/src/GatewayDiamond.sol
+++ b/src/GatewayDiamond.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {GatewayActorStorage} from "./lib/LibGatewayActorStorage.sol";
-import {IDiamond} from "./interfaces/IDiamond.sol";
-import {IDiamondCut} from "./interfaces/IDiamondCut.sol";
-import {IDiamondLoupe} from "./interfaces/IDiamondLoupe.sol";
-import {IERC165} from "./interfaces/IERC165.sol";
-import {Validator, Membership} from "./structs/Subnet.sol";
-import {InvalidCollateral, InvalidSubmissionPeriod, InvalidMajorityPercentage} from "./errors/IPCErrors.sol";
-import {LibDiamond} from "./lib/LibDiamond.sol";
-import {LibGateway} from "./lib/LibGateway.sol";
-import {SubnetID} from "./structs/Subnet.sol";
-import {LibStaking} from "./lib/LibStaking.sol";
+import { GatewayActorStorage } from "./lib/LibGatewayActorStorage.sol";
+import { IDiamond } from "./interfaces/IDiamond.sol";
+import { IDiamondCut } from "./interfaces/IDiamondCut.sol";
+import { IDiamondLoupe } from "./interfaces/IDiamondLoupe.sol";
+import { IERC165 } from "./interfaces/IERC165.sol";
+import { Validator, Membership } from "./structs/Subnet.sol";
+import { InvalidCollateral, InvalidSubmissionPeriod, InvalidMajorityPercentage } from "./errors/IPCErrors.sol";
+import { LibDiamond } from "./lib/LibDiamond.sol";
+import { LibGateway } from "./lib/LibGateway.sol";
+import { SubnetID } from "./structs/Subnet.sol";
+import { LibStaking } from "./lib/LibStaking.sol";
 
 error FunctionNotFound(bytes4 _functionSelector);
 
@@ -47,7 +47,7 @@ contract GatewayDiamond {
         }
 
         LibDiamond.setContractOwner(msg.sender);
-        LibDiamond.diamondCut({_diamondCut: _diamondCut, _init: address(0), _calldata: new bytes(0)});
+        LibDiamond.diamondCut({ _diamondCut: _diamondCut, _init: address(0), _calldata: new bytes(0) });
 
         LibDiamond.DiamondStorage storage ds = LibDiamond.diamondStorage();
         // adding ERC165 data
@@ -74,7 +74,7 @@ contract GatewayDiamond {
         // empty validator change logs
         s.validatorsTracker.changes.startConfigurationNumber = LibStaking.INITIAL_CONFIGURATION_NUMBER;
         // set initial validators and update membership
-        Membership memory initial = Membership({configurationNumber: 0, validators: params.genesisValidators});
+        Membership memory initial = Membership({ configurationNumber: 0, validators: params.genesisValidators });
         LibGateway.updateMembership(initial);
     }
 

--- a/src/SubnetActorDiamond.sol
+++ b/src/SubnetActorDiamond.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {SubnetActorStorage} from "./lib/LibSubnetActorStorage.sol";
-import {ConsensusType} from "./enums/ConsensusType.sol";
-import {IDiamond} from "./interfaces/IDiamond.sol";
-import {IDiamondCut} from "./interfaces/IDiamondCut.sol";
-import {IDiamondLoupe} from "./interfaces/IDiamondLoupe.sol";
-import {IERC165} from "./interfaces/IERC165.sol";
-import {GatewayCannotBeZero, NotGateway, InvalidSubmissionPeriod, InvalidCollateral, InvalidMajorityPercentage, InvalidPowerScale} from "./errors/IPCErrors.sol";
-import {LibDiamond} from "./lib/LibDiamond.sol";
-import {SubnetID, PermissionMode} from "./structs/Subnet.sol";
-import {SubnetIDHelper} from "./lib/SubnetIDHelper.sol";
-import {LibStaking} from "./lib/LibStaking.sol";
+import { SubnetActorStorage } from "./lib/LibSubnetActorStorage.sol";
+import { ConsensusType } from "./enums/ConsensusType.sol";
+import { IDiamond } from "./interfaces/IDiamond.sol";
+import { IDiamondCut } from "./interfaces/IDiamondCut.sol";
+import { IDiamondLoupe } from "./interfaces/IDiamondLoupe.sol";
+import { IERC165 } from "./interfaces/IERC165.sol";
+import { GatewayCannotBeZero, NotGateway, InvalidSubmissionPeriod, InvalidCollateral, InvalidMajorityPercentage, InvalidPowerScale } from "./errors/IPCErrors.sol";
+import { LibDiamond } from "./lib/LibDiamond.sol";
+import { SubnetID, PermissionMode } from "./structs/Subnet.sol";
+import { SubnetIDHelper } from "./lib/SubnetIDHelper.sol";
+import { LibStaking } from "./lib/LibStaking.sol";
 
 error FunctionNotFound(bytes4 _functionSelector);
 
@@ -53,7 +53,7 @@ contract SubnetActorDiamond {
         }
 
         LibDiamond.setContractOwner(msg.sender);
-        LibDiamond.diamondCut({_diamondCut: _diamondCut, _init: address(0), _calldata: new bytes(0)});
+        LibDiamond.diamondCut({ _diamondCut: _diamondCut, _init: address(0), _calldata: new bytes(0) });
 
         LibDiamond.DiamondStorage storage ds = LibDiamond.diamondStorage();
         // adding ERC165 data

--- a/src/SubnetRegistryDiamond.sol
+++ b/src/SubnetRegistryDiamond.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {IDiamond} from "./interfaces/IDiamond.sol";
-import {IDiamondCut} from "../src/interfaces/IDiamondCut.sol";
-import {IDiamondLoupe} from "./interfaces/IDiamondLoupe.sol";
-import {IERC165} from "./interfaces/IERC165.sol";
-import {SubnetRegistryActorStorage} from "./lib/LibSubnetRegistryStorage.sol";
-import {GatewayCannotBeZero, FacetCannotBeZero} from "./errors/IPCErrors.sol";
-import {LibDiamond} from "./lib/LibDiamond.sol";
+import { IDiamond } from "./interfaces/IDiamond.sol";
+import { IDiamondCut } from "../src/interfaces/IDiamondCut.sol";
+import { IDiamondLoupe } from "./interfaces/IDiamondLoupe.sol";
+import { IERC165 } from "./interfaces/IERC165.sol";
+import { SubnetRegistryActorStorage } from "./lib/LibSubnetRegistryStorage.sol";
+import { GatewayCannotBeZero, FacetCannotBeZero } from "./errors/IPCErrors.sol";
+import { LibDiamond } from "./lib/LibDiamond.sol";
 error FunctionNotFound(bytes4 _functionSelector);
 
 contract SubnetRegistryDiamond {
@@ -33,7 +33,7 @@ contract SubnetRegistryDiamond {
         }
 
         LibDiamond.setContractOwner(msg.sender);
-        LibDiamond.diamondCut({_diamondCut: _diamondCut, _init: address(0), _calldata: new bytes(0)});
+        LibDiamond.diamondCut({ _diamondCut: _diamondCut, _init: address(0), _calldata: new bytes(0) });
 
         LibDiamond.DiamondStorage storage ds = LibDiamond.diamondStorage();
         // adding ERC165 data

--- a/src/diamond/DiamondCutFacet.sol
+++ b/src/diamond/DiamondCutFacet.sol
@@ -6,8 +6,8 @@ pragma solidity 0.8.19;
 * EIP-2535 Diamonds: https://eips.ethereum.org/EIPS/eip-2535
 /******************************************************************************/
 
-import {IDiamondCut} from "../interfaces/IDiamondCut.sol";
-import {LibDiamond} from "../lib/LibDiamond.sol";
+import { IDiamondCut } from "../interfaces/IDiamondCut.sol";
+import { LibDiamond } from "../lib/LibDiamond.sol";
 
 contract DiamondCutFacet is IDiamondCut {
     /// @notice Add/replace/remove any number of functions and optionally execute
@@ -18,6 +18,6 @@ contract DiamondCutFacet is IDiamondCut {
     ///                  _calldata is executed with delegatecall on _init
     function diamondCut(FacetCut[] calldata _diamondCut, address _init, bytes calldata _calldata) external override {
         LibDiamond.enforceIsContractOwner();
-        LibDiamond.diamondCut({_diamondCut: _diamondCut, _init: _init, _calldata: _calldata});
+        LibDiamond.diamondCut({ _diamondCut: _diamondCut, _init: _init, _calldata: _calldata });
     }
 }

--- a/src/diamond/DiamondLoupeFacet.sol
+++ b/src/diamond/DiamondLoupeFacet.sol
@@ -8,9 +8,9 @@ pragma solidity 0.8.19;
 // The functions in DiamondLoupeFacet MUST be added to a diamond.
 // The EIP-2535 Diamond standard requires these functions.
 
-import {LibDiamond} from "../lib/LibDiamond.sol";
-import {IDiamondLoupe} from "../interfaces/IDiamondLoupe.sol";
-import {IERC165} from "../interfaces/IERC165.sol";
+import { LibDiamond } from "../lib/LibDiamond.sol";
+import { IDiamondLoupe } from "../interfaces/IDiamondLoupe.sol";
+import { IERC165 } from "../interfaces/IERC165.sol";
 
 contract DiamondLoupeFacet is IDiamondLoupe, IERC165 {
     // Diamond Loupe Functions

--- a/src/gateway/GatewayGetterFacet.sol
+++ b/src/gateway/GatewayGetterFacet.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {CrossMsg, BottomUpCheckpoint, StorableMsg, ParentFinality, CheckpointInfo} from "../structs/Checkpoint.sol";
-import {SubnetID, Subnet} from "../structs/Subnet.sol";
-import {Membership} from "../structs/Subnet.sol";
-import {LibGateway} from "../lib/LibGateway.sol";
-import {GatewayActorStorage} from "../lib/LibGatewayActorStorage.sol";
-import {SubnetIDHelper} from "../lib/SubnetIDHelper.sol";
-import {EnumerableSet} from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
+import { CrossMsg, BottomUpCheckpoint, StorableMsg, ParentFinality, CheckpointInfo } from "../structs/Checkpoint.sol";
+import { SubnetID, Subnet } from "../structs/Subnet.sol";
+import { Membership } from "../structs/Subnet.sol";
+import { LibGateway } from "../lib/LibGateway.sol";
+import { GatewayActorStorage } from "../lib/LibGatewayActorStorage.sol";
+import { SubnetIDHelper } from "../lib/SubnetIDHelper.sol";
+import { EnumerableSet } from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
 
 contract GatewayGetterFacet {
     // slither-disable-next-line uninitialized-state

--- a/src/gateway/GatewayManagerFacet.sol
+++ b/src/gateway/GatewayManagerFacet.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {GatewayActorModifiers} from "../lib/LibGatewayActorStorage.sol";
-import {BURNT_FUNDS_ACTOR} from "../constants/Constants.sol";
-import {CrossMsg} from "../structs/Checkpoint.sol";
-import {Status} from "../enums/Status.sol";
-import {FvmAddress} from "../structs/FvmAddress.sol";
-import {SubnetID, Subnet} from "../structs/Subnet.sol";
-import {AlreadyRegisteredSubnet, CannotReleaseZero, MethodNotAllowed, NotEnoughFunds, NotEnoughFundsToRelease, NotEnoughCollateral, NotEmptySubnetCircSupply, NotRegisteredSubnet, InvalidCrossMsgValue} from "../errors/IPCErrors.sol";
-import {LibGateway} from "../lib/LibGateway.sol";
-import {SubnetIDHelper} from "../lib/SubnetIDHelper.sol";
-import {CrossMsgHelper} from "../lib/CrossMsgHelper.sol";
-import {FilAddress} from "fevmate/utils/FilAddress.sol";
-import {ReentrancyGuard} from "../lib/LibReentrancyGuard.sol";
+import { GatewayActorModifiers } from "../lib/LibGatewayActorStorage.sol";
+import { BURNT_FUNDS_ACTOR } from "../constants/Constants.sol";
+import { CrossMsg } from "../structs/Checkpoint.sol";
+import { Status } from "../enums/Status.sol";
+import { FvmAddress } from "../structs/FvmAddress.sol";
+import { SubnetID, Subnet } from "../structs/Subnet.sol";
+import { AlreadyRegisteredSubnet, CannotReleaseZero, MethodNotAllowed, NotEnoughFunds, NotEnoughFundsToRelease, NotEnoughCollateral, NotEmptySubnetCircSupply, NotRegisteredSubnet, InvalidCrossMsgValue } from "../errors/IPCErrors.sol";
+import { LibGateway } from "../lib/LibGateway.sol";
+import { SubnetIDHelper } from "../lib/SubnetIDHelper.sol";
+import { CrossMsgHelper } from "../lib/CrossMsgHelper.sol";
+import { FilAddress } from "fevmate/utils/FilAddress.sol";
+import { ReentrancyGuard } from "../lib/LibReentrancyGuard.sol";
 
 string constant ERR_CHILD_SUBNET_NOT_ALLOWED = "Subnet does not allow child subnets";
 

--- a/src/gateway/GatewayMessengerFacet.sol
+++ b/src/gateway/GatewayMessengerFacet.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.19;
 
-import {GatewayActorModifiers} from "../lib/LibGatewayActorStorage.sol";
-import {BURNT_FUNDS_ACTOR} from "../constants/Constants.sol";
-import {CrossMsg, StorableMsg} from "../structs/Checkpoint.sol";
-import {IPCMsgType} from "../enums/IPCMsgType.sol";
-import {SubnetID} from "../structs/Subnet.sol";
-import {InvalidCrossMsgFromSubnet, InvalidCrossMsgDstSubnet, CannotSendCrossMsgToItself, InvalidCrossMsgValue, MethodNotAllowed} from "../errors/IPCErrors.sol";
-import {SubnetIDHelper} from "../lib/SubnetIDHelper.sol";
-import {LibGateway} from "../lib/LibGateway.sol";
-import {StorableMsgHelper} from "../lib/StorableMsgHelper.sol";
-import {FilAddress} from "fevmate/utils/FilAddress.sol";
+import { GatewayActorModifiers } from "../lib/LibGatewayActorStorage.sol";
+import { BURNT_FUNDS_ACTOR } from "../constants/Constants.sol";
+import { CrossMsg, StorableMsg } from "../structs/Checkpoint.sol";
+import { IPCMsgType } from "../enums/IPCMsgType.sol";
+import { SubnetID } from "../structs/Subnet.sol";
+import { InvalidCrossMsgFromSubnet, InvalidCrossMsgDstSubnet, CannotSendCrossMsgToItself, InvalidCrossMsgValue, MethodNotAllowed } from "../errors/IPCErrors.sol";
+import { SubnetIDHelper } from "../lib/SubnetIDHelper.sol";
+import { LibGateway } from "../lib/LibGateway.sol";
+import { StorableMsgHelper } from "../lib/StorableMsgHelper.sol";
+import { FilAddress } from "fevmate/utils/FilAddress.sol";
 
 string constant ERR_GENERAL_CROSS_MSG_DISABLED = "Support for general-purpose cross-net messages is disabled";
 string constant ERR_MULTILEVEL_CROSS_MSG_DISABLED = "Support for multi-level cross-net messages is disabled";
@@ -45,7 +45,7 @@ contract GatewayMessengerFacet is GatewayActorModifiers {
         // commit cross-message for propagation
         bool shouldBurn = _commitCrossMessage(crossMsg);
 
-        _crossMsgSideEffects({v: crossMsg.message.value, shouldBurn: shouldBurn});
+        _crossMsgSideEffects({ v: crossMsg.message.value, shouldBurn: shouldBurn });
     }
 
     /**
@@ -67,7 +67,7 @@ contract GatewayMessengerFacet is GatewayActorModifiers {
         uint256 v = crossMsg.message.value;
         delete s.postbox[msgCid];
 
-        _crossMsgSideEffects({v: v, shouldBurn: shouldBurn});
+        _crossMsgSideEffects({ v: v, shouldBurn: shouldBurn });
 
         uint256 feeRemainder = msg.value - s.minCrossMsgFee;
 

--- a/src/gateway/GatewayRouterFacet.sol
+++ b/src/gateway/GatewayRouterFacet.sol
@@ -1,28 +1,28 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {ISubnetActor} from "../interfaces/ISubnetActor.sol";
-import {GatewayActorModifiers} from "../lib/LibGatewayActorStorage.sol";
-import {CrossMsg, StorableMsg, ParentFinality, BottomUpCheckpoint, CheckpointInfo} from "../structs/Checkpoint.sol";
-import {Status} from "../enums/Status.sol";
-import {IPCMsgType} from "../enums/IPCMsgType.sol";
-import {SubnetID, Subnet, Validator, ValidatorInfo, ValidatorSet} from "../structs/Subnet.sol";
-import {IPCMsgType} from "../enums/IPCMsgType.sol";
-import {Membership} from "../structs/Subnet.sol";
-import {NotEnoughSubnetCircSupply, InvalidCheckpointEpoch, InvalidSignature, NotAuthorized, SignatureReplay, InvalidRetentionHeight, FailedRemoveIncompleteCheckpoint} from "../errors/IPCErrors.sol";
-import {InvalidCheckpointSource, InvalidCrossMsgNonce, InvalidCrossMsgDstSubnet, CheckpointAlreadyExists, CheckpointAlreadyProcessed, FailedAddIncompleteCheckpoint, FailedAddSignatory} from "../errors/IPCErrors.sol";
-import {NotRegisteredSubnet, SubnetNotActive, SubnetNotFound, InvalidSubnet, CheckpointNotCreated, ZeroMembershipWeight} from "../errors/IPCErrors.sol";
-import {SubnetIDHelper} from "../lib/SubnetIDHelper.sol";
-import {CrossMsgHelper} from "../lib/CrossMsgHelper.sol";
-import {LibGateway} from "../lib/LibGateway.sol";
-import {StorableMsgHelper} from "../lib/StorableMsgHelper.sol";
-import {FilAddress} from "fevmate/utils/FilAddress.sol";
-import {ECDSA} from "openzeppelin-contracts/utils/cryptography/ECDSA.sol";
-import {MerkleProof} from "openzeppelin-contracts/utils/cryptography/MerkleProof.sol";
-import {EnumerableSet} from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
-import {StakingChangeRequest, ParentValidatorsTracker} from "../structs/Subnet.sol";
-import {LibValidatorTracking, LibValidatorSet} from "../lib/LibStaking.sol";
-import {Address} from "openzeppelin-contracts/utils/Address.sol";
+import { ISubnetActor } from "../interfaces/ISubnetActor.sol";
+import { GatewayActorModifiers } from "../lib/LibGatewayActorStorage.sol";
+import { CrossMsg, StorableMsg, ParentFinality, BottomUpCheckpoint, CheckpointInfo } from "../structs/Checkpoint.sol";
+import { Status } from "../enums/Status.sol";
+import { IPCMsgType } from "../enums/IPCMsgType.sol";
+import { SubnetID, Subnet, Validator, ValidatorInfo, ValidatorSet } from "../structs/Subnet.sol";
+import { IPCMsgType } from "../enums/IPCMsgType.sol";
+import { Membership } from "../structs/Subnet.sol";
+import { NotEnoughSubnetCircSupply, InvalidCheckpointEpoch, InvalidSignature, NotAuthorized, SignatureReplay, InvalidRetentionHeight, FailedRemoveIncompleteCheckpoint } from "../errors/IPCErrors.sol";
+import { InvalidCheckpointSource, InvalidCrossMsgNonce, InvalidCrossMsgDstSubnet, CheckpointAlreadyExists, CheckpointAlreadyProcessed, FailedAddIncompleteCheckpoint, FailedAddSignatory } from "../errors/IPCErrors.sol";
+import { NotRegisteredSubnet, SubnetNotActive, SubnetNotFound, InvalidSubnet, CheckpointNotCreated, ZeroMembershipWeight } from "../errors/IPCErrors.sol";
+import { SubnetIDHelper } from "../lib/SubnetIDHelper.sol";
+import { CrossMsgHelper } from "../lib/CrossMsgHelper.sol";
+import { LibGateway } from "../lib/LibGateway.sol";
+import { StorableMsgHelper } from "../lib/StorableMsgHelper.sol";
+import { FilAddress } from "fevmate/utils/FilAddress.sol";
+import { ECDSA } from "openzeppelin-contracts/utils/cryptography/ECDSA.sol";
+import { MerkleProof } from "openzeppelin-contracts/utils/cryptography/MerkleProof.sol";
+import { EnumerableSet } from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
+import { StakingChangeRequest, ParentValidatorsTracker } from "../structs/Subnet.sol";
+import { LibValidatorTracking, LibValidatorSet } from "../lib/LibStaking.sol";
+import { Address } from "openzeppelin-contracts/utils/Address.sol";
 
 contract GatewayRouterFacet is GatewayActorModifiers {
     using FilAddress for address;
@@ -126,14 +126,14 @@ contract GatewayRouterFacet is GatewayActorModifiers {
         for (uint256 i; i < vLength; ) {
             address addr = validators[i];
             ValidatorInfo storage info = s.validatorsTracker.validators.validators[addr];
-            vs[i] = Validator({weight: info.confirmedCollateral, addr: addr, metadata: info.metadata});
+            vs[i] = Validator({ weight: info.confirmedCollateral, addr: addr, metadata: info.metadata });
             unchecked {
                 ++i;
             }
         }
 
         // update membership with the applied changes
-        LibGateway.updateMembership(Membership({configurationNumber: configurationNumber, validators: vs}));
+        LibGateway.updateMembership(Membership({ configurationNumber: configurationNumber, validators: vs }));
         return configurationNumber;
     }
 
@@ -235,7 +235,7 @@ contract GatewayRouterFacet is GatewayActorModifiers {
         // The validator is allowed to send a signature if it was in the membership at the target height
         // Constructing leaf: https://github.com/OpenZeppelin/merkle-tree#leaf-hash
         bytes32 validatorLeaf = keccak256(bytes.concat(keccak256(abi.encode(recoveredSignatory, weight))));
-        bool valid = MerkleProof.verify({proof: membershipProof, root: checkpointInfo.rootHash, leaf: validatorLeaf});
+        bool valid = MerkleProof.verify({ proof: membershipProof, root: checkpointInfo.rootHash, leaf: validatorLeaf });
         if (!valid) {
             revert NotAuthorized(recoveredSignatory);
         }

--- a/src/interfaces/IDiamondCut.sol
+++ b/src/interfaces/IDiamondCut.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {IDiamond} from "./IDiamond.sol";
+import { IDiamond } from "./IDiamond.sol";
 
 interface IDiamondCut is IDiamond {
     /**

--- a/src/interfaces/IGateway.sol
+++ b/src/interfaces/IGateway.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {BottomUpCheckpoint, CrossMsg, ParentFinality} from "../structs/Checkpoint.sol";
-import {SubnetID} from "../structs/Subnet.sol";
-import {FvmAddress} from "../structs/FvmAddress.sol";
+import { BottomUpCheckpoint, CrossMsg, ParentFinality } from "../structs/Checkpoint.sol";
+import { SubnetID } from "../structs/Subnet.sol";
+import { FvmAddress } from "../structs/FvmAddress.sol";
 
 /// @title Gateway interface
 /// @author LimeChain team

--- a/src/interfaces/ISubnetActor.sol
+++ b/src/interfaces/ISubnetActor.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {BottomUpCheckpoint, CrossMsg} from "../structs/Checkpoint.sol";
+import { BottomUpCheckpoint, CrossMsg } from "../structs/Checkpoint.sol";
 
 /// @title Subnet Actor interface
 /// @author LimeChain team

--- a/src/structs/Checkpoint.sol
+++ b/src/structs/Checkpoint.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {SubnetID, IPCAddress} from "./Subnet.sol";
+import { SubnetID, IPCAddress } from "./Subnet.sol";
 
 /// @notice The parent finality for IPC parent at certain height.
 struct ParentFinality {

--- a/src/structs/Subnet.sol
+++ b/src/structs/Subnet.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {SubnetID} from "./Subnet.sol";
-import {FvmAddress} from "./FvmAddress.sol";
-import {Status} from "../enums/Status.sol";
-import {MaxPQ} from "../lib/priority/LibMaxPQ.sol";
-import {MinPQ} from "../lib/priority/LibMinPQ.sol";
+import { SubnetID } from "./Subnet.sol";
+import { FvmAddress } from "./FvmAddress.sol";
+import { Status } from "../enums/Status.sol";
+import { MaxPQ } from "../lib/priority/LibMaxPQ.sol";
+import { MinPQ } from "../lib/priority/LibMinPQ.sol";
 
 struct SubnetID {
     /// @notice chainID of the root subnet

--- a/src/subnet/SubnetActorGetterFacet.sol
+++ b/src/subnet/SubnetActorGetterFacet.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {ConsensusType} from "../enums/ConsensusType.sol";
-import {BottomUpCheckpoint, CrossMsg} from "../structs/Checkpoint.sol";
-import {SubnetID} from "../structs/Subnet.sol";
-import {SubnetID, ValidatorInfo, Validator} from "../structs/Subnet.sol";
-import {SubnetActorStorage} from "../lib/LibSubnetActorStorage.sol";
-import {SubnetIDHelper} from "../lib/SubnetIDHelper.sol";
-import {Address} from "openzeppelin-contracts/utils/Address.sol";
-import {EnumerableSet} from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
-import {LibStaking} from "../lib/LibStaking.sol";
+import { ConsensusType } from "../enums/ConsensusType.sol";
+import { BottomUpCheckpoint, CrossMsg } from "../structs/Checkpoint.sol";
+import { SubnetID } from "../structs/Subnet.sol";
+import { SubnetID, ValidatorInfo, Validator } from "../structs/Subnet.sol";
+import { SubnetActorStorage } from "../lib/LibSubnetActorStorage.sol";
+import { SubnetIDHelper } from "../lib/SubnetIDHelper.sol";
+import { Address } from "openzeppelin-contracts/utils/Address.sol";
+import { EnumerableSet } from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
+import { LibStaking } from "../lib/LibStaking.sol";
 
 contract SubnetActorGetterFacet {
     using EnumerableSet for EnumerableSet.AddressSet;

--- a/src/subnet/SubnetActorManagerFacet.sol
+++ b/src/subnet/SubnetActorManagerFacet.sol
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {InvalidFederationPayload, SubnetAlreadyBootstrapped, NotEnoughFunds, CollateralIsZero, CannotReleaseZero, NotOwnerOfPublicKey, EmptyAddress, NotEnoughBalance, NotEnoughCollateral, NotValidator, NotAllValidatorsHaveLeft, NotStakedBefore, InvalidSignatureErr, InvalidCheckpointEpoch, InvalidCheckpointMessagesHash, InvalidPublicKeyLength, MethodNotAllowed} from "../errors/IPCErrors.sol";
-import {IGateway} from "../interfaces/IGateway.sol";
-import {ISubnetActor} from "../interfaces/ISubnetActor.sol";
-import {BottomUpCheckpoint, CrossMsg} from "../structs/Checkpoint.sol";
-import {Validator, ValidatorSet, PermissionMode} from "../structs/Subnet.sol";
-import {Pausable} from "../lib/LibPausable.sol";
-import {LibDiamond} from "../lib/LibDiamond.sol";
-import {MultisignatureChecker} from "../lib/LibMultisignatureChecker.sol";
-import {ReentrancyGuard} from "../lib/LibReentrancyGuard.sol";
-import {SubnetActorModifiers} from "../lib/LibSubnetActorStorage.sol";
-import {LibValidatorSet, LibStaking} from "../lib/LibStaking.sol";
-import {LibDiamond} from "../lib/LibDiamond.sol";
-import {EnumerableSet} from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
-import {Address} from "openzeppelin-contracts/utils/Address.sol";
+import { InvalidFederationPayload, SubnetAlreadyBootstrapped, NotEnoughFunds, CollateralIsZero, CannotReleaseZero, NotOwnerOfPublicKey, EmptyAddress, NotEnoughBalance, NotEnoughCollateral, NotValidator, NotAllValidatorsHaveLeft, NotStakedBefore, InvalidSignatureErr, InvalidCheckpointEpoch, InvalidCheckpointMessagesHash, InvalidPublicKeyLength, MethodNotAllowed } from "../errors/IPCErrors.sol";
+import { IGateway } from "../interfaces/IGateway.sol";
+import { ISubnetActor } from "../interfaces/ISubnetActor.sol";
+import { BottomUpCheckpoint, CrossMsg } from "../structs/Checkpoint.sol";
+import { Validator, ValidatorSet, PermissionMode } from "../structs/Subnet.sol";
+import { Pausable } from "../lib/LibPausable.sol";
+import { LibDiamond } from "../lib/LibDiamond.sol";
+import { MultisignatureChecker } from "../lib/LibMultisignatureChecker.sol";
+import { ReentrancyGuard } from "../lib/LibReentrancyGuard.sol";
+import { SubnetActorModifiers } from "../lib/LibSubnetActorStorage.sol";
+import { LibValidatorSet, LibStaking } from "../lib/LibStaking.sol";
+import { LibDiamond } from "../lib/LibDiamond.sol";
+import { EnumerableSet } from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
+import { Address } from "openzeppelin-contracts/utils/Address.sol";
 
 string constant ERR_PERMISSIONED_AND_BOOTSTRAPPED = "Method not allowed if permissioned is enabled and subnet bootstrapped";
 
@@ -83,7 +83,7 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Pausable
 
         if (checkpoint.blockHeight == s.lastBottomUpCheckpointHeight + s.bottomUpCheckPeriod) {
             // validate signatures and quorum threshold, revert if validation fails
-            validateActiveQuorumSignatures({signatories: signatories, hash: checkpointHash, signatures: signatures});
+            validateActiveQuorumSignatures({ signatories: signatories, hash: checkpointHash, signatures: signatures });
 
             // If the checkpoint height is the next expected height then this is a new checkpoint which must be executed
             // in the Gateway Actor, the checkpoint and the relayer must be stored, last bottom-up checkpoint updated.
@@ -187,7 +187,7 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Pausable
                 revert NotOwnerOfPublicKey();
             }
 
-            LibStaking.setFederatedPower({validator: validators[i], metadata: publicKeys[i], amount: powers[i]});
+            LibStaking.setFederatedPower({ validator: validators[i], metadata: publicKeys[i], amount: powers[i] });
 
             unchecked {
                 ++i;
@@ -235,7 +235,7 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Pausable
                     emit SubnetBootstrapped(s.genesisValidators);
 
                     // register adding the genesis circulating supply (if it exists)
-                    IGateway(s.ipcGatewayAddr).register{value: totalCollateral + s.genesisCircSupply}(
+                    IGateway(s.ipcGatewayAddr).register{ value: totalCollateral + s.genesisCircSupply }(
                         s.genesisCircSupply
                     );
                 }

--- a/src/subnetregistry/RegisterSubnetFacet.sol
+++ b/src/subnetregistry/RegisterSubnetFacet.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {IDiamond} from "../interfaces/IDiamond.sol";
-import {SubnetActorDiamond} from "../SubnetActorDiamond.sol";
-import {SubnetRegistryActorStorage} from "../lib/LibSubnetRegistryStorage.sol";
+import { IDiamond } from "../interfaces/IDiamond.sol";
+import { SubnetActorDiamond } from "../SubnetActorDiamond.sol";
+import { SubnetRegistryActorStorage } from "../lib/LibSubnetRegistryStorage.sol";
 
-import {ReentrancyGuard} from "../lib/LibReentrancyGuard.sol";
-import {WrongGateway} from "../errors/IPCErrors.sol";
+import { ReentrancyGuard } from "../lib/LibReentrancyGuard.sol";
+import { WrongGateway } from "../errors/IPCErrors.sol";
 
 contract RegisterSubnetFacet is ReentrancyGuard {
     SubnetRegistryActorStorage internal s;

--- a/src/subnetregistry/SubnetGetterFacet.sol
+++ b/src/subnetregistry/SubnetGetterFacet.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
-import {SubnetRegistryActorStorage} from "../lib/LibSubnetRegistryStorage.sol";
-import {CannotFindSubnet, FacetCannotBeZero} from "../errors/IPCErrors.sol";
-import {LibDiamond} from "../lib/LibDiamond.sol";
+import { SubnetRegistryActorStorage } from "../lib/LibSubnetRegistryStorage.sol";
+import { CannotFindSubnet, FacetCannotBeZero } from "../errors/IPCErrors.sol";
+import { LibDiamond } from "../lib/LibDiamond.sol";
 
 contract SubnetGetterFacet {
     // slither-disable-next-line uninitialized-state

--- a/test/IntegrationTestBase.sol
+++ b/test/IntegrationTestBase.sol
@@ -5,39 +5,39 @@ import "forge-std/Test.sol";
 import "forge-std/StdInvariant.sol";
 
 import "../src/errors/IPCErrors.sol";
-import {NumberContractFacetSeven, NumberContractFacetEight} from "./helpers/NumberContract.sol";
-import {EMPTY_BYTES, METHOD_SEND, EMPTY_HASH} from "../src/constants/Constants.sol";
-import {ConsensusType} from "../src/enums/ConsensusType.sol";
-import {Status} from "../src/enums/Status.sol";
-import {IERC165} from "../src/interfaces/IERC165.sol";
-import {IDiamond} from "../src/interfaces/IDiamond.sol";
-import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
-import {IDiamondCut} from "../src/interfaces/IDiamondCut.sol";
-import {ISubnetActor} from "../src/interfaces/ISubnetActor.sol";
-import {CheckpointInfo} from "../src/structs/Checkpoint.sol";
-import {CrossMsg, BottomUpCheckpoint, StorableMsg, ParentFinality} from "../src/structs/Checkpoint.sol";
-import {FvmAddress} from "../src/structs/FvmAddress.sol";
-import {SubnetID, PermissionMode, PermissionMode, Subnet, IPCAddress, Membership, Validator, StakingChange, StakingChangeRequest, StakingOperation} from "../src/structs/Subnet.sol";
-import {SubnetIDHelper} from "../src/lib/SubnetIDHelper.sol";
-import {FvmAddressHelper} from "../src/lib/FvmAddressHelper.sol";
-import {CrossMsgHelper} from "../src/lib/CrossMsgHelper.sol";
-import {StorableMsgHelper} from "../src/lib/StorableMsgHelper.sol";
-import {FilAddress} from "fevmate/utils/FilAddress.sol";
-import {GatewayDiamond, FunctionNotFound} from "../src/GatewayDiamond.sol";
-import {SubnetActorDiamond} from "../src/SubnetActorDiamond.sol";
-import {GatewayGetterFacet} from "../src/gateway/GatewayGetterFacet.sol";
-import {GatewayMessengerFacet} from "../src/gateway/GatewayMessengerFacet.sol";
-import {GatewayManagerFacet} from "../src/gateway/GatewayManagerFacet.sol";
-import {GatewayRouterFacet} from "../src/gateway/GatewayRouterFacet.sol";
-import {SubnetActorManagerFacetMock} from "./mocks/SubnetActor.sol";
-import {SubnetActorManagerFacet} from "../src/subnet/SubnetActorManagerFacet.sol";
-import {SubnetActorGetterFacet} from "../src/subnet/SubnetActorGetterFacet.sol";
-import {DiamondLoupeFacet} from "../src/diamond/DiamondLoupeFacet.sol";
-import {DiamondCutFacet} from "../src/diamond/DiamondCutFacet.sol";
-import {LibDiamond} from "../src/lib/LibDiamond.sol";
-import {MerkleTreeHelper} from "./helpers/MerkleTreeHelper.sol";
+import { NumberContractFacetSeven, NumberContractFacetEight } from "./helpers/NumberContract.sol";
+import { EMPTY_BYTES, METHOD_SEND, EMPTY_HASH } from "../src/constants/Constants.sol";
+import { ConsensusType } from "../src/enums/ConsensusType.sol";
+import { Status } from "../src/enums/Status.sol";
+import { IERC165 } from "../src/interfaces/IERC165.sol";
+import { IDiamond } from "../src/interfaces/IDiamond.sol";
+import { IDiamondLoupe } from "../src/interfaces/IDiamondLoupe.sol";
+import { IDiamondCut } from "../src/interfaces/IDiamondCut.sol";
+import { ISubnetActor } from "../src/interfaces/ISubnetActor.sol";
+import { CheckpointInfo } from "../src/structs/Checkpoint.sol";
+import { CrossMsg, BottomUpCheckpoint, StorableMsg, ParentFinality } from "../src/structs/Checkpoint.sol";
+import { FvmAddress } from "../src/structs/FvmAddress.sol";
+import { SubnetID, PermissionMode, PermissionMode, Subnet, IPCAddress, Membership, Validator, StakingChange, StakingChangeRequest, StakingOperation } from "../src/structs/Subnet.sol";
+import { SubnetIDHelper } from "../src/lib/SubnetIDHelper.sol";
+import { FvmAddressHelper } from "../src/lib/FvmAddressHelper.sol";
+import { CrossMsgHelper } from "../src/lib/CrossMsgHelper.sol";
+import { StorableMsgHelper } from "../src/lib/StorableMsgHelper.sol";
+import { FilAddress } from "fevmate/utils/FilAddress.sol";
+import { GatewayDiamond, FunctionNotFound } from "../src/GatewayDiamond.sol";
+import { SubnetActorDiamond } from "../src/SubnetActorDiamond.sol";
+import { GatewayGetterFacet } from "../src/gateway/GatewayGetterFacet.sol";
+import { GatewayMessengerFacet } from "../src/gateway/GatewayMessengerFacet.sol";
+import { GatewayManagerFacet } from "../src/gateway/GatewayManagerFacet.sol";
+import { GatewayRouterFacet } from "../src/gateway/GatewayRouterFacet.sol";
+import { SubnetActorManagerFacetMock } from "./mocks/SubnetActor.sol";
+import { SubnetActorManagerFacet } from "../src/subnet/SubnetActorManagerFacet.sol";
+import { SubnetActorGetterFacet } from "../src/subnet/SubnetActorGetterFacet.sol";
+import { DiamondLoupeFacet } from "../src/diamond/DiamondLoupeFacet.sol";
+import { DiamondCutFacet } from "../src/diamond/DiamondCutFacet.sol";
+import { LibDiamond } from "../src/lib/LibDiamond.sol";
+import { MerkleTreeHelper } from "./helpers/MerkleTreeHelper.sol";
 
-import {TestUtils} from "./helpers/TestUtils.sol";
+import { TestUtils } from "./helpers/TestUtils.sol";
 
 contract IntegrationTestBase is Test {
     using SubnetIDHelper for SubnetID;
@@ -139,7 +139,7 @@ contract IntegrationTestBase is Test {
         address gw
     ) internal pure virtual returns (SubnetActorDiamond.ConstructorParams memory) {
         SubnetActorDiamond.ConstructorParams memory params = SubnetActorDiamond.ConstructorParams({
-            parentId: SubnetID({root: ROOTNET_CHAINID, route: new address[](0)}),
+            parentId: SubnetID({ root: ROOTNET_CHAINID, route: new address[](0) }),
             ipcGatewayAddr: gw,
             consensus: ConsensusType.Fendermint,
             minActivationCollateral: DEFAULT_COLLATERAL_AMOUNT,
@@ -169,7 +169,7 @@ contract IntegrationTestBase is Test {
 
     function defaultGatewayParams() internal pure virtual returns (GatewayDiamond.ConstructorParams memory) {
         GatewayDiamond.ConstructorParams memory params = GatewayDiamond.ConstructorParams({
-            networkName: SubnetID({root: ROOTNET_CHAINID, route: new address[](0)}),
+            networkName: SubnetID({ root: ROOTNET_CHAINID, route: new address[](0) }),
             bottomUpCheckPeriod: DEFAULT_CHECKPOINT_PERIOD,
             msgFee: DEFAULT_CROSS_MSG_FEE,
             minCollateral: DEFAULT_COLLATERAL_AMOUNT,
@@ -467,7 +467,7 @@ contract IntegrationTestBase is Test {
         weights[1] = 100;
         weights[2] = 100;
 
-        ParentFinality memory finality = ParentFinality({height: block.number, blockHash: bytes32(0)});
+        ParentFinality memory finality = ParentFinality({ height: block.number, blockHash: bytes32(0) });
 
         vm.prank(FilAddress.SYSTEM_ACTOR);
         gwRouter.commitParentFinality(finality);
@@ -518,7 +518,7 @@ contract IntegrationTestBase is Test {
         weights[0] = weight;
 
         vm.deal(validator, 1);
-        ParentFinality memory finality = ParentFinality({height: block.number, blockHash: bytes32(0)});
+        ParentFinality memory finality = ParentFinality({ height: block.number, blockHash: bytes32(0) });
         // uint64 n = gwGetter.getLastConfigurationNumber() + 1;
 
         vm.startPrank(FilAddress.SYSTEM_ACTOR);
@@ -541,7 +541,7 @@ contract IntegrationTestBase is Test {
 
         require(gwGetter.crossMsgFee() > 0, "crossMsgFee is 0");
 
-        gwManager.fund{value: fundAmount}(subnetId, FvmAddressHelper.from(funderAddress));
+        gwManager.fund{ value: fundAmount }(subnetId, FvmAddressHelper.from(funderAddress));
 
         (, , uint256 nonce, , uint256 circSupply, ) = getSubnet(address(saManager));
 
@@ -554,7 +554,7 @@ contract IntegrationTestBase is Test {
     function join(address validatorAddress, bytes memory pubkey) public {
         vm.prank(validatorAddress);
         vm.deal(validatorAddress, DEFAULT_COLLATERAL_AMOUNT + 1);
-        saManager.join{value: DEFAULT_COLLATERAL_AMOUNT}(pubkey);
+        saManager.join{ value: DEFAULT_COLLATERAL_AMOUNT }(pubkey);
     }
 
     function confirmChange(address validator, uint256 privKey) internal {
@@ -636,7 +636,7 @@ contract IntegrationTestBase is Test {
 
     function release(uint256 releaseAmount) public {
         uint256 expectedNonce = gwGetter.bottomUpNonce() + 1;
-        gwManager.release{value: releaseAmount}(FvmAddressHelper.from(msg.sender));
+        gwManager.release{ value: releaseAmount }(FvmAddressHelper.from(msg.sender));
         require(gwGetter.bottomUpNonce() == expectedNonce, "gwGetter.bottomUpNonce() == expectedNonce");
     }
 
@@ -645,7 +645,7 @@ contract IntegrationTestBase is Test {
 
         (, uint256 stakedBefore, , , , ) = getSubnet(subnetAddress);
 
-        gwManager.addStake{value: stakeAmount}();
+        gwManager.addStake{ value: stakeAmount }();
 
         uint256 balanceAfter = subnetAddress.balance;
         (, uint256 stakedAfter, , , , ) = getSubnet(subnetAddress);
@@ -657,7 +657,7 @@ contract IntegrationTestBase is Test {
     function registerSubnetGW(uint256 collateral, address subnetAddress, GatewayDiamond gw) public {
         GatewayManagerFacet manager = GatewayManagerFacet(address(gw));
 
-        manager.register{value: collateral}(0);
+        manager.register{ value: collateral }(0);
 
         (SubnetID memory id, uint256 stake, uint256 topDownNonce, , uint256 circSupply, Status status) = getSubnetGW(
             subnetAddress,

--- a/test/helpers/FvmAddressHelper.sol
+++ b/test/helpers/FvmAddressHelper.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 import "forge-std/console.sol";
 
 import "../../src/lib/FvmAddressHelper.sol";
-import {FvmAddress} from "../../src/structs/FvmAddress.sol";
+import { FvmAddress } from "../../src/structs/FvmAddress.sol";
 
 contract FvmAddressHelperTest is Test {
     using FvmAddressHelper for FvmAddress;

--- a/test/helpers/MerkleTreeHelper.sol
+++ b/test/helpers/MerkleTreeHelper.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {Merkle} from "murky/Merkle.sol";
+import { Merkle } from "murky/Merkle.sol";
 
 library MerkleTreeHelper {
     function createMerkleProofsForValidators(

--- a/test/integration/GatewayDiamond.t.sol
+++ b/test/integration/GatewayDiamond.t.sol
@@ -4,34 +4,34 @@ pragma solidity 0.8.19;
 import "forge-std/Test.sol";
 
 import "../../src/errors/IPCErrors.sol";
-import {NumberContractFacetSeven, NumberContractFacetEight} from "../helpers/NumberContract.sol";
-import {EMPTY_BYTES, METHOD_SEND, EMPTY_HASH} from "../../src/constants/Constants.sol";
-import {Status} from "../../src/enums/Status.sol";
-import {IERC165} from "../../src/interfaces/IERC165.sol";
-import {IDiamond} from "../../src/interfaces/IDiamond.sol";
-import {IDiamondLoupe} from "../../src/interfaces/IDiamondLoupe.sol";
-import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
-import {CheckpointInfo} from "../../src/structs/Checkpoint.sol";
-import {CrossMsg, BottomUpCheckpoint, StorableMsg, ParentFinality} from "../../src/structs/Checkpoint.sol";
-import {FvmAddress} from "../../src/structs/FvmAddress.sol";
-import {SubnetID, Subnet, IPCAddress, Membership, Validator, StakingChange, StakingChangeRequest, StakingOperation} from "../../src/structs/Subnet.sol";
-import {SubnetIDHelper} from "../../src/lib/SubnetIDHelper.sol";
-import {FvmAddressHelper} from "../../src/lib/FvmAddressHelper.sol";
-import {CrossMsgHelper} from "../../src/lib/CrossMsgHelper.sol";
-import {StorableMsgHelper} from "../../src/lib/StorableMsgHelper.sol";
-import {FilAddress} from "fevmate/utils/FilAddress.sol";
-import {GatewayDiamond, FunctionNotFound} from "../../src/GatewayDiamond.sol";
-import {SubnetActorDiamond} from "../../src/SubnetActorDiamond.sol";
-import {GatewayGetterFacet} from "../../src/gateway/GatewayGetterFacet.sol";
-import {GatewayManagerFacet} from "../../src/gateway/GatewayManagerFacet.sol";
-import {GatewayRouterFacet} from "../../src/gateway/GatewayRouterFacet.sol";
-import {GatewayMessengerFacet, ERR_GENERAL_CROSS_MSG_DISABLED, ERR_MULTILEVEL_CROSS_MSG_DISABLED} from "../../src/gateway/GatewayMessengerFacet.sol";
-import {DiamondCutFacet} from "../../src/diamond/DiamondCutFacet.sol";
-import {LibDiamond} from "../../src/lib/LibDiamond.sol";
-import {MerkleTreeHelper} from "../helpers/MerkleTreeHelper.sol";
+import { NumberContractFacetSeven, NumberContractFacetEight } from "../helpers/NumberContract.sol";
+import { EMPTY_BYTES, METHOD_SEND, EMPTY_HASH } from "../../src/constants/Constants.sol";
+import { Status } from "../../src/enums/Status.sol";
+import { IERC165 } from "../../src/interfaces/IERC165.sol";
+import { IDiamond } from "../../src/interfaces/IDiamond.sol";
+import { IDiamondLoupe } from "../../src/interfaces/IDiamondLoupe.sol";
+import { IDiamondCut } from "../../src/interfaces/IDiamondCut.sol";
+import { CheckpointInfo } from "../../src/structs/Checkpoint.sol";
+import { CrossMsg, BottomUpCheckpoint, StorableMsg, ParentFinality } from "../../src/structs/Checkpoint.sol";
+import { FvmAddress } from "../../src/structs/FvmAddress.sol";
+import { SubnetID, Subnet, IPCAddress, Membership, Validator, StakingChange, StakingChangeRequest, StakingOperation } from "../../src/structs/Subnet.sol";
+import { SubnetIDHelper } from "../../src/lib/SubnetIDHelper.sol";
+import { FvmAddressHelper } from "../../src/lib/FvmAddressHelper.sol";
+import { CrossMsgHelper } from "../../src/lib/CrossMsgHelper.sol";
+import { StorableMsgHelper } from "../../src/lib/StorableMsgHelper.sol";
+import { FilAddress } from "fevmate/utils/FilAddress.sol";
+import { GatewayDiamond, FunctionNotFound } from "../../src/GatewayDiamond.sol";
+import { SubnetActorDiamond } from "../../src/SubnetActorDiamond.sol";
+import { GatewayGetterFacet } from "../../src/gateway/GatewayGetterFacet.sol";
+import { GatewayManagerFacet } from "../../src/gateway/GatewayManagerFacet.sol";
+import { GatewayRouterFacet } from "../../src/gateway/GatewayRouterFacet.sol";
+import { GatewayMessengerFacet, ERR_GENERAL_CROSS_MSG_DISABLED, ERR_MULTILEVEL_CROSS_MSG_DISABLED } from "../../src/gateway/GatewayMessengerFacet.sol";
+import { DiamondCutFacet } from "../../src/diamond/DiamondCutFacet.sol";
+import { LibDiamond } from "../../src/lib/LibDiamond.sol";
+import { MerkleTreeHelper } from "../helpers/MerkleTreeHelper.sol";
 
-import {TestUtils} from "../helpers/TestUtils.sol";
-import {IntegrationTestBase} from "../IntegrationTestBase.sol";
+import { TestUtils } from "../helpers/TestUtils.sol";
+import { IntegrationTestBase } from "../IntegrationTestBase.sol";
 
 contract GatewayActorDiamondTest is Test, IntegrationTestBase {
     using SubnetIDHelper for SubnetID;
@@ -51,7 +51,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         require(gwGetter.crossMsgFee() == DEFAULT_CROSS_MSG_FEE, "unexpected crossMsgFee");
         require(gwGetter.bottomUpCheckPeriod() == DEFAULT_CHECKPOINT_PERIOD, "unexpected bottomUpCheckPeriod");
         require(
-            gwGetter.getNetworkName().equals(SubnetID({root: ROOTNET_CHAINID, route: new address[](0)})),
+            gwGetter.getNetworkName().equals(SubnetID({ root: ROOTNET_CHAINID, route: new address[](0) })),
             "unexpected getNetworkName"
         );
         require(gwGetter.majorityPercentage() == DEFAULT_MAJORITY_PERCENTAGE, "unexpected majorityPercentage");
@@ -155,7 +155,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         GatewayRouterFacet depRouter = new GatewayRouterFacet();
 
         GatewayDiamond.ConstructorParams memory constructorParams = GatewayDiamond.ConstructorParams({
-            networkName: SubnetID({root: ROOTNET_CHAINID, route: new address[](0)}),
+            networkName: SubnetID({ root: ROOTNET_CHAINID, route: new address[](0) }),
             bottomUpCheckPeriod: checkpointPeriod,
             msgFee: DEFAULT_CROSS_MSG_FEE,
             minCollateral: DEFAULT_COLLATERAL_AMOUNT,
@@ -193,7 +193,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         GatewayRouterFacet depRouter = new GatewayRouterFacet();
 
         GatewayDiamond.ConstructorParams memory constructorParams = GatewayDiamond.ConstructorParams({
-            networkName: SubnetID({root: ROOTNET_CHAINID, route: path}),
+            networkName: SubnetID({ root: ROOTNET_CHAINID, route: path }),
             bottomUpCheckPeriod: checkpointPeriod,
             msgFee: DEFAULT_CROSS_MSG_FEE,
             minCollateral: DEFAULT_COLLATERAL_AMOUNT,
@@ -288,7 +288,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         vm.assume(collateral < DEFAULT_COLLATERAL_AMOUNT);
         vm.expectRevert(NotEnoughCollateral.selector);
 
-        gwManager.register{value: collateral}(0);
+        gwManager.register{ value: collateral }(0);
     }
 
     function testGatewayDiamond_Register_Fail_SubnetAlreadyExists() public {
@@ -296,7 +296,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
 
         vm.expectRevert(AlreadyRegisteredSubnet.selector);
 
-        gwManager.register{value: DEFAULT_COLLATERAL_AMOUNT}(0);
+        gwManager.register{ value: DEFAULT_COLLATERAL_AMOUNT }(0);
     }
 
     function testGatewayDiamond_AddStake_Works_SingleStaking(uint256 stakeAmount, uint256 registerAmount) public {
@@ -389,13 +389,13 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
 
         vm.expectRevert(NotEnoughFunds.selector);
 
-        gwManager.addStake{value: 0}();
+        gwManager.addStake{ value: 0 }();
     }
 
     function testGatewayDiamond_AddStake_Fail_SubnetNotExists() public {
         vm.expectRevert(NotRegisteredSubnet.selector);
 
-        gwManager.addStake{value: 1}();
+        gwManager.addStake{ value: 1 }();
     }
 
     function testGatewayDiamond_ReleaseStake_Works_FullAmount(uint256 stakeAmount) public {
@@ -546,15 +546,15 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
 
         // General-purpose cross-net messages are currenlty disabled.
         vm.expectRevert(abi.encodeWithSelector(MethodNotAllowed.selector, ERR_GENERAL_CROSS_MSG_DISABLED));
-        gwMessenger.sendUserXnetMessage{value: DEFAULT_CROSS_MSG_FEE - 1}(
+        gwMessenger.sendUserXnetMessage{ value: DEFAULT_CROSS_MSG_FEE - 1 }(
             CrossMsg({
                 message: StorableMsg({
                     from: IPCAddress({
-                        subnetId: SubnetID({root: ROOTNET_CHAINID, route: new address[](0)}),
+                        subnetId: SubnetID({ root: ROOTNET_CHAINID, route: new address[](0) }),
                         rawAddress: FvmAddressHelper.from(caller)
                     }),
                     to: IPCAddress({
-                        subnetId: SubnetID({root: 0, route: new address[](0)}),
+                        subnetId: SubnetID({ root: 0, route: new address[](0) }),
                         rawAddress: FvmAddressHelper.from(caller)
                     }),
                     value: 1,
@@ -570,15 +570,15 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         // vm.expectRevert(NotEnoughFee.selector);
         // General-purpose cross-net messages are currenlty disabled.
         vm.expectRevert(abi.encodeWithSelector(MethodNotAllowed.selector, ERR_GENERAL_CROSS_MSG_DISABLED));
-        gwMessenger.sendUserXnetMessage{value: DEFAULT_CROSS_MSG_FEE + 1}(
+        gwMessenger.sendUserXnetMessage{ value: DEFAULT_CROSS_MSG_FEE + 1 }(
             CrossMsg({
                 message: StorableMsg({
                     from: IPCAddress({
-                        subnetId: SubnetID({root: ROOTNET_CHAINID, route: new address[](0)}),
+                        subnetId: SubnetID({ root: ROOTNET_CHAINID, route: new address[](0) }),
                         rawAddress: FvmAddressHelper.from(caller)
                     }),
                     to: IPCAddress({
-                        subnetId: SubnetID({root: 0, route: new address[](0)}),
+                        subnetId: SubnetID({ root: 0, route: new address[](0) }),
                         rawAddress: FvmAddressHelper.from(caller)
                     }),
                     value: 1,
@@ -601,15 +601,15 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         registerSubnet(DEFAULT_COLLATERAL_AMOUNT, caller);
 
         vm.expectRevert();
-        gwMessenger.sendUserXnetMessage{value: fee - 1}(
+        gwMessenger.sendUserXnetMessage{ value: fee - 1 }(
             CrossMsg({
                 message: StorableMsg({
                     from: IPCAddress({
-                        subnetId: SubnetID({root: ROOTNET_CHAINID, route: new address[](0)}),
+                        subnetId: SubnetID({ root: ROOTNET_CHAINID, route: new address[](0) }),
                         rawAddress: FvmAddressHelper.from(caller)
                     }),
                     to: IPCAddress({
-                        subnetId: SubnetID({root: 0, route: new address[](0)}),
+                        subnetId: SubnetID({ root: 0, route: new address[](0) }),
                         rawAddress: FvmAddressHelper.from(caller)
                     }),
                     value: 1,
@@ -665,7 +665,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         (SubnetID memory subnetId, , , , , ) = getSubnet(address(saManager));
 
         vm.expectRevert(InvalidCrossMsgValue.selector);
-        gwManager.fund{value: 0}(subnetId, FvmAddressHelper.from(funderAddress));
+        gwManager.fund{ value: 0 }(subnetId, FvmAddressHelper.from(funderAddress));
     }
 
     function testGatewayDiamond_Fund_Works_MultipleFundings(uint8 numberOfFunds) public {
@@ -699,7 +699,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
 
         (SubnetID memory subnetId, , , , , ) = getSubnet(address(saManager));
         vm.prank(funderAddress);
-        gwManager.fund{value: amount}(subnetId, FvmAddressHelper.from(msg.sender));
+        gwManager.fund{ value: amount }(subnetId, FvmAddressHelper.from(msg.sender));
     }
 
     function testGatewayDiamond_Fund_Fails_NotRegistered() public {
@@ -721,13 +721,13 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
 
         vm.startPrank(funderAddress);
 
-        SubnetID memory wrongSubnetId = SubnetID({root: ROOTNET_CHAINID, route: wrongSubnetPath});
+        SubnetID memory wrongSubnetId = SubnetID({ root: ROOTNET_CHAINID, route: wrongSubnetPath });
 
         vm.expectRevert(NotRegisteredSubnet.selector);
-        gwManager.fund{value: fundAmount}(wrongSubnetId, FvmAddressHelper.from(msg.sender));
+        gwManager.fund{ value: fundAmount }(wrongSubnetId, FvmAddressHelper.from(msg.sender));
 
         vm.expectRevert(NotRegisteredSubnet.selector);
-        gwManager.fund{value: fundAmount}(SubnetID(ROOTNET_CHAINID, wrongPath), FvmAddressHelper.from(msg.sender));
+        gwManager.fund{ value: fundAmount }(SubnetID(ROOTNET_CHAINID, wrongPath), FvmAddressHelper.from(msg.sender));
     }
 
     function testGatewayDiamond_Fund_Works_BLSAccountSingleFunding() public {
@@ -765,7 +765,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         path[1] = address(2);
 
         GatewayDiamond.ConstructorParams memory constructorParams = GatewayDiamond.ConstructorParams({
-            networkName: SubnetID({root: ROOTNET_CHAINID, route: path}),
+            networkName: SubnetID({ root: ROOTNET_CHAINID, route: path }),
             bottomUpCheckPeriod: DEFAULT_CHECKPOINT_PERIOD,
             msgFee: DEFAULT_CROSS_MSG_FEE,
             minCollateral: DEFAULT_COLLATERAL_AMOUNT,
@@ -784,7 +784,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         vm.deal(callerAddress, 1 ether);
         vm.expectRevert(InvalidCrossMsgValue.selector);
 
-        gwManager.release{value: 0 ether}(FvmAddressHelper.from(msg.sender));
+        gwManager.release{ value: 0 ether }(FvmAddressHelper.from(msg.sender));
     }
 
     function testGatewayDiamond_Release_Works_BLSAccount(uint256 releaseAmount, uint256 crossMsgFee) public {
@@ -797,7 +797,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         path[1] = makeAddr("subnet_one");
 
         GatewayDiamond.ConstructorParams memory constructorParams = GatewayDiamond.ConstructorParams({
-            networkName: SubnetID({root: ROOTNET_CHAINID, route: path}),
+            networkName: SubnetID({ root: ROOTNET_CHAINID, route: path }),
             bottomUpCheckPeriod: DEFAULT_CHECKPOINT_PERIOD,
             msgFee: crossMsgFee,
             minCollateral: DEFAULT_COLLATERAL_AMOUNT,
@@ -828,7 +828,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         path[1] = makeAddr("subnet_one");
 
         GatewayDiamond.ConstructorParams memory constructorParams = GatewayDiamond.ConstructorParams({
-            networkName: SubnetID({root: ROOTNET_CHAINID, route: path}),
+            networkName: SubnetID({ root: ROOTNET_CHAINID, route: path }),
             bottomUpCheckPeriod: DEFAULT_CHECKPOINT_PERIOD,
             msgFee: crossMsgFee,
             minCollateral: DEFAULT_COLLATERAL_AMOUNT,
@@ -860,7 +860,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         path[1] = makeAddr("subnet_one");
 
         GatewayDiamond.ConstructorParams memory constructorParams = GatewayDiamond.ConstructorParams({
-            networkName: SubnetID({root: ROOTNET_CHAINID, route: path}),
+            networkName: SubnetID({ root: ROOTNET_CHAINID, route: path }),
             bottomUpCheckPeriod: DEFAULT_CHECKPOINT_PERIOD,
             msgFee: crossMsgFee,
             minCollateral: DEFAULT_COLLATERAL_AMOUNT,
@@ -893,15 +893,15 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         // vm.expectRevert(InvalidCrossMsgDstSubnet.selector);
         // General-purpose cross-net messages are currenlty disabled.
         vm.expectRevert(abi.encodeWithSelector(MethodNotAllowed.selector, ERR_GENERAL_CROSS_MSG_DISABLED));
-        gwMessenger.sendUserXnetMessage{value: DEFAULT_CROSS_MSG_FEE + 1}(
+        gwMessenger.sendUserXnetMessage{ value: DEFAULT_CROSS_MSG_FEE + 1 }(
             CrossMsg({
                 message: StorableMsg({
                     from: IPCAddress({
-                        subnetId: SubnetID({root: ROOTNET_CHAINID, route: new address[](0)}),
+                        subnetId: SubnetID({ root: ROOTNET_CHAINID, route: new address[](0) }),
                         rawAddress: FvmAddressHelper.from(caller)
                     }),
                     to: IPCAddress({
-                        subnetId: SubnetID({root: 0, route: new address[](0)}),
+                        subnetId: SubnetID({ root: 0, route: new address[](0) }),
                         rawAddress: FvmAddressHelper.from(caller)
                     }),
                     value: 1,
@@ -925,14 +925,14 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         // vm.expectRevert(CannotSendCrossMsgToItself.selector);
         // General-purpose cross-net messages are currenlty disabled.
         vm.expectRevert(abi.encodeWithSelector(MethodNotAllowed.selector, ERR_GENERAL_CROSS_MSG_DISABLED));
-        gwMessenger.sendUserXnetMessage{value: DEFAULT_CROSS_MSG_FEE + 1}(
+        gwMessenger.sendUserXnetMessage{ value: DEFAULT_CROSS_MSG_FEE + 1 }(
             CrossMsg({
                 message: StorableMsg({
                     from: IPCAddress({
-                        subnetId: SubnetID({root: ROOTNET_CHAINID, route: new address[](0)}),
+                        subnetId: SubnetID({ root: ROOTNET_CHAINID, route: new address[](0) }),
                         rawAddress: FvmAddressHelper.from(caller)
                     }),
-                    to: IPCAddress({subnetId: destinationSubnet, rawAddress: FvmAddressHelper.from(caller)}),
+                    to: IPCAddress({ subnetId: destinationSubnet, rawAddress: FvmAddressHelper.from(caller) }),
                     value: 1,
                     nonce: 0,
                     method: METHOD_SEND,
@@ -954,14 +954,14 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         // vm.expectRevert(InvalidCrossMsgValue.selector);
         // General-purpose cross-net messages are currenlty disabled.
         vm.expectRevert(abi.encodeWithSelector(MethodNotAllowed.selector, ERR_GENERAL_CROSS_MSG_DISABLED));
-        gwMessenger.sendUserXnetMessage{value: DEFAULT_CROSS_MSG_FEE + 1}(
+        gwMessenger.sendUserXnetMessage{ value: DEFAULT_CROSS_MSG_FEE + 1 }(
             CrossMsg({
                 message: StorableMsg({
                     from: IPCAddress({
-                        subnetId: SubnetID({root: ROOTNET_CHAINID, route: new address[](0)}),
+                        subnetId: SubnetID({ root: ROOTNET_CHAINID, route: new address[](0) }),
                         rawAddress: FvmAddressHelper.from(caller)
                     }),
-                    to: IPCAddress({subnetId: destinationSubnet, rawAddress: FvmAddressHelper.from(caller)}),
+                    to: IPCAddress({ subnetId: destinationSubnet, rawAddress: FvmAddressHelper.from(caller) }),
                     value: 5,
                     nonce: 0,
                     method: METHOD_SEND,
@@ -985,14 +985,14 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
 
         // General-purpose cross-net messages are currenlty disabled.
         vm.expectRevert(abi.encodeWithSelector(MethodNotAllowed.selector, ERR_GENERAL_CROSS_MSG_DISABLED));
-        gwMessenger.sendUserXnetMessage{value: DEFAULT_CROSS_MSG_FEE + 1}(
+        gwMessenger.sendUserXnetMessage{ value: DEFAULT_CROSS_MSG_FEE + 1 }(
             CrossMsg({
                 message: StorableMsg({
                     from: IPCAddress({
-                        subnetId: SubnetID({root: ROOTNET_CHAINID, route: new address[](0)}),
+                        subnetId: SubnetID({ root: ROOTNET_CHAINID, route: new address[](0) }),
                         rawAddress: FvmAddressHelper.from(caller)
                     }),
-                    to: IPCAddress({subnetId: destinationSubnet, rawAddress: FvmAddressHelper.from(caller)}),
+                    to: IPCAddress({ subnetId: destinationSubnet, rawAddress: FvmAddressHelper.from(caller) }),
                     value: 1,
                     nonce: 0,
                     method: METHOD_SEND,
@@ -1014,14 +1014,14 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         // vm.expectRevert(InvalidCrossMsgFromSubnet.selector);
         // General-purpose cross-net messages are currenlty disabled.
         vm.expectRevert(abi.encodeWithSelector(MethodNotAllowed.selector, ERR_GENERAL_CROSS_MSG_DISABLED));
-        gwMessenger.sendUserXnetMessage{value: DEFAULT_CROSS_MSG_FEE + 1}(
+        gwMessenger.sendUserXnetMessage{ value: DEFAULT_CROSS_MSG_FEE + 1 }(
             CrossMsg({
                 message: StorableMsg({
                     from: IPCAddress({
-                        subnetId: SubnetID({root: 0, route: new address[](0)}),
+                        subnetId: SubnetID({ root: 0, route: new address[](0) }),
                         rawAddress: FvmAddressHelper.from(caller)
                     }),
-                    to: IPCAddress({subnetId: destinationSubnet, rawAddress: FvmAddressHelper.from(caller)}),
+                    to: IPCAddress({ subnetId: destinationSubnet, rawAddress: FvmAddressHelper.from(caller) }),
                     value: 1,
                     nonce: 0,
                     method: METHOD_SEND,
@@ -1043,14 +1043,14 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         // vm.expectRevert(NotEnoughFee.selector);
         // General-purpose cross-net messages are currenlty disabled.
         vm.expectRevert(abi.encodeWithSelector(MethodNotAllowed.selector, ERR_GENERAL_CROSS_MSG_DISABLED));
-        gwMessenger.sendUserXnetMessage{value: DEFAULT_CROSS_MSG_FEE}(
+        gwMessenger.sendUserXnetMessage{ value: DEFAULT_CROSS_MSG_FEE }(
             CrossMsg({
                 message: StorableMsg({
                     from: IPCAddress({
-                        subnetId: SubnetID({root: ROOTNET_CHAINID, route: new address[](0)}),
+                        subnetId: SubnetID({ root: ROOTNET_CHAINID, route: new address[](0) }),
                         rawAddress: FvmAddressHelper.from(caller)
                     }),
-                    to: IPCAddress({subnetId: destinationSubnet, rawAddress: FvmAddressHelper.from(address(0))}),
+                    to: IPCAddress({ subnetId: destinationSubnet, rawAddress: FvmAddressHelper.from(address(0)) }),
                     value: 0,
                     nonce: 0,
                     method: METHOD_SEND,
@@ -1072,14 +1072,14 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         // vm.expectRevert(NotEnoughFunds.selector);
         // General-purpose cross-net messages are currenlty disabled.
         vm.expectRevert(abi.encodeWithSelector(MethodNotAllowed.selector, ERR_GENERAL_CROSS_MSG_DISABLED));
-        gwMessenger.sendUserXnetMessage{value: 0}(
+        gwMessenger.sendUserXnetMessage{ value: 0 }(
             CrossMsg({
                 message: StorableMsg({
                     from: IPCAddress({
-                        subnetId: SubnetID({root: ROOTNET_CHAINID, route: new address[](0)}),
+                        subnetId: SubnetID({ root: ROOTNET_CHAINID, route: new address[](0) }),
                         rawAddress: FvmAddressHelper.from(caller)
                     }),
-                    to: IPCAddress({subnetId: destinationSubnet, rawAddress: FvmAddressHelper.from(address(0))}),
+                    to: IPCAddress({ subnetId: destinationSubnet, rawAddress: FvmAddressHelper.from(address(0)) }),
                     value: 0,
                     nonce: 0,
                     method: METHOD_SEND,
@@ -1102,7 +1102,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         vm.prank(caller);
         vm.expectRevert(NotSystemActor.selector);
 
-        ParentFinality memory finality = ParentFinality({height: block.number, blockHash: bytes32(0)});
+        ParentFinality memory finality = ParentFinality({ height: block.number, blockHash: bytes32(0) });
 
         gwRouter.commitParentFinality(finality);
     }
@@ -1116,11 +1116,11 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
 
         changes[0] = StakingChangeRequest({
             configurationNumber: 1,
-            change: StakingChange({validator: val1, op: StakingOperation.Deposit, payload: abi.encode(amount)})
+            change: StakingChange({ validator: val1, op: StakingOperation.Deposit, payload: abi.encode(amount) })
         });
         changes[1] = StakingChangeRequest({
             configurationNumber: 2,
-            change: StakingChange({validator: val2, op: StakingOperation.Deposit, payload: abi.encode(amount)})
+            change: StakingChange({ validator: val2, op: StakingOperation.Deposit, payload: abi.encode(amount) })
         });
 
         vm.startPrank(FilAddress.SYSTEM_ACTOR);
@@ -1139,7 +1139,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
 
         changes[0] = StakingChangeRequest({
             configurationNumber: 3,
-            change: StakingChange({validator: val1, op: StakingOperation.Withdraw, payload: abi.encode(amount)})
+            change: StakingChange({ validator: val1, op: StakingOperation.Withdraw, payload: abi.encode(amount) })
         });
 
         vm.startPrank(FilAddress.SYSTEM_ACTOR);
@@ -1173,7 +1173,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
 
         vm.startPrank(FilAddress.SYSTEM_ACTOR);
 
-        ParentFinality memory finality = ParentFinality({height: block.number, blockHash: bytes32(0)});
+        ParentFinality memory finality = ParentFinality({ height: block.number, blockHash: bytes32(0) });
 
         gwRouter.commitParentFinality(finality);
         ParentFinality memory committedFinality = gwGetter.getParentFinality(block.number);
@@ -1314,7 +1314,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         require(exist, "subnet does not exist");
         require(subnetInfo.circSupply == 0, "unexpected initial circulation supply");
 
-        gwManager.fund{value: DEFAULT_COLLATERAL_AMOUNT}(subnetId, FvmAddressHelper.from(address(caller)));
+        gwManager.fund{ value: DEFAULT_COLLATERAL_AMOUNT }(subnetId, FvmAddressHelper.from(address(caller)));
         (, subnetInfo) = gwGetter.getSubnet(subnetId);
         require(subnetInfo.circSupply == DEFAULT_COLLATERAL_AMOUNT, "unexpected circulation supply after funding");
 

--- a/test/integration/GatewayL2Diamond.t.sol
+++ b/test/integration/GatewayL2Diamond.t.sol
@@ -4,26 +4,26 @@ pragma solidity 0.8.19;
 import "forge-std/Test.sol";
 
 import "../../src/errors/IPCErrors.sol";
-import {EMPTY_BYTES, METHOD_SEND, EMPTY_HASH} from "../../src/constants/Constants.sol";
-import {CrossMsg, StorableMsg} from "../../src/structs/Checkpoint.sol";
-import {FvmAddress} from "../../src/structs/FvmAddress.sol";
-import {SubnetID, Subnet, IPCAddress, Validator} from "../../src/structs/Subnet.sol";
-import {SubnetIDHelper} from "../../src/lib/SubnetIDHelper.sol";
-import {FvmAddressHelper} from "../../src/lib/FvmAddressHelper.sol";
-import {CrossMsgHelper} from "../../src/lib/CrossMsgHelper.sol";
-import {StorableMsgHelper} from "../../src/lib/StorableMsgHelper.sol";
-import {GatewayDiamond, FEATURE_MULTILEVEL_CROSSMSG} from "../../src/GatewayDiamond.sol";
-import {SubnetActorDiamond} from "../../src/SubnetActorDiamond.sol";
-import {GatewayGetterFacet} from "../../src/gateway/GatewayGetterFacet.sol";
-import {GatewayManagerFacet} from "../../src/gateway/GatewayManagerFacet.sol";
-import {GatewayRouterFacet} from "../../src/gateway/GatewayRouterFacet.sol";
-import {DiamondCutFacet} from "../../src/diamond/DiamondCutFacet.sol";
-import {GatewayMessengerFacet} from "../../src/gateway/GatewayMessengerFacet.sol";
-import {DiamondLoupeFacet} from "../../src/diamond/DiamondLoupeFacet.sol";
-import {DiamondCutFacet} from "../../src/diamond/DiamondCutFacet.sol";
-import {TestUtils} from "../helpers/TestUtils.sol";
-import {IntegrationTestBase} from "../IntegrationTestBase.sol";
-import {FilAddress} from "fevmate/utils/FilAddress.sol";
+import { EMPTY_BYTES, METHOD_SEND, EMPTY_HASH } from "../../src/constants/Constants.sol";
+import { CrossMsg, StorableMsg } from "../../src/structs/Checkpoint.sol";
+import { FvmAddress } from "../../src/structs/FvmAddress.sol";
+import { SubnetID, Subnet, IPCAddress, Validator } from "../../src/structs/Subnet.sol";
+import { SubnetIDHelper } from "../../src/lib/SubnetIDHelper.sol";
+import { FvmAddressHelper } from "../../src/lib/FvmAddressHelper.sol";
+import { CrossMsgHelper } from "../../src/lib/CrossMsgHelper.sol";
+import { StorableMsgHelper } from "../../src/lib/StorableMsgHelper.sol";
+import { GatewayDiamond, FEATURE_MULTILEVEL_CROSSMSG } from "../../src/GatewayDiamond.sol";
+import { SubnetActorDiamond } from "../../src/SubnetActorDiamond.sol";
+import { GatewayGetterFacet } from "../../src/gateway/GatewayGetterFacet.sol";
+import { GatewayManagerFacet } from "../../src/gateway/GatewayManagerFacet.sol";
+import { GatewayRouterFacet } from "../../src/gateway/GatewayRouterFacet.sol";
+import { DiamondCutFacet } from "../../src/diamond/DiamondCutFacet.sol";
+import { GatewayMessengerFacet } from "../../src/gateway/GatewayMessengerFacet.sol";
+import { DiamondLoupeFacet } from "../../src/diamond/DiamondLoupeFacet.sol";
+import { DiamondCutFacet } from "../../src/diamond/DiamondCutFacet.sol";
+import { TestUtils } from "../helpers/TestUtils.sol";
+import { IntegrationTestBase } from "../IntegrationTestBase.sol";
+import { FilAddress } from "fevmate/utils/FilAddress.sol";
 
 contract GatewayL2ActorDiamondTest is Test, IntegrationTestBase {
     using SubnetIDHelper for SubnetID;
@@ -53,7 +53,7 @@ contract GatewayL2ActorDiamondTest is Test, IntegrationTestBase {
         path2[1] = CHILD_NETWORK_ADDRESS_2;
 
         GatewayDiamond.ConstructorParams memory params = GatewayDiamond.ConstructorParams({
-            networkName: SubnetID({root: ROOTNET_CHAINID, route: path2}),
+            networkName: SubnetID({ root: ROOTNET_CHAINID, route: path2 }),
             bottomUpCheckPeriod: DEFAULT_CHECKPOINT_PERIOD,
             msgFee: DEFAULT_CROSS_MSG_FEE,
             minCollateral: DEFAULT_COLLATERAL_AMOUNT,
@@ -80,8 +80,8 @@ contract GatewayL2ActorDiamondTest is Test, IntegrationTestBase {
         for (uint64 i = 0; i < n; i++) {
             topDownMsgs[i] = CrossMsg({
                 message: StorableMsg({
-                    from: IPCAddress({subnetId: id, rawAddress: FvmAddressHelper.from(address(this))}),
-                    to: IPCAddress({subnetId: id, rawAddress: FvmAddressHelper.from(address(this))}),
+                    from: IPCAddress({ subnetId: id, rawAddress: FvmAddressHelper.from(address(this)) }),
+                    to: IPCAddress({ subnetId: id, rawAddress: FvmAddressHelper.from(address(this)) }),
                     value: 0,
                     nonce: i,
                     method: this.callback.selector,
@@ -116,7 +116,7 @@ contract GatewayL2ActorDiamondTest is Test, IntegrationTestBase {
 
         vm.expectCall(caller, 1 ether - gwGetter.crossMsgFee(), new bytes(0), 1);
         vm.prank(caller);
-        gwMessenger.propagate{value: 1 ether}(postboxId);
+        gwMessenger.propagate{ value: 1 ether }(postboxId);
 
         require(caller.balance == 1 ether - gwGetter.crossMsgFee(), "unexpected balance");
     }
@@ -137,7 +137,7 @@ contract GatewayL2ActorDiamondTest is Test, IntegrationTestBase {
 
         vm.prank(caller);
         vm.expectCall(caller, 0, EMPTY_BYTES, 0);
-        gwMessenger.propagate{value: fee}(postboxId);
+        gwMessenger.propagate{ value: fee }(postboxId);
         require(caller.balance == 0, "unexpected balance");
     }
 

--- a/test/integration/SubnetActorDiamond.t.sol
+++ b/test/integration/SubnetActorDiamond.t.sol
@@ -2,40 +2,40 @@
 pragma solidity 0.8.19;
 
 import "../../src/errors/IPCErrors.sol";
-import {Test} from "forge-std/Test.sol";
-import {TestUtils} from "../helpers/TestUtils.sol";
-import {NumberContractFacetSeven, NumberContractFacetEight} from "../helpers/NumberContract.sol";
-import {EMPTY_BYTES, METHOD_SEND, EMPTY_HASH} from "../../src/constants/Constants.sol";
-import {ConsensusType} from "../../src/enums/ConsensusType.sol";
-import {Status} from "../../src/enums/Status.sol";
-import {CrossMsg, BottomUpCheckpoint, StorableMsg} from "../../src/structs/Checkpoint.sol";
-import {FvmAddress} from "../../src/structs/FvmAddress.sol";
-import {SubnetID, PermissionMode, IPCAddress, Subnet, ValidatorInfo, Validator} from "../../src/structs/Subnet.sol";
-import {StorableMsg} from "../../src/structs/Checkpoint.sol";
-import {IERC165} from "../../src/interfaces/IERC165.sol";
-import {IGateway} from "../../src/interfaces/IGateway.sol";
-import {IDiamond} from "../../src/interfaces/IDiamond.sol";
-import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
-import {IDiamondLoupe} from "../../src/interfaces/IDiamondLoupe.sol";
-import {FvmAddressHelper} from "../../src/lib/FvmAddressHelper.sol";
-import {StorableMsgHelper} from "../../src/lib/StorableMsgHelper.sol";
-import {SubnetIDHelper} from "../../src/lib/SubnetIDHelper.sol";
-import {SubnetActorDiamond, FunctionNotFound} from "../../src/SubnetActorDiamond.sol";
-import {GatewayDiamond} from "../../src/GatewayDiamond.sol";
-import {GatewayGetterFacet} from "../../src/gateway/GatewayGetterFacet.sol";
-import {GatewayMessengerFacet} from "../../src/gateway/GatewayMessengerFacet.sol";
-import {GatewayManagerFacet} from "../../src/gateway/GatewayManagerFacet.sol";
-import {GatewayRouterFacet} from "../../src/gateway/GatewayRouterFacet.sol";
-import {SubnetActorManagerFacet, ERR_PERMISSIONED_AND_BOOTSTRAPPED} from "../../src/subnet/SubnetActorManagerFacet.sol";
-import {SubnetActorGetterFacet} from "../../src/subnet/SubnetActorGetterFacet.sol";
-import {DiamondCutFacet} from "../../src/diamond/DiamondCutFacet.sol";
-import {DiamondLoupeFacet} from "../../src/diamond/DiamondLoupeFacet.sol";
-import {FilAddress} from "fevmate/utils/FilAddress.sol";
-import {LibStaking} from "../../src/lib/LibStaking.sol";
-import {LibDiamond} from "../../src/lib/LibDiamond.sol";
-import {Pausable} from "../../src/lib/LibPausable.sol";
+import { Test } from "forge-std/Test.sol";
+import { TestUtils } from "../helpers/TestUtils.sol";
+import { NumberContractFacetSeven, NumberContractFacetEight } from "../helpers/NumberContract.sol";
+import { EMPTY_BYTES, METHOD_SEND, EMPTY_HASH } from "../../src/constants/Constants.sol";
+import { ConsensusType } from "../../src/enums/ConsensusType.sol";
+import { Status } from "../../src/enums/Status.sol";
+import { CrossMsg, BottomUpCheckpoint, StorableMsg } from "../../src/structs/Checkpoint.sol";
+import { FvmAddress } from "../../src/structs/FvmAddress.sol";
+import { SubnetID, PermissionMode, IPCAddress, Subnet, ValidatorInfo, Validator } from "../../src/structs/Subnet.sol";
+import { StorableMsg } from "../../src/structs/Checkpoint.sol";
+import { IERC165 } from "../../src/interfaces/IERC165.sol";
+import { IGateway } from "../../src/interfaces/IGateway.sol";
+import { IDiamond } from "../../src/interfaces/IDiamond.sol";
+import { IDiamondCut } from "../../src/interfaces/IDiamondCut.sol";
+import { IDiamondLoupe } from "../../src/interfaces/IDiamondLoupe.sol";
+import { FvmAddressHelper } from "../../src/lib/FvmAddressHelper.sol";
+import { StorableMsgHelper } from "../../src/lib/StorableMsgHelper.sol";
+import { SubnetIDHelper } from "../../src/lib/SubnetIDHelper.sol";
+import { SubnetActorDiamond, FunctionNotFound } from "../../src/SubnetActorDiamond.sol";
+import { GatewayDiamond } from "../../src/GatewayDiamond.sol";
+import { GatewayGetterFacet } from "../../src/gateway/GatewayGetterFacet.sol";
+import { GatewayMessengerFacet } from "../../src/gateway/GatewayMessengerFacet.sol";
+import { GatewayManagerFacet } from "../../src/gateway/GatewayManagerFacet.sol";
+import { GatewayRouterFacet } from "../../src/gateway/GatewayRouterFacet.sol";
+import { SubnetActorManagerFacet, ERR_PERMISSIONED_AND_BOOTSTRAPPED } from "../../src/subnet/SubnetActorManagerFacet.sol";
+import { SubnetActorGetterFacet } from "../../src/subnet/SubnetActorGetterFacet.sol";
+import { DiamondCutFacet } from "../../src/diamond/DiamondCutFacet.sol";
+import { DiamondLoupeFacet } from "../../src/diamond/DiamondLoupeFacet.sol";
+import { FilAddress } from "fevmate/utils/FilAddress.sol";
+import { LibStaking } from "../../src/lib/LibStaking.sol";
+import { LibDiamond } from "../../src/lib/LibDiamond.sol";
+import { Pausable } from "../../src/lib/LibPausable.sol";
 
-import {IntegrationTestBase} from "../IntegrationTestBase.sol";
+import { IntegrationTestBase } from "../IntegrationTestBase.sol";
 
 contract SubnetActorDiamondTest is Test, IntegrationTestBase {
     using SubnetIDHelper for SubnetID;
@@ -96,7 +96,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         vm.deal(validator2, DEFAULT_MIN_VALIDATOR_STAKE);
 
         vm.startPrank(validator1);
-        saManager.join{value: validator1Stake}(publicKey1);
+        saManager.join{ value: validator1Stake }(publicKey1);
         collateral = validator1Stake;
 
         require(gatewayAddress.balance == collateral, "gw balance is incorrect after validator1 joining");
@@ -123,7 +123,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         // subnet bootstrapped and should go through queue
         // second and third validators join
         vm.startPrank(validator2);
-        saManager.join{value: DEFAULT_MIN_VALIDATOR_STAKE}(publicKey2);
+        saManager.join{ value: DEFAULT_MIN_VALIDATOR_STAKE }(publicKey2);
 
         // collateral not confirmed yet
         v = saGetter.getValidator(validator2);
@@ -173,7 +173,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         vm.startPrank(validator1);
         vm.deal(validator1, stake);
 
-        saManager.stake{value: stake}();
+        saManager.stake{ value: stake }();
 
         v = saGetter.getValidator(validator1);
         require(v.totalCollateral == validator1Stake + stake, "unexpected total collateral after stake");
@@ -328,7 +328,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         vm.prank(validator);
         vm.expectRevert(NotOwnerOfPublicKey.selector);
 
-        saManager.join{value: 10}(new bytes(65));
+        saManager.join{ value: 10 }(new bytes(65));
     }
 
     function testSubnetActorDiamond_Join_Fail_InvalidPublicKeyLength() public {
@@ -338,7 +338,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         vm.prank(validator);
         vm.expectRevert(InvalidPublicKeyLength.selector);
 
-        saManager.join{value: 10}(new bytes(64));
+        saManager.join{ value: 10 }(new bytes(64));
     }
 
     function testSubnetActorDiamond_Join_Fail_ZeroColalteral() public {
@@ -356,7 +356,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
 
         vm.deal(validator, DEFAULT_MIN_VALIDATOR_STAKE);
         vm.prank(validator);
-        saManager.join{value: DEFAULT_MIN_VALIDATOR_STAKE}(publicKey);
+        saManager.join{ value: DEFAULT_MIN_VALIDATOR_STAKE }(publicKey);
 
         // validator adds empty node
         vm.prank(validator);
@@ -406,13 +406,13 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         vm.deal(validator3, DEFAULT_MIN_VALIDATOR_STAKE);
 
         vm.prank(validator1);
-        saManager.join{value: DEFAULT_MIN_VALIDATOR_STAKE}(publicKey1);
+        saManager.join{ value: DEFAULT_MIN_VALIDATOR_STAKE }(publicKey1);
 
         vm.prank(validator2);
-        saManager.join{value: 3 * DEFAULT_MIN_VALIDATOR_STAKE}(publicKey2);
+        saManager.join{ value: 3 * DEFAULT_MIN_VALIDATOR_STAKE }(publicKey2);
 
         vm.prank(validator3);
-        saManager.join{value: DEFAULT_MIN_VALIDATOR_STAKE}(publicKey3);
+        saManager.join{ value: DEFAULT_MIN_VALIDATOR_STAKE }(publicKey3);
 
         confirmChange(validator1, privKey1);
 
@@ -447,10 +447,10 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
 
         vm.prank(validator);
         vm.expectRevert(NotStakedBefore.selector);
-        saManager.stake{value: 10}();
+        saManager.stake{ value: 10 }();
 
         vm.prank(validator);
-        saManager.join{value: 3}(publicKey);
+        saManager.join{ value: 3 }(publicKey);
 
         ValidatorInfo memory info = saGetter.getValidator(validator);
         require(info.totalCollateral == 3);
@@ -460,8 +460,8 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         CrossMsg[] memory msgs = new CrossMsg[](1);
         msgs[0] = CrossMsg({
             message: StorableMsg({
-                from: IPCAddress({subnetId: saGetter.getParent(), rawAddress: FvmAddressHelper.from(address(this))}),
-                to: IPCAddress({subnetId: saGetter.getParent(), rawAddress: FvmAddressHelper.from(address(this))}),
+                from: IPCAddress({ subnetId: saGetter.getParent(), rawAddress: FvmAddressHelper.from(address(this)) }),
+                to: IPCAddress({ subnetId: saGetter.getParent(), rawAddress: FvmAddressHelper.from(address(this)) }),
                 value: DEFAULT_CROSS_MSG_FEE + 1,
                 nonce: 0,
                 method: METHOD_SEND,
@@ -487,7 +487,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
             pubKeys[i] = TestUtils.deriveValidatorPubKeyBytes(keys[i]);
             vm.deal(validators[i], 10 gwei);
             vm.prank(validators[i]);
-            saManager.join{value: 10}(pubKeys[i]);
+            saManager.join{ value: 10 }(pubKeys[i]);
         }
 
         saManager.validateActiveQuorumSignatures(validators, hash, signatures);
@@ -507,7 +507,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
             pubKeys[i] = TestUtils.deriveValidatorPubKeyBytes(keys[i]);
             vm.deal(validators[i], 10 gwei);
             vm.prank(validators[i]);
-            saManager.join{value: 10}(pubKeys[i]);
+            saManager.join{ value: 10 }(pubKeys[i]);
         }
 
         vm.expectRevert(abi.encodeWithSelector(InvalidSignatureErr.selector, 4));
@@ -523,7 +523,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
             vm.deal(validators[i], 10 gwei);
             pubKeys[i] = TestUtils.deriveValidatorPubKeyBytes(keys[i]);
             vm.prank(validators[i]);
-            saManager.join{value: 10}(pubKeys[i]);
+            saManager.join{ value: 10 }(pubKeys[i]);
         }
 
         CrossMsg memory crossMsg = CrossMsg({
@@ -532,7 +532,10 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
                     subnetId: saGetter.getParent(),
                     rawAddress: FvmAddressHelper.from(address(saDiamond))
                 }),
-                to: IPCAddress({subnetId: saGetter.getParent(), rawAddress: FvmAddressHelper.from(address(saDiamond))}),
+                to: IPCAddress({
+                    subnetId: saGetter.getParent(),
+                    rawAddress: FvmAddressHelper.from(address(saDiamond))
+                }),
                 value: DEFAULT_CROSS_MSG_FEE + 1,
                 nonce: 0,
                 method: METHOD_SEND,
@@ -570,7 +573,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
 
         vm.deal(address(saDiamond), 100 ether);
         vm.prank(address(saDiamond));
-        gwManager.register{value: DEFAULT_MIN_VALIDATOR_STAKE + 3 * DEFAULT_CROSS_MSG_FEE}(3 * DEFAULT_CROSS_MSG_FEE);
+        gwManager.register{ value: DEFAULT_MIN_VALIDATOR_STAKE + 3 * DEFAULT_CROSS_MSG_FEE }(3 * DEFAULT_CROSS_MSG_FEE);
 
         bytes32 hash = keccak256(abi.encode(checkpoint));
 
@@ -626,7 +629,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
             vm.deal(validators[i], 10 gwei);
             pubKeys[i] = TestUtils.deriveValidatorPubKeyBytes(keys[i]);
             vm.prank(validators[i]);
-            saManager.join{value: 10}(pubKeys[i]);
+            saManager.join{ value: 10 }(pubKeys[i]);
         }
 
         // send the first checkpoint
@@ -636,7 +639,10 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
                     subnetId: saGetter.getParent(),
                     rawAddress: FvmAddressHelper.from(address(saDiamond))
                 }),
-                to: IPCAddress({subnetId: saGetter.getParent(), rawAddress: FvmAddressHelper.from(address(saDiamond))}),
+                to: IPCAddress({
+                    subnetId: saGetter.getParent(),
+                    rawAddress: FvmAddressHelper.from(address(saDiamond))
+                }),
                 value: DEFAULT_CROSS_MSG_FEE + 1,
                 nonce: 0,
                 method: METHOD_SEND,
@@ -658,7 +664,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
 
         vm.deal(address(saDiamond), 100 ether);
         vm.prank(address(saDiamond));
-        gwManager.register{value: DEFAULT_MIN_VALIDATOR_STAKE + 6 * DEFAULT_CROSS_MSG_FEE}(6 * DEFAULT_CROSS_MSG_FEE);
+        gwManager.register{ value: DEFAULT_MIN_VALIDATOR_STAKE + 6 * DEFAULT_CROSS_MSG_FEE }(6 * DEFAULT_CROSS_MSG_FEE);
 
         bytes32 hash = keccak256(abi.encode(checkpoint));
 
@@ -686,7 +692,10 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
                     subnetId: saGetter.getParent(),
                     rawAddress: FvmAddressHelper.from(address(saDiamond))
                 }),
-                to: IPCAddress({subnetId: saGetter.getParent(), rawAddress: FvmAddressHelper.from(address(saDiamond))}),
+                to: IPCAddress({
+                    subnetId: saGetter.getParent(),
+                    rawAddress: FvmAddressHelper.from(address(saDiamond))
+                }),
                 value: DEFAULT_CROSS_MSG_FEE + 1,
                 nonce: 1,
                 method: METHOD_SEND,
@@ -809,7 +818,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
 
         vm.deal(validator, DEFAULT_MIN_VALIDATOR_STAKE);
         vm.prank(validator);
-        saManager.join{value: DEFAULT_MIN_VALIDATOR_STAKE}(publicKey);
+        saManager.join{ value: DEFAULT_MIN_VALIDATOR_STAKE }(publicKey);
         require(
             saGetter.getValidator(validator).totalCollateral == DEFAULT_MIN_VALIDATOR_STAKE,
             "initial collateral correct"
@@ -848,7 +857,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         // pre-fund and pre-release from same address
         vm.startPrank(preReleaser);
         vm.deal(preReleaser, 2 * fundAmount);
-        saManager.preFund{value: 2 * fundAmount}();
+        saManager.preFund{ value: 2 * fundAmount }();
         require(saGetter.genesisCircSupply() == 2 * fundAmount, "genesis circ supply not correct");
         saManager.preRelease(fundAmount);
         require(saGetter.genesisCircSupply() == fundAmount, "genesis circ supply not correct");
@@ -867,19 +876,19 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         // pre-fund from validator and from pre-funder
         vm.startPrank(validator1);
         vm.deal(validator1, fundAmount);
-        saManager.preFund{value: fundAmount}();
+        saManager.preFund{ value: fundAmount }();
         vm.stopPrank();
 
         vm.startPrank(preFunder);
         vm.deal(preFunder, fundAmount);
-        saManager.preFund{value: fundAmount}();
+        saManager.preFund{ value: fundAmount }();
         vm.stopPrank();
 
         // initial validator joins
         vm.deal(validator1, DEFAULT_MIN_VALIDATOR_STAKE);
 
         vm.startPrank(validator1);
-        saManager.join{value: DEFAULT_MIN_VALIDATOR_STAKE}(publicKey1);
+        saManager.join{ value: DEFAULT_MIN_VALIDATOR_STAKE }(publicKey1);
         vm.stopPrank();
         collateral = DEFAULT_MIN_VALIDATOR_STAKE;
 
@@ -911,7 +920,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         vm.startPrank(preFunder);
         vm.expectRevert(SubnetAlreadyBootstrapped.selector);
         vm.deal(preFunder, fundAmount);
-        saManager.preFund{value: fundAmount}();
+        saManager.preFund{ value: fundAmount }();
         vm.stopPrank();
     }
 
@@ -925,13 +934,13 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         // pre-fund from validator
         vm.startPrank(validator1);
         vm.deal(validator1, fundAmount);
-        saManager.preFund{value: fundAmount}();
+        saManager.preFund{ value: fundAmount }();
         vm.stopPrank();
 
         // initial validator joins but doesn't bootstrap the subnet
         vm.deal(validator1, collateral);
         vm.startPrank(validator1);
-        saManager.join{value: collateral}(publicKey1);
+        saManager.join{ value: collateral }(publicKey1);
         require(
             address(saDiamond).balance == collateral + fundAmount,
             "subnet balance is incorrect after validator1 joining"
@@ -952,7 +961,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         vm.deal(validator1, DEFAULT_MIN_VALIDATOR_STAKE);
 
         vm.startPrank(validator1);
-        saManager.join{value: DEFAULT_MIN_VALIDATOR_STAKE}(publicKey1);
+        saManager.join{ value: DEFAULT_MIN_VALIDATOR_STAKE }(publicKey1);
         vm.stopPrank();
 
         // pre-release not allowed with bootstrapped subnet
@@ -974,11 +983,11 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         }
 
         vm.prank(validators[0]);
-        saManager.join{value: 100 * DEFAULT_MIN_VALIDATOR_STAKE}(publicKeys[0]);
+        saManager.join{ value: 100 * DEFAULT_MIN_VALIDATOR_STAKE }(publicKeys[0]);
 
         for (uint i = 1; i < n; i++) {
             vm.prank(validators[i]);
-            saManager.join{value: DEFAULT_MIN_VALIDATOR_STAKE}(publicKeys[i]);
+            saManager.join{ value: DEFAULT_MIN_VALIDATOR_STAKE }(publicKeys[i]);
         }
 
         confirmChange(validators[0], privKeys[0]);
@@ -1000,11 +1009,11 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         }
 
         vm.prank(validators[0]);
-        saManager.join{value: 100 * DEFAULT_MIN_VALIDATOR_STAKE}(publicKeys[0]);
+        saManager.join{ value: 100 * DEFAULT_MIN_VALIDATOR_STAKE }(publicKeys[0]);
 
         for (uint i = 1; i < n; i++) {
             vm.prank(validators[i]);
-            saManager.join{value: DEFAULT_MIN_VALIDATOR_STAKE - 1}(publicKeys[i]);
+            saManager.join{ value: DEFAULT_MIN_VALIDATOR_STAKE - 1 }(publicKeys[i]);
         }
 
         confirmChange(validators[0], privKeys[0]);
@@ -1027,11 +1036,11 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         }
 
         vm.prank(validators[0]);
-        saManager.join{value: 100 * DEFAULT_MIN_VALIDATOR_STAKE}(publicKeys[0]);
+        saManager.join{ value: 100 * DEFAULT_MIN_VALIDATOR_STAKE }(publicKeys[0]);
 
         for (uint i = 1; i < n; i++) {
             vm.prank(validators[i]);
-            saManager.join{value: 1}(publicKeys[i]);
+            saManager.join{ value: 1 }(publicKeys[i]);
         }
 
         confirmChange(validators[0], privKeys[0]);
@@ -1049,7 +1058,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         for (uint i = 0; i < n; i++) {
             vm.deal(validators[i], 1);
             vm.prank(validators[i]);
-            saManager.join{value: 1}(publicKeys[i]);
+            saManager.join{ value: 1 }(publicKeys[i]);
         }
 
         require(!saGetter.bootstrapped());
@@ -1091,10 +1100,10 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         (address validator1, bytes memory publicKey1) = TestUtils.deriveValidatorAddress(100);
         vm.deal(validator1, DEFAULT_MIN_VALIDATOR_STAKE * 2);
         vm.startPrank(validator1);
-        saManager.join{value: DEFAULT_MIN_VALIDATOR_STAKE}(publicKey1);
+        saManager.join{ value: DEFAULT_MIN_VALIDATOR_STAKE }(publicKey1);
 
         vm.expectRevert(abi.encodeWithSelector(MethodNotAllowed.selector, ERR_PERMISSIONED_AND_BOOTSTRAPPED));
-        saManager.join{value: DEFAULT_MIN_VALIDATOR_STAKE}(publicKey1);
+        saManager.join{ value: DEFAULT_MIN_VALIDATOR_STAKE }(publicKey1);
     }
 
     function testSubnetActorDiamond_FederatedValidation_works() public {
@@ -1121,7 +1130,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
 
         vm.deal(validators[0], DEFAULT_MIN_VALIDATOR_STAKE * 2);
         vm.startPrank(validators[0]);
-        saManager.join{value: DEFAULT_MIN_VALIDATOR_STAKE}(publicKeys[0]);
+        saManager.join{ value: DEFAULT_MIN_VALIDATOR_STAKE }(publicKeys[0]);
         vm.stopPrank();
 
         saManager.setFederatedPower(validators, publicKeys, powers);
@@ -1174,7 +1183,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         vm.prank(validators[0]);
         vm.deal(validators[0], 20);
         vm.expectRevert(Pausable.EnforcedPause.selector);
-        saManager.join{value: 10}(publicKeys[0]);
+        saManager.join{ value: 10 }(publicKeys[0]);
     }
 
     function testSubnetActorDiamond_Pausable_NotOwner() public {

--- a/test/integration/SubnetRegistry.t.sol
+++ b/test/integration/SubnetRegistry.t.sol
@@ -1,30 +1,30 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {EMPTY_BYTES} from "../../src/constants/Constants.sol";
-import {ConsensusType} from "../../src/enums/ConsensusType.sol";
+import { EMPTY_BYTES } from "../../src/constants/Constants.sol";
+import { ConsensusType } from "../../src/enums/ConsensusType.sol";
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
-import {TestUtils} from "../helpers/TestUtils.sol";
-import {IERC165} from "../../src/interfaces/IERC165.sol";
-import {IDiamond} from "../../src/interfaces/IDiamond.sol";
-import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
-import {IDiamondLoupe} from "../../src/interfaces/IDiamondLoupe.sol";
-import {LibDiamond} from "../../src/lib/LibDiamond.sol";
+import { TestUtils } from "../helpers/TestUtils.sol";
+import { IERC165 } from "../../src/interfaces/IERC165.sol";
+import { IDiamond } from "../../src/interfaces/IDiamond.sol";
+import { IDiamondCut } from "../../src/interfaces/IDiamondCut.sol";
+import { IDiamondLoupe } from "../../src/interfaces/IDiamondLoupe.sol";
+import { LibDiamond } from "../../src/lib/LibDiamond.sol";
 
-import {SubnetActorGetterFacet} from "../../src/subnet/SubnetActorGetterFacet.sol";
-import {SubnetActorManagerFacet} from "../../src/subnet/SubnetActorManagerFacet.sol";
-import {SubnetActorDiamond} from "../../src/SubnetActorDiamond.sol";
-import {SubnetID, PermissionMode} from "../../src/structs/Subnet.sol";
-import {SubnetRegistryDiamond} from "../../src/SubnetRegistryDiamond.sol";
-import {SubnetIDHelper} from "../../src/lib/SubnetIDHelper.sol";
+import { SubnetActorGetterFacet } from "../../src/subnet/SubnetActorGetterFacet.sol";
+import { SubnetActorManagerFacet } from "../../src/subnet/SubnetActorManagerFacet.sol";
+import { SubnetActorDiamond } from "../../src/SubnetActorDiamond.sol";
+import { SubnetID, PermissionMode } from "../../src/structs/Subnet.sol";
+import { SubnetRegistryDiamond } from "../../src/SubnetRegistryDiamond.sol";
+import { SubnetIDHelper } from "../../src/lib/SubnetIDHelper.sol";
 
 //facets
-import {RegisterSubnetFacet} from "../../src/subnetregistry/RegisterSubnetFacet.sol";
-import {SubnetGetterFacet} from "../../src/subnetregistry/SubnetGetterFacet.sol";
-import {DiamondLoupeFacet} from "../../src/diamond/DiamondLoupeFacet.sol";
-import {DiamondCutFacet} from "../../src/diamond/DiamondCutFacet.sol";
+import { RegisterSubnetFacet } from "../../src/subnetregistry/RegisterSubnetFacet.sol";
+import { SubnetGetterFacet } from "../../src/subnetregistry/SubnetGetterFacet.sol";
+import { DiamondLoupeFacet } from "../../src/diamond/DiamondLoupeFacet.sol";
+import { DiamondCutFacet } from "../../src/diamond/DiamondCutFacet.sol";
 
 contract SubnetRegistryTest is Test {
     using SubnetIDHelper for SubnetID;
@@ -258,7 +258,7 @@ contract SubnetRegistryTest is Test {
 
     function test_Registry_Deployment_DifferentGateway() public {
         SubnetActorDiamond.ConstructorParams memory params = SubnetActorDiamond.ConstructorParams({
-            parentId: SubnetID({root: ROOTNET_CHAINID, route: new address[](0)}),
+            parentId: SubnetID({ root: ROOTNET_CHAINID, route: new address[](0) }),
             ipcGatewayAddr: address(1),
             consensus: ConsensusType.Fendermint,
             minActivationCollateral: DEFAULT_MIN_VALIDATOR_STAKE,
@@ -277,7 +277,7 @@ contract SubnetRegistryTest is Test {
     function test_Registry_LatestSubnetDeploy_Revert() public {
         vm.startPrank(DEFAULT_SENDER);
         SubnetActorDiamond.ConstructorParams memory params = SubnetActorDiamond.ConstructorParams({
-            parentId: SubnetID({root: ROOTNET_CHAINID, route: new address[](0)}),
+            parentId: SubnetID({ root: ROOTNET_CHAINID, route: new address[](0) }),
             ipcGatewayAddr: DEFAULT_IPC_GATEWAY_ADDR,
             consensus: ConsensusType.Fendermint,
             minActivationCollateral: DEFAULT_MIN_VALIDATOR_STAKE,
@@ -297,7 +297,7 @@ contract SubnetRegistryTest is Test {
     function test_Registry_GetSubnetDeployedByNonce_Revert() public {
         vm.startPrank(DEFAULT_SENDER);
         SubnetActorDiamond.ConstructorParams memory params = SubnetActorDiamond.ConstructorParams({
-            parentId: SubnetID({root: ROOTNET_CHAINID, route: new address[](0)}),
+            parentId: SubnetID({ root: ROOTNET_CHAINID, route: new address[](0) }),
             ipcGatewayAddr: DEFAULT_IPC_GATEWAY_ADDR,
             consensus: ConsensusType.Fendermint,
             minActivationCollateral: DEFAULT_MIN_VALIDATOR_STAKE,
@@ -348,7 +348,7 @@ contract SubnetRegistryTest is Test {
         }
 
         SubnetActorDiamond.ConstructorParams memory params = SubnetActorDiamond.ConstructorParams({
-            parentId: SubnetID({root: ROOTNET_CHAINID, route: path}),
+            parentId: SubnetID({ root: ROOTNET_CHAINID, route: path }),
             ipcGatewayAddr: DEFAULT_IPC_GATEWAY_ADDR,
             consensus: ConsensusType.Fendermint,
             minActivationCollateral: _minCollateral,
@@ -437,7 +437,7 @@ contract SubnetRegistryTest is Test {
     ) public {
         vm.startPrank(DEFAULT_SENDER);
         SubnetActorDiamond.ConstructorParams memory params = SubnetActorDiamond.ConstructorParams({
-            parentId: SubnetID({root: ROOTNET_CHAINID, route: new address[](0)}),
+            parentId: SubnetID({ root: ROOTNET_CHAINID, route: new address[](0) }),
             ipcGatewayAddr: _ipcGatewayAddr,
             consensus: _consensus,
             minActivationCollateral: _minActivationCollateral,

--- a/test/invariants/SubnetActorInvariants.t.sol
+++ b/test/invariants/SubnetActorInvariants.t.sol
@@ -2,23 +2,23 @@
 pragma solidity 0.8.19;
 
 import "../../src/errors/IPCErrors.sol";
-import {StdInvariant} from "forge-std/Test.sol";
-import {TestUtils} from "../helpers/TestUtils.sol";
-import {SubnetID, Subnet} from "../../src/structs/Subnet.sol";
-import {SubnetIDHelper} from "../../src/lib/SubnetIDHelper.sol";
-import {GatewayDiamond} from "../../src/GatewayDiamond.sol";
-import {GatewayGetterFacet} from "../../src/gateway/GatewayGetterFacet.sol";
-import {GatewayMessengerFacet} from "../../src/gateway/GatewayMessengerFacet.sol";
-import {GatewayManagerFacet} from "../../src/gateway/GatewayManagerFacet.sol";
-import {GatewayRouterFacet} from "../../src/gateway/GatewayRouterFacet.sol";
-import {SubnetActorHandler, ETH_SUPPLY} from "./handlers/SubnetActorHandler.sol";
-import {SubnetActorManagerFacetMock} from "../mocks/SubnetActor.sol";
-import {SubnetActorManagerFacet} from "../../src/subnet/SubnetActorManagerFacet.sol";
-import {SubnetActorGetterFacet} from "../../src/subnet/SubnetActorGetterFacet.sol";
+import { StdInvariant } from "forge-std/Test.sol";
+import { TestUtils } from "../helpers/TestUtils.sol";
+import { SubnetID, Subnet } from "../../src/structs/Subnet.sol";
+import { SubnetIDHelper } from "../../src/lib/SubnetIDHelper.sol";
+import { GatewayDiamond } from "../../src/GatewayDiamond.sol";
+import { GatewayGetterFacet } from "../../src/gateway/GatewayGetterFacet.sol";
+import { GatewayMessengerFacet } from "../../src/gateway/GatewayMessengerFacet.sol";
+import { GatewayManagerFacet } from "../../src/gateway/GatewayManagerFacet.sol";
+import { GatewayRouterFacet } from "../../src/gateway/GatewayRouterFacet.sol";
+import { SubnetActorHandler, ETH_SUPPLY } from "./handlers/SubnetActorHandler.sol";
+import { SubnetActorManagerFacetMock } from "../mocks/SubnetActor.sol";
+import { SubnetActorManagerFacet } from "../../src/subnet/SubnetActorManagerFacet.sol";
+import { SubnetActorGetterFacet } from "../../src/subnet/SubnetActorGetterFacet.sol";
 
-import {IntegrationTestBase} from "../IntegrationTestBase.sol";
+import { IntegrationTestBase } from "../IntegrationTestBase.sol";
 
-import {console} from "forge-std/console.sol";
+import { console } from "forge-std/console.sol";
 
 contract SubnetActorInvariants is StdInvariant, IntegrationTestBase {
     using SubnetIDHelper for SubnetID;
@@ -50,7 +50,7 @@ contract SubnetActorInvariants is StdInvariant, IntegrationTestBase {
         fuzzSelectors[2] = SubnetActorHandler.stake.selector;
         fuzzSelectors[3] = SubnetActorHandler.unstake.selector;
 
-        targetSelector(FuzzSelector({addr: address(subnetActorHandler), selectors: fuzzSelectors}));
+        targetSelector(FuzzSelector({ addr: address(subnetActorHandler), selectors: fuzzSelectors }));
         targetContract(address(subnetActorHandler));
     }
 

--- a/test/invariants/SubnetRegistryInvariants.t.sol
+++ b/test/invariants/SubnetRegistryInvariants.t.sol
@@ -1,27 +1,27 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {StdInvariant, Test} from "forge-std/Test.sol";
+import { StdInvariant, Test } from "forge-std/Test.sol";
 import "forge-std/console.sol";
 
-import {TestUtils} from "../helpers/TestUtils.sol";
-import {ConsensusType} from "../../src/enums/ConsensusType.sol";
-import {IDiamond} from "../../src/interfaces/IDiamond.sol";
-import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
-import {IDiamondLoupe} from "../../src/interfaces/IDiamondLoupe.sol";
-import {SubnetRegistryHandler} from "./handlers/SubnetRegistryHandler.sol";
-import {SubnetRegistryDiamond} from "../../src/SubnetRegistryDiamond.sol";
-import {SubnetIDHelper} from "../../src/lib/SubnetIDHelper.sol";
+import { TestUtils } from "../helpers/TestUtils.sol";
+import { ConsensusType } from "../../src/enums/ConsensusType.sol";
+import { IDiamond } from "../../src/interfaces/IDiamond.sol";
+import { IDiamondCut } from "../../src/interfaces/IDiamondCut.sol";
+import { IDiamondLoupe } from "../../src/interfaces/IDiamondLoupe.sol";
+import { SubnetRegistryHandler } from "./handlers/SubnetRegistryHandler.sol";
+import { SubnetRegistryDiamond } from "../../src/SubnetRegistryDiamond.sol";
+import { SubnetIDHelper } from "../../src/lib/SubnetIDHelper.sol";
 
-import {SubnetActorGetterFacet} from "../../src/subnet/SubnetActorGetterFacet.sol";
-import {SubnetActorManagerFacet} from "../../src/subnet/SubnetActorManagerFacet.sol";
-import {SubnetActorDiamond} from "../../src/SubnetActorDiamond.sol";
-import {SubnetID} from "../../src/structs/Subnet.sol";
+import { SubnetActorGetterFacet } from "../../src/subnet/SubnetActorGetterFacet.sol";
+import { SubnetActorManagerFacet } from "../../src/subnet/SubnetActorManagerFacet.sol";
+import { SubnetActorDiamond } from "../../src/SubnetActorDiamond.sol";
+import { SubnetID } from "../../src/structs/Subnet.sol";
 
-import {RegisterSubnetFacet} from "../../src/subnetregistry/RegisterSubnetFacet.sol";
-import {SubnetGetterFacet} from "../../src/subnetregistry/SubnetGetterFacet.sol";
-import {DiamondLoupeFacet} from "../../src/diamond/DiamondLoupeFacet.sol";
-import {DiamondCutFacet} from "../../src/diamond/DiamondCutFacet.sol";
+import { RegisterSubnetFacet } from "../../src/subnetregistry/RegisterSubnetFacet.sol";
+import { SubnetGetterFacet } from "../../src/subnetregistry/SubnetGetterFacet.sol";
+import { DiamondLoupeFacet } from "../../src/diamond/DiamondLoupeFacet.sol";
+import { DiamondCutFacet } from "../../src/diamond/DiamondCutFacet.sol";
 
 contract SubnetRegistryInvariants is StdInvariant, Test {
     using SubnetIDHelper for SubnetID;
@@ -128,7 +128,7 @@ contract SubnetRegistryInvariants is StdInvariant, Test {
         bytes4[] memory fuzzSelectors = new bytes4[](1);
         fuzzSelectors[0] = SubnetRegistryHandler.deploySubnetActorFromRegistry.selector;
 
-        targetSelector(FuzzSelector({addr: address(registryHandler), selectors: fuzzSelectors}));
+        targetSelector(FuzzSelector({ addr: address(registryHandler), selectors: fuzzSelectors }));
         targetContract(address(registryHandler));
     }
 

--- a/test/invariants/handlers/SubnetActorHandler.sol
+++ b/test/invariants/handlers/SubnetActorHandler.sol
@@ -4,20 +4,20 @@ pragma solidity 0.8.19;
 import "forge-std/console.sol";
 import "forge-std/StdUtils.sol";
 import "forge-std/StdCheats.sol";
-import {CommonBase} from "forge-std/Base.sol";
+import { CommonBase } from "forge-std/Base.sol";
 
-import {SubnetActorDiamond} from "../../../src/SubnetActorDiamond.sol";
-import {SubnetActorManagerFacet} from "../../../src/subnet/SubnetActorManagerFacet.sol";
-import {SubnetActorGetterFacet} from "../../../src/subnet/SubnetActorGetterFacet.sol";
-import {SubnetActorManagerFacetMock} from "../../mocks/SubnetActor.sol";
+import { SubnetActorDiamond } from "../../../src/SubnetActorDiamond.sol";
+import { SubnetActorManagerFacet } from "../../../src/subnet/SubnetActorManagerFacet.sol";
+import { SubnetActorGetterFacet } from "../../../src/subnet/SubnetActorGetterFacet.sol";
+import { SubnetActorManagerFacetMock } from "../../mocks/SubnetActor.sol";
 
-import {ConsensusType} from "../../../src/enums/ConsensusType.sol";
-import {SubnetID} from "../../../src/structs/Subnet.sol";
-import {SubnetIDHelper} from "../../../src/lib/SubnetIDHelper.sol";
+import { ConsensusType } from "../../../src/enums/ConsensusType.sol";
+import { SubnetID } from "../../../src/structs/Subnet.sol";
+import { SubnetIDHelper } from "../../../src/lib/SubnetIDHelper.sol";
 
-import {TestUtils} from "../../helpers/TestUtils.sol";
+import { TestUtils } from "../../helpers/TestUtils.sol";
 
-import {EnumerableSet} from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
+import { EnumerableSet } from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
 
 uint256 constant ETH_SUPPLY = 129_590_000 ether;
 
@@ -89,7 +89,7 @@ contract SubnetActorHandler is CommonBase, StdCheats, StdUtils {
 
         _pay(validator, amount);
         vm.prank(validator);
-        managerFacet.join{value: amount}(publicKey);
+        managerFacet.join{ value: amount }(publicKey);
         managerFacet.confirmNextChange();
 
         ghost_stakedSum += amount;
@@ -103,7 +103,7 @@ contract SubnetActorHandler is CommonBase, StdCheats, StdUtils {
         _pay(validator, amount);
 
         vm.prank(validator);
-        managerFacet.stake{value: amount}();
+        managerFacet.stake{ value: amount }();
         managerFacet.confirmNextChange();
 
         ghost_stakedSum += amount;
@@ -142,7 +142,7 @@ contract SubnetActorHandler is CommonBase, StdCheats, StdUtils {
     }
 
     function _pay(address to, uint256 amount) internal {
-        (bool s, ) = to.call{value: amount}("");
+        (bool s, ) = to.call{ value: amount }("");
         require(s, "pay() failed");
     }
 

--- a/test/invariants/handlers/SubnetRegistryHandler.sol
+++ b/test/invariants/handlers/SubnetRegistryHandler.sol
@@ -4,20 +4,20 @@ pragma solidity 0.8.19;
 import "forge-std/console.sol";
 import "forge-std/StdUtils.sol";
 import "forge-std/StdCheats.sol";
-import {CommonBase} from "forge-std/Base.sol";
+import { CommonBase } from "forge-std/Base.sol";
 
-import {RegisterSubnetFacet} from "../../../src/subnetregistry/RegisterSubnetFacet.sol";
-import {SubnetGetterFacet} from "../../../src/subnetregistry/SubnetGetterFacet.sol";
-import {SubnetActorDiamond} from "../../../src/SubnetActorDiamond.sol";
-import {SubnetRegistryDiamond} from "../../../src/SubnetRegistryDiamond.sol";
+import { RegisterSubnetFacet } from "../../../src/subnetregistry/RegisterSubnetFacet.sol";
+import { SubnetGetterFacet } from "../../../src/subnetregistry/SubnetGetterFacet.sol";
+import { SubnetActorDiamond } from "../../../src/SubnetActorDiamond.sol";
+import { SubnetRegistryDiamond } from "../../../src/SubnetRegistryDiamond.sol";
 
-import {ConsensusType} from "../../../src/enums/ConsensusType.sol";
-import {SubnetID, PermissionMode} from "../../../src/structs/Subnet.sol";
-import {SubnetIDHelper} from "../../../src/lib/SubnetIDHelper.sol";
+import { ConsensusType } from "../../../src/enums/ConsensusType.sol";
+import { SubnetID, PermissionMode } from "../../../src/structs/Subnet.sol";
+import { SubnetIDHelper } from "../../../src/lib/SubnetIDHelper.sol";
 
-import {TestUtils} from "../../helpers/TestUtils.sol";
+import { TestUtils } from "../../helpers/TestUtils.sol";
 
-import {EnumerableSet} from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
+import { EnumerableSet } from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
 
 contract SubnetRegistryHandler is CommonBase, StdCheats, StdUtils {
     using EnumerableSet for EnumerableSet.AddressSet;
@@ -116,7 +116,7 @@ contract SubnetRegistryHandler is CommonBase, StdCheats, StdUtils {
         }
 
         SubnetActorDiamond.ConstructorParams memory params = SubnetActorDiamond.ConstructorParams({
-            parentId: SubnetID({root: ROOTNET_CHAINID, route: path}),
+            parentId: SubnetID({ root: ROOTNET_CHAINID, route: path }),
             ipcGatewayAddr: registerGetterFacet.getGateway(),
             consensus: ConsensusType.Fendermint,
             minActivationCollateral: _minCollateral,

--- a/test/mocks/SubnetActor.sol
+++ b/test/mocks/SubnetActor.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {SubnetActorManagerFacet} from "../../src/subnet/SubnetActorManagerFacet.sol";
-import {LibStaking} from "../../src/lib/LibStaking.sol";
+import { SubnetActorManagerFacet } from "../../src/subnet/SubnetActorManagerFacet.sol";
+import { LibStaking } from "../../src/lib/LibStaking.sol";
 
 contract SubnetActorManagerFacetMock is SubnetActorManagerFacet {
     function confirmChange(uint64 _configurationNumber) external {

--- a/test/unit/CrossMsgHelper.t.sol
+++ b/test/unit/CrossMsgHelper.t.sol
@@ -7,7 +7,7 @@ import "forge-std/console.sol";
 import "../../src/lib/CrossMsgHelper.sol";
 import "../../src/lib/SubnetIDHelper.sol";
 import "../../src/lib/FvmAddressHelper.sol";
-import {FvmAddress} from "../../src/structs/FvmAddress.sol";
+import { FvmAddress } from "../../src/structs/FvmAddress.sol";
 
 import "openzeppelin-contracts/utils/Address.sol";
 

--- a/test/unit/FvmAddressHelper.t.sol
+++ b/test/unit/FvmAddressHelper.t.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.19;
 
 import "forge-std/Test.sol";
 
-import {FvmAddress} from "../../src/structs/FvmAddress.sol";
-import {FvmAddressHelper} from "../helpers/FvmAddressHelper.sol";
+import { FvmAddress } from "../../src/structs/FvmAddress.sol";
+import { FvmAddressHelper } from "../helpers/FvmAddressHelper.sol";
 
 contract FvmAddressHelperTest is Test {
     using FvmAddressHelper for FvmAddress;

--- a/test/unit/LibMaxPQ.t.sol
+++ b/test/unit/LibMaxPQ.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {Test} from "forge-std/Test.sol";
-import {console} from "forge-std/console.sol";
+import { Test } from "forge-std/Test.sol";
+import { console } from "forge-std/console.sol";
 
-import {MaxPQ, LibMaxPQ} from "../../src/lib/priority/LibMaxPQ.sol";
-import {LibValidatorSet} from "../../src/lib/LibStaking.sol";
-import {ValidatorSet} from "../../src/structs/Subnet.sol";
+import { MaxPQ, LibMaxPQ } from "../../src/lib/priority/LibMaxPQ.sol";
+import { LibValidatorSet } from "../../src/lib/LibStaking.sol";
+import { ValidatorSet } from "../../src/structs/Subnet.sol";
 
 contract LibMaxPQTest is Test {
     using LibValidatorSet for ValidatorSet;

--- a/test/unit/LibMinPQ.t.sol
+++ b/test/unit/LibMinPQ.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {Test} from "forge-std/Test.sol";
-import {console} from "forge-std/console.sol";
+import { Test } from "forge-std/Test.sol";
+import { console } from "forge-std/console.sol";
 
-import {MinPQ, LibMinPQ} from "../../src/lib/priority/LibMinPQ.sol";
-import {LibValidatorSet} from "../../src/lib/LibStaking.sol";
-import {ValidatorSet} from "../../src/structs/Subnet.sol";
+import { MinPQ, LibMinPQ } from "../../src/lib/priority/LibMinPQ.sol";
+import { LibValidatorSet } from "../../src/lib/LibStaking.sol";
+import { ValidatorSet } from "../../src/structs/Subnet.sol";
 
 contract LibMinPQTest is Test {
     using LibValidatorSet for ValidatorSet;

--- a/test/unit/LibMultisignatureChecker.t.sol
+++ b/test/unit/LibMultisignatureChecker.t.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.19;
 
 import "forge-std/Test.sol";
-import {TestUtils} from "../helpers/TestUtils.sol";
-import {MultisignatureChecker} from "../../src/lib/LibMultisignatureChecker.sol";
-import {ECDSA} from "openzeppelin-contracts/utils/cryptography/ECDSA.sol";
+import { TestUtils } from "../helpers/TestUtils.sol";
+import { MultisignatureChecker } from "../../src/lib/LibMultisignatureChecker.sol";
+import { ECDSA } from "openzeppelin-contracts/utils/cryptography/ECDSA.sol";
 import "elliptic-curve-solidity/contracts/EllipticCurve.sol";
 
 contract MultisignatureCheckerTest is StdInvariant, Test {

--- a/test/unit/LibValidatorSet.t.sol
+++ b/test/unit/LibValidatorSet.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {Test} from "forge-std/Test.sol";
-import {console} from "forge-std/console.sol";
+import { Test } from "forge-std/Test.sol";
+import { console } from "forge-std/console.sol";
 
-import {MaxPQ, LibMaxPQ} from "../../src/lib/priority/LibMaxPQ.sol";
-import {MinPQ, LibMinPQ} from "../../src/lib/priority/LibMinPQ.sol";
-import {LibValidatorSet} from "../../src/lib/LibStaking.sol";
-import {ValidatorSet} from "../../src/structs/Subnet.sol";
+import { MaxPQ, LibMaxPQ } from "../../src/lib/priority/LibMaxPQ.sol";
+import { MinPQ, LibMinPQ } from "../../src/lib/priority/LibMinPQ.sol";
+import { LibValidatorSet } from "../../src/lib/LibStaking.sol";
+import { ValidatorSet } from "../../src/structs/Subnet.sol";
 
 contract LibValidatorSetTest is Test {
     using LibValidatorSet for ValidatorSet;

--- a/test/unit/MerkleTree.t.sol
+++ b/test/unit/MerkleTree.t.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.19;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
-import {MerkleTreeHelper} from "../helpers/MerkleTreeHelper.sol";
-import {MerkleProof} from "openzeppelin-contracts/utils/cryptography/MerkleProof.sol";
-import {Merkle} from "murky/Merkle.sol";
+import { MerkleTreeHelper } from "../helpers/MerkleTreeHelper.sol";
+import { MerkleProof } from "openzeppelin-contracts/utils/cryptography/MerkleProof.sol";
+import { Merkle } from "murky/Merkle.sol";
 
 contract MerkleTree is Test {
     Merkle merkleTree;
@@ -31,11 +31,11 @@ contract MerkleTree is Test {
         bytes32 leaf;
 
         leaf = keccak256(bytes.concat(keccak256(abi.encode(addrs[0], weights[0]))));
-        valid = MerkleProof.verify({proof: proofs[0], root: root, leaf: leaf});
+        valid = MerkleProof.verify({ proof: proofs[0], root: root, leaf: leaf });
         require(valid, "the valid leaf in the tree");
 
         leaf = keccak256(bytes.concat(keccak256(abi.encode(addrs[0], weights[1]))));
-        valid = MerkleProof.verify({proof: proofs[0], root: root, leaf: leaf});
+        valid = MerkleProof.verify({ proof: proofs[0], root: root, leaf: leaf });
         require(!valid, "invalid leaf is not in the tree");
     }
 }

--- a/test/unit/StorableMsgHelper.t.sol
+++ b/test/unit/StorableMsgHelper.t.sol
@@ -3,10 +3,10 @@ pragma solidity 0.8.19;
 
 import "forge-std/Test.sol";
 
-import {METHOD_SEND, EMPTY_BYTES} from "../../src/constants/Constants.sol";
+import { METHOD_SEND, EMPTY_BYTES } from "../../src/constants/Constants.sol";
 import "../../src/lib/StorableMsgHelper.sol";
 import "../../src/lib/FvmAddressHelper.sol";
-import {IPCAddress} from "../../src/structs/Subnet.sol";
+import { IPCAddress } from "../../src/structs/Subnet.sol";
 
 contract StorableMsgHelperTest is Test {
     using StorableMsgHelper for StorableMsg;
@@ -33,8 +33,11 @@ contract StorableMsgHelperTest is Test {
 
     function test_ToHash_Works_NonEmptyMessage() public pure {
         StorableMsg memory storableMsg = StorableMsg({
-            from: IPCAddress({subnetId: SubnetID(0, new address[](0)), rawAddress: FvmAddressHelper.from(address(0))}),
-            to: IPCAddress({subnetId: SubnetID(0, new address[](0)), rawAddress: FvmAddressHelper.from(address(0))}),
+            from: IPCAddress({
+                subnetId: SubnetID(0, new address[](0)),
+                rawAddress: FvmAddressHelper.from(address(0))
+            }),
+            to: IPCAddress({ subnetId: SubnetID(0, new address[](0)), rawAddress: FvmAddressHelper.from(address(0)) }),
             value: 1,
             nonce: 1,
             method: METHOD_SEND,
@@ -56,11 +59,11 @@ contract StorableMsgHelperTest is Test {
 
         StorableMsg memory storableMsg = StorableMsg({
             from: IPCAddress({
-                subnetId: SubnetID({root: ROOTNET_CHAINID, route: from}),
+                subnetId: SubnetID({ root: ROOTNET_CHAINID, route: from }),
                 rawAddress: FvmAddressHelper.from(address(3))
             }),
             to: IPCAddress({
-                subnetId: SubnetID({root: ROOTNET_CHAINID, route: to}),
+                subnetId: SubnetID({ root: ROOTNET_CHAINID, route: to }),
                 rawAddress: FvmAddressHelper.from(address(3))
             }),
             value: 1,
@@ -71,14 +74,14 @@ contract StorableMsgHelperTest is Test {
         });
 
         require(
-            storableMsg.applyType(SubnetID({root: ROOTNET_CHAINID, route: from})) == IPCMsgType.TopDown,
+            storableMsg.applyType(SubnetID({ root: ROOTNET_CHAINID, route: from })) == IPCMsgType.TopDown,
             "Should be TopDown"
         );
 
         address[] memory current = new address[](2);
         current[0] = address(1);
         current[1] = address(2);
-        SubnetID memory subnetId = SubnetID({root: ROOTNET_CHAINID, route: current});
+        SubnetID memory subnetId = SubnetID({ root: ROOTNET_CHAINID, route: current });
 
         require(storableMsg.applyType(subnetId) == IPCMsgType.TopDown, "Should be TopDown");
 
@@ -88,7 +91,7 @@ contract StorableMsgHelperTest is Test {
         current2[2] = address(3);
 
         require(
-            storableMsg.applyType(SubnetID({root: ROOTNET_CHAINID, route: current2})) == IPCMsgType.TopDown,
+            storableMsg.applyType(SubnetID({ root: ROOTNET_CHAINID, route: current2 })) == IPCMsgType.TopDown,
             "Should be TopDown"
         );
     }
@@ -102,11 +105,11 @@ contract StorableMsgHelperTest is Test {
 
         StorableMsg memory storableMsg = StorableMsg({
             from: IPCAddress({
-                subnetId: SubnetID({root: ROOTNET_CHAINID, route: from}),
+                subnetId: SubnetID({ root: ROOTNET_CHAINID, route: from }),
                 rawAddress: FvmAddressHelper.from(address(3))
             }),
             to: IPCAddress({
-                subnetId: SubnetID({root: ROOTNET_CHAINID, route: to}),
+                subnetId: SubnetID({ root: ROOTNET_CHAINID, route: to }),
                 rawAddress: FvmAddressHelper.from(address(3))
             }),
             value: 1,
@@ -117,11 +120,11 @@ contract StorableMsgHelperTest is Test {
         });
 
         require(
-            storableMsg.applyType(SubnetID({root: ROOTNET_CHAINID, route: from})) == IPCMsgType.BottomUp,
+            storableMsg.applyType(SubnetID({ root: ROOTNET_CHAINID, route: from })) == IPCMsgType.BottomUp,
             "Should be BottomUp"
         );
         require(
-            storableMsg.applyType(SubnetID({root: ROOTNET_CHAINID, route: to})) == IPCMsgType.BottomUp,
+            storableMsg.applyType(SubnetID({ root: ROOTNET_CHAINID, route: to })) == IPCMsgType.BottomUp,
             "Should be BottomUp"
         );
     }

--- a/test/unit/SubnetIDHelper.t.sol
+++ b/test/unit/SubnetIDHelper.t.sol
@@ -250,12 +250,12 @@ contract SubnetIDHelperTest is Test {
     function test_CreateSubnetId_Works() public view {
         address[] memory route = new address[](0);
 
-        SubnetID memory subnetId = SubnetID({root: ROOTNET_CHAINID, route: route}).createSubnetId(SUBNET_ONE_ADDRESS);
+        SubnetID memory subnetId = SubnetID({ root: ROOTNET_CHAINID, route: route }).createSubnetId(SUBNET_ONE_ADDRESS);
 
         address[] memory expectedRoute = new address[](1);
         expectedRoute[0] = SUBNET_ONE_ADDRESS;
 
-        require(subnetId.toHash() == SubnetID({root: ROOTNET_CHAINID, route: expectedRoute}).toHash());
+        require(subnetId.toHash() == SubnetID({ root: ROOTNET_CHAINID, route: expectedRoute }).toHash());
     }
 
     function test_GetActor_Works_EmptySubnet() public view {
@@ -266,7 +266,7 @@ contract SubnetIDHelperTest is Test {
     function test_GetActor_Works_RootSubnet() public pure {
         address[] memory route = new address[](0);
 
-        address emptyActor = SubnetID({root: ROOTNET_CHAINID, route: route}).getActor();
+        address emptyActor = SubnetID({ root: ROOTNET_CHAINID, route: route }).getActor();
         require(emptyActor == address(0));
     }
 
@@ -274,7 +274,7 @@ contract SubnetIDHelperTest is Test {
         address[] memory route = new address[](1);
         route[0] = SUBNET_ONE_ADDRESS;
 
-        address actor = SubnetID({root: ROOTNET_CHAINID, route: route}).getActor();
+        address actor = SubnetID({ root: ROOTNET_CHAINID, route: route }).getActor();
         require(actor == SUBNET_ONE_ADDRESS);
     }
 
@@ -286,20 +286,20 @@ contract SubnetIDHelperTest is Test {
         address[] memory route = new address[](1);
         route[0] = SUBNET_ONE_ADDRESS;
 
-        require(SubnetID({root: ROOTNET_CHAINID, route: route}).isRoot() == false);
+        require(SubnetID({ root: ROOTNET_CHAINID, route: route }).isRoot() == false);
     }
 
     function test_IsRoot_Works_RootSubnet() public pure {
         address[] memory route = new address[](0);
 
-        require(SubnetID({root: ROOTNET_CHAINID, route: route}).isRoot() == true);
+        require(SubnetID({ root: ROOTNET_CHAINID, route: route }).isRoot() == true);
     }
 
     function test_Equals_Works_Empty() public view {
         require(EMPTY_SUBNET_ID.equals(EMPTY_SUBNET_ID) == true);
-        require(EMPTY_SUBNET_ID.equals(SubnetID({root: 0, route: new address[](0)})) == true);
+        require(EMPTY_SUBNET_ID.equals(SubnetID({ root: 0, route: new address[](0) })) == true);
         address[] memory route = new address[](0);
-        require(EMPTY_SUBNET_ID.equals(SubnetID({root: 0, route: route})) == true);
+        require(EMPTY_SUBNET_ID.equals(SubnetID({ root: 0, route: route })) == true);
     }
 
     function test_Equals_Works_NonEmpty() public view {
@@ -310,17 +310,19 @@ contract SubnetIDHelperTest is Test {
         route2[0] = SUBNET_TWO_ADDRESS;
 
         require(
-            SubnetID({root: ROOTNET_CHAINID, route: route}).equals(SubnetID({root: ROOTNET_CHAINID, route: route})) ==
-                true
+            SubnetID({ root: ROOTNET_CHAINID, route: route }).equals(
+                SubnetID({ root: ROOTNET_CHAINID, route: route })
+            ) == true
         );
         require(
-            SubnetID({root: ROOTNET_CHAINID, route: route}).equals(SubnetID({root: ROOTNET_CHAINID, route: route2})) ==
-                false
+            SubnetID({ root: ROOTNET_CHAINID, route: route }).equals(
+                SubnetID({ root: ROOTNET_CHAINID, route: route2 })
+            ) == false
         );
     }
 
     function test_Equals_Works_RootNotSame() public view {
-        require(EMPTY_SUBNET_ID.equals(SubnetID({root: ROOTNET_CHAINID, route: new address[](0)})) == false);
+        require(EMPTY_SUBNET_ID.equals(SubnetID({ root: ROOTNET_CHAINID, route: new address[](0) })) == false);
     }
 
     function test_IsEmpty_Works_Empty() public view {


### PR DESCRIPTION
- Use https://github.com/trivago/prettier-plugin-sort-imports to sort imports.
- Enable brace spacing.
- Add new entries prettierignore to ignore generated dirs.
- Apply formatting to all files.

NOTE: Wait until all WIP PRs have landed to refmt and merge. For now, let's use this PR to discuss the choices.