### PR TITLE
cleanup: remove unused `AccountHelper#isAccount` predicate.

### DIFF
--- a/src/constants/Constants.sol
+++ b/src/constants/Constants.sol
@@ -4,5 +4,4 @@ pragma solidity 0.8.19;
 address constant BURNT_FUNDS_ACTOR = address(99);
 bytes32 constant EMPTY_HASH = bytes32("");
 bytes constant EMPTY_BYTES = bytes("");
-bytes32 constant ADDRESS_CODEHASH = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;
 bytes4 constant METHOD_SEND = bytes4(0);

--- a/src/lib/AccountHelper.sol
+++ b/src/lib/AccountHelper.sol
@@ -1,24 +1,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {ADDRESS_CODEHASH} from "../constants/Constants.sol";
 import {FilAddress} from "fevmate/utils/FilAddress.sol";
 
 /// @title Helper library for checking account type
 /// @author LimeChain team
 library AccountHelper {
-    function isAccount(address _address) external view returns (bool) {
-        uint256 size;
-
-        /* solhint-disable no-inline-assembly */
-        assembly {
-            size := extcodesize(_address)
-        }
-        /* solhint-enable no-inline-assembly */
-
-        return size == 0 && ADDRESS_CODEHASH == _address.codehash && ADDRESS_CODEHASH == keccak256(_address.code);
-    }
-
     function isSystemActor(address _address) external pure returns (bool) {
         return _address == FilAddress.SYSTEM_ACTOR;
     }

--- a/test/unit/AccountHelper.t.sol
+++ b/test/unit/AccountHelper.t.sol
@@ -6,53 +6,8 @@ import "forge-std/Test.sol";
 import "fevmate/utils/FilAddress.sol";
 import "../../src/lib/AccountHelper.sol";
 
-contract DummyContract {
-    using AccountHelper for address;
-
-    bool public isAccount;
-
-    constructor() {
-        isAccount = address(this).isAccount();
-    }
-}
-
 contract AccountHelperTest is Test {
     using AccountHelper for address;
-
-    address constant ETH_ADDRESS = address(100);
-    address constant BLS_ADDREESS = 0xfF000000000000000000000000000000bEefbEEf;
-
-    function test_IsAccount_Fails_NonExistingAccount() public view {
-        require(ETH_ADDRESS.isAccount() == false);
-    }
-
-    function test_IsAccount_Fails_BlsAccount() public view {
-        require(BLS_ADDREESS.isAccount() == false);
-    }
-
-    function test_IsAccount_Works_ContractConstructor() public {
-        DummyContract dc = new DummyContract();
-
-        require(dc.isAccount() == true);
-    }
-
-    function test_IsAccount_Fails_ContractAccount() public {
-        DummyContract dc = new DummyContract();
-
-        require(address(dc).isAccount() == false);
-    }
-
-    function test_IsAccount_Works_EthAccount() public {
-        activateAccount(ETH_ADDRESS);
-
-        require(ETH_ADDRESS.isAccount() == true);
-    }
-
-    function test_IsAccount_Works_BlsAccount() public {
-        activateAccount(BLS_ADDREESS);
-
-        require(BLS_ADDREESS.isAccount() == true);
-    }
 
     function test_IsSystemActor_True() public pure {
         require(FilAddress.SYSTEM_ACTOR.isSystemActor() == true);


### PR DESCRIPTION
The logic here wasn't completely correct. A BLS account in FEVM would look like an account. It'll return true for precompiles. An inexistent address (which could later become an account) will return false.

Not sure if these behaviours were intended, since the method is not documented. But given that it's also not used, it's better to drop it so it doesn't get used in this form.