### PR TITLE
Update test.yml - coverage test is failing incorrectly sometimes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,8 @@ jobs:
         with:
           cache: false
 
-      - name: Run coverage check
-        run: make coverage
+      - name: Run coverage check - flaky so we run twice to catch false negatives
+        run: make coverage || make coverage
 
       - name: Run tests
         run: forge test -vvv --ffi


### PR DESCRIPTION
I started noticing yesterday that our code coverage test is flaky and failing incorrectly some of the time.

This patch is very duct tape, but it runs it once and if and only if it fails it runs it again. If we are failing this test 10% of the time, running it twice could mean that it will only fail 100%-90%*90%=1% of the time.

Assuming this flakiness is independently happening due to a random bug in forge. 

We should also understand why this is failing on a deeper level and fix it, and this fix may not make a change if somehow it is consistently failing, but the effort is really low and is a good chance at helping with almost no downside. 

Currently we are merging into dev with this test failing, so our current situation deserves some sort of short term patch

here's an example commit that it fails on. I think I hit this yesterday also but can't find my other commit from it. [If you look at the check on this commit it fails](https://github.com/consensus-shipyard/ipc-solidity-actors/commit/aa83f28030e36cf21a7cecce7a6a9f44bd870c63) but when i run the coverage check on that commit hash again it passes
```
Overall coverage rate:
  lines......: 52.5% (1021 of 1946 lines)
  functions..: 59.2% (216 of 365 functions)
  branches...: 48.1% (276 of 574 branches)
./tools/check_coverage.sh
coverage test passed
```