### PR TITLE
Bootstrap federated validation

### DIFF
--- a/.storage-layouts/GatewayActorModifiers.json
+++ b/.storage-layouts/GatewayActorModifiers.json
@@ -1,12 +1,12 @@
 {
     "storage": [
         {
-            "astId": 10621,
+            "astId": 10635,
             "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
             "label": "s",
             "offset": 0,
             "slot": "0",
-            "type": "t_struct(GatewayActorStorage)10607_storage"
+            "type": "t_struct(GatewayActorStorage)10621_storage"
         }
     ],
     "types": {
@@ -27,14 +27,14 @@
             "label": "bytes32[]",
             "numberOfBytes": "32"
         },
-        "t_array(t_struct(CrossMsg)16665_storage)dyn_storage": {
-            "base": "t_struct(CrossMsg)16665_storage",
+        "t_array(t_struct(CrossMsg)16704_storage)dyn_storage": {
+            "base": "t_struct(CrossMsg)16704_storage",
             "encoding": "dynamic_array",
             "label": "struct CrossMsg[]",
             "numberOfBytes": "32"
         },
-        "t_array(t_struct(Validator)16907_storage)dyn_storage": {
-            "base": "t_struct(Validator)16907_storage",
+        "t_array(t_struct(Validator)16946_storage)dyn_storage": {
+            "base": "t_struct(Validator)16946_storage",
             "encoding": "dynamic_array",
             "label": "struct Validator[]",
             "numberOfBytes": "32"
@@ -59,22 +59,22 @@
             "label": "bytes",
             "numberOfBytes": "32"
         },
-        "t_enum(PermissionMode)16861": {
+        "t_enum(PermissionMode)16900": {
             "encoding": "inplace",
             "label": "enum PermissionMode",
             "numberOfBytes": "1"
         },
-        "t_enum(QuorumObjKind)16703": {
+        "t_enum(QuorumObjKind)16742": {
             "encoding": "inplace",
             "label": "enum QuorumObjKind",
             "numberOfBytes": "1"
         },
-        "t_enum(StakingOperation)16792": {
+        "t_enum(StakingOperation)16831": {
             "encoding": "inplace",
             "label": "enum StakingOperation",
             "numberOfBytes": "1"
         },
-        "t_enum(Status)5165": {
+        "t_enum(Status)5184": {
             "encoding": "inplace",
             "label": "enum Status",
             "numberOfBytes": "1"
@@ -86,12 +86,12 @@
             "numberOfBytes": "32",
             "value": "t_bytes_storage"
         },
-        "t_mapping(t_address,t_struct(ValidatorInfo)16857_storage)": {
+        "t_mapping(t_address,t_struct(ValidatorInfo)16896_storage)": {
             "encoding": "mapping",
             "key": "t_address",
             "label": "mapping(address => struct ValidatorInfo)",
             "numberOfBytes": "32",
-            "value": "t_struct(ValidatorInfo)16857_storage"
+            "value": "t_struct(ValidatorInfo)16896_storage"
         },
         "t_mapping(t_address,t_uint16)": {
             "encoding": "mapping",
@@ -100,19 +100,19 @@
             "numberOfBytes": "32",
             "value": "t_uint16"
         },
-        "t_mapping(t_bytes32,t_struct(CrossMsg)16665_storage)": {
+        "t_mapping(t_bytes32,t_struct(CrossMsg)16704_storage)": {
             "encoding": "mapping",
             "key": "t_bytes32",
             "label": "mapping(bytes32 => struct CrossMsg)",
             "numberOfBytes": "32",
-            "value": "t_struct(CrossMsg)16665_storage"
+            "value": "t_struct(CrossMsg)16704_storage"
         },
-        "t_mapping(t_bytes32,t_struct(Subnet)16787_storage)": {
+        "t_mapping(t_bytes32,t_struct(Subnet)16826_storage)": {
             "encoding": "mapping",
             "key": "t_bytes32",
             "label": "mapping(bytes32 => struct Subnet)",
             "numberOfBytes": "32",
-            "value": "t_struct(Subnet)16787_storage"
+            "value": "t_struct(Subnet)16826_storage"
         },
         "t_mapping(t_bytes32,t_uint256)": {
             "encoding": "mapping",
@@ -142,40 +142,40 @@
             "numberOfBytes": "32",
             "value": "t_struct(AddressSet)3351_storage"
         },
-        "t_mapping(t_uint256,t_struct(BottomUpCheckpoint)16623_storage)": {
+        "t_mapping(t_uint256,t_struct(BottomUpCheckpoint)16662_storage)": {
             "encoding": "mapping",
             "key": "t_uint256",
             "label": "mapping(uint256 => struct BottomUpCheckpoint)",
             "numberOfBytes": "32",
-            "value": "t_struct(BottomUpCheckpoint)16623_storage"
+            "value": "t_struct(BottomUpCheckpoint)16662_storage"
         },
-        "t_mapping(t_uint256,t_struct(BottomUpMsgBatch)16636_storage)": {
+        "t_mapping(t_uint256,t_struct(BottomUpMsgBatch)16675_storage)": {
             "encoding": "mapping",
             "key": "t_uint256",
             "label": "mapping(uint256 => struct BottomUpMsgBatch)",
             "numberOfBytes": "32",
-            "value": "t_struct(BottomUpMsgBatch)16636_storage"
+            "value": "t_struct(BottomUpMsgBatch)16675_storage"
         },
-        "t_mapping(t_uint256,t_struct(ParentFinality)16609_storage)": {
+        "t_mapping(t_uint256,t_struct(ParentFinality)16648_storage)": {
             "encoding": "mapping",
             "key": "t_uint256",
             "label": "mapping(uint256 => struct ParentFinality)",
             "numberOfBytes": "32",
-            "value": "t_struct(ParentFinality)16609_storage"
+            "value": "t_struct(ParentFinality)16648_storage"
         },
-        "t_mapping(t_uint256,t_struct(QuorumInfo)16719_storage)": {
+        "t_mapping(t_uint256,t_struct(QuorumInfo)16758_storage)": {
             "encoding": "mapping",
             "key": "t_uint256",
             "label": "mapping(uint256 => struct QuorumInfo)",
             "numberOfBytes": "32",
-            "value": "t_struct(QuorumInfo)16719_storage"
+            "value": "t_struct(QuorumInfo)16758_storage"
         },
-        "t_mapping(t_uint64,t_struct(StakingChange)16800_storage)": {
+        "t_mapping(t_uint64,t_struct(StakingChange)16839_storage)": {
             "encoding": "mapping",
             "key": "t_uint64",
             "label": "mapping(uint64 => struct StakingChange)",
             "numberOfBytes": "32",
-            "value": "t_struct(StakingChange)16800_storage"
+            "value": "t_struct(StakingChange)16839_storage"
         },
         "t_struct(AddressSet)3351_storage": {
             "encoding": "inplace",
@@ -192,20 +192,20 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(BottomUpCheckpoint)16623_storage": {
+        "t_struct(BottomUpCheckpoint)16662_storage": {
             "encoding": "inplace",
             "label": "struct BottomUpCheckpoint",
             "members": [
                 {
-                    "astId": 16613,
+                    "astId": 16652,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "subnetID",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(SubnetID)16770_storage"
+                    "type": "t_struct(SubnetID)16809_storage"
                 },
                 {
-                    "astId": 16616,
+                    "astId": 16655,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "blockHeight",
                     "offset": 0,
@@ -213,7 +213,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16619,
+                    "astId": 16658,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "blockHash",
                     "offset": 0,
@@ -221,7 +221,7 @@
                     "type": "t_bytes32"
                 },
                 {
-                    "astId": 16622,
+                    "astId": 16661,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "nextConfigurationNumber",
                     "offset": 0,
@@ -231,20 +231,20 @@
             ],
             "numberOfBytes": "160"
         },
-        "t_struct(BottomUpMsgBatch)16636_storage": {
+        "t_struct(BottomUpMsgBatch)16675_storage": {
             "encoding": "inplace",
             "label": "struct BottomUpMsgBatch",
             "members": [
                 {
-                    "astId": 16627,
+                    "astId": 16666,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "subnetID",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(SubnetID)16770_storage"
+                    "type": "t_struct(SubnetID)16809_storage"
                 },
                 {
-                    "astId": 16630,
+                    "astId": 16669,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "blockHeight",
                     "offset": 0,
@@ -252,30 +252,30 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16635,
+                    "astId": 16674,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "msgs",
                     "offset": 0,
                     "slot": "3",
-                    "type": "t_array(t_struct(CrossMsg)16665_storage)dyn_storage"
+                    "type": "t_array(t_struct(CrossMsg)16704_storage)dyn_storage"
                 }
             ],
             "numberOfBytes": "128"
         },
-        "t_struct(CrossMsg)16665_storage": {
+        "t_struct(CrossMsg)16704_storage": {
             "encoding": "inplace",
             "label": "struct CrossMsg",
             "members": [
                 {
-                    "astId": 16662,
+                    "astId": 16701,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "message",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(StorableMsg)16682_storage"
+                    "type": "t_struct(StorableMsg)16721_storage"
                 },
                 {
-                    "astId": 16664,
+                    "astId": 16703,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "wrapped",
                     "offset": 0,
@@ -285,12 +285,12 @@
             ],
             "numberOfBytes": "416"
         },
-        "t_struct(FvmAddress)16689_storage": {
+        "t_struct(FvmAddress)16728_storage": {
             "encoding": "inplace",
             "label": "struct FvmAddress",
             "members": [
                 {
-                    "astId": 16686,
+                    "astId": 16725,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "addrType",
                     "offset": 0,
@@ -298,7 +298,7 @@
                     "type": "t_uint8"
                 },
                 {
-                    "astId": 16688,
+                    "astId": 16727,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "payload",
                     "offset": 0,
@@ -308,28 +308,28 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(GatewayActorStorage)10607_storage": {
+        "t_struct(GatewayActorStorage)10621_storage": {
             "encoding": "inplace",
             "label": "struct GatewayActorStorage",
             "members": [
                 {
-                    "astId": 10509,
+                    "astId": 10523,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "subnets",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_mapping(t_bytes32,t_struct(Subnet)16787_storage)"
+                    "type": "t_mapping(t_bytes32,t_struct(Subnet)16826_storage)"
                 },
                 {
-                    "astId": 10515,
+                    "astId": 10529,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "finalitiesMap",
                     "offset": 0,
                     "slot": "1",
-                    "type": "t_mapping(t_uint256,t_struct(ParentFinality)16609_storage)"
+                    "type": "t_mapping(t_uint256,t_struct(ParentFinality)16648_storage)"
                 },
                 {
-                    "astId": 10518,
+                    "astId": 10532,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "latestParentHeight",
                     "offset": 0,
@@ -337,63 +337,63 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 10524,
+                    "astId": 10538,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "postbox",
                     "offset": 0,
                     "slot": "3",
-                    "type": "t_mapping(t_bytes32,t_struct(CrossMsg)16665_storage)"
+                    "type": "t_mapping(t_bytes32,t_struct(CrossMsg)16704_storage)"
                 },
                 {
-                    "astId": 10528,
+                    "astId": 10542,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "currentMembership",
                     "offset": 0,
                     "slot": "4",
-                    "type": "t_struct(Membership)16914_storage"
+                    "type": "t_struct(Membership)16953_storage"
                 },
                 {
-                    "astId": 10532,
+                    "astId": 10546,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "lastMembership",
                     "offset": 0,
                     "slot": "6",
-                    "type": "t_struct(Membership)16914_storage"
-                },
-                {
-                    "astId": 10538,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "bottomUpCheckpoints",
-                    "offset": 0,
-                    "slot": "8",
-                    "type": "t_mapping(t_uint256,t_struct(BottomUpCheckpoint)16623_storage)"
-                },
-                {
-                    "astId": 10544,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "bottomUpMsgBatches",
-                    "offset": 0,
-                    "slot": "9",
-                    "type": "t_mapping(t_uint256,t_struct(BottomUpMsgBatch)16636_storage)"
-                },
-                {
-                    "astId": 10548,
-                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
-                    "label": "checkpointQuorumMap",
-                    "offset": 0,
-                    "slot": "10",
-                    "type": "t_struct(QuorumMap)16750_storage"
+                    "type": "t_struct(Membership)16953_storage"
                 },
                 {
                     "astId": 10552,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+                    "label": "bottomUpCheckpoints",
+                    "offset": 0,
+                    "slot": "8",
+                    "type": "t_mapping(t_uint256,t_struct(BottomUpCheckpoint)16662_storage)"
+                },
+                {
+                    "astId": 10558,
+                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+                    "label": "bottomUpMsgBatches",
+                    "offset": 0,
+                    "slot": "9",
+                    "type": "t_mapping(t_uint256,t_struct(BottomUpMsgBatch)16675_storage)"
+                },
+                {
+                    "astId": 10562,
+                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
+                    "label": "checkpointQuorumMap",
+                    "offset": 0,
+                    "slot": "10",
+                    "type": "t_struct(QuorumMap)16789_storage"
+                },
+                {
+                    "astId": 10566,
+                    "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "bottomUpMsgBatchQuorumMap",
                     "offset": 0,
                     "slot": "17",
-                    "type": "t_struct(QuorumMap)16750_storage"
+                    "type": "t_struct(QuorumMap)16789_storage"
                 },
                 {
-                    "astId": 10556,
+                    "astId": 10570,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "subnetKeys",
                     "offset": 0,
@@ -401,15 +401,15 @@
                     "type": "t_array(t_bytes32)dyn_storage"
                 },
                 {
-                    "astId": 10560,
+                    "astId": 10574,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "networkName",
                     "offset": 0,
                     "slot": "25",
-                    "type": "t_struct(SubnetID)16770_storage"
+                    "type": "t_struct(SubnetID)16809_storage"
                 },
                 {
-                    "astId": 10563,
+                    "astId": 10577,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "minStake",
                     "offset": 0,
@@ -417,7 +417,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 10566,
+                    "astId": 10580,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "minCrossMsgFee",
                     "offset": 0,
@@ -425,7 +425,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 10569,
+                    "astId": 10583,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "majorityPercentage",
                     "offset": 0,
@@ -433,7 +433,7 @@
                     "type": "t_uint8"
                 },
                 {
-                    "astId": 10572,
+                    "astId": 10586,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "bottomUpNonce",
                     "offset": 1,
@@ -441,7 +441,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 10575,
+                    "astId": 10589,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "appliedTopDownNonce",
                     "offset": 9,
@@ -449,7 +449,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 10578,
+                    "astId": 10592,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "totalSubnets",
                     "offset": 17,
@@ -457,7 +457,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 10581,
+                    "astId": 10595,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "bottomUpCheckPeriod",
                     "offset": 0,
@@ -465,7 +465,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 10584,
+                    "astId": 10598,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "bottomUpMsgBatchPeriod",
                     "offset": 0,
@@ -473,7 +473,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 10587,
+                    "astId": 10601,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "maxMsgsPerBottomUpBatch",
                     "offset": 0,
@@ -481,15 +481,15 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 10591,
+                    "astId": 10605,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "validatorsTracker",
                     "offset": 0,
                     "slot": "33",
-                    "type": "t_struct(ParentValidatorsTracker)16893_storage"
+                    "type": "t_struct(ParentValidatorsTracker)16932_storage"
                 },
                 {
-                    "astId": 10594,
+                    "astId": 10608,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "maxTreeDepth",
                     "offset": 0,
@@ -497,7 +497,7 @@
                     "type": "t_uint8"
                 },
                 {
-                    "astId": 10597,
+                    "astId": 10611,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "generalPurposeCrossMsg",
                     "offset": 1,
@@ -505,7 +505,7 @@
                     "type": "t_bool"
                 },
                 {
-                    "astId": 10600,
+                    "astId": 10614,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "multiLevelCrossMsg",
                     "offset": 2,
@@ -513,7 +513,7 @@
                     "type": "t_bool"
                 },
                 {
-                    "astId": 10603,
+                    "astId": 10617,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "checkpointRelayerRewards",
                     "offset": 3,
@@ -521,7 +521,7 @@
                     "type": "t_bool"
                 },
                 {
-                    "astId": 10606,
+                    "astId": 10620,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "crossMsgRelayerRewards",
                     "offset": 4,
@@ -531,58 +531,58 @@
             ],
             "numberOfBytes": "1440"
         },
-        "t_struct(IPCAddress)16900_storage": {
+        "t_struct(IPCAddress)16939_storage": {
             "encoding": "inplace",
             "label": "struct IPCAddress",
             "members": [
                 {
-                    "astId": 16896,
+                    "astId": 16935,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "subnetId",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(SubnetID)16770_storage"
+                    "type": "t_struct(SubnetID)16809_storage"
                 },
                 {
-                    "astId": 16899,
+                    "astId": 16938,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "rawAddress",
                     "offset": 0,
                     "slot": "2",
-                    "type": "t_struct(FvmAddress)16689_storage"
+                    "type": "t_struct(FvmAddress)16728_storage"
                 }
             ],
             "numberOfBytes": "128"
         },
-        "t_struct(MaxPQ)15102_storage": {
+        "t_struct(MaxPQ)15141_storage": {
             "encoding": "inplace",
             "label": "struct MaxPQ",
             "members": [
                 {
-                    "astId": 15101,
+                    "astId": 15140,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "inner",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(PQ)16349_storage"
+                    "type": "t_struct(PQ)16388_storage"
                 }
             ],
             "numberOfBytes": "96"
         },
-        "t_struct(Membership)16914_storage": {
+        "t_struct(Membership)16953_storage": {
             "encoding": "inplace",
             "label": "struct Membership",
             "members": [
                 {
-                    "astId": 16911,
+                    "astId": 16950,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "validators",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_array(t_struct(Validator)16907_storage)dyn_storage"
+                    "type": "t_array(t_struct(Validator)16946_storage)dyn_storage"
                 },
                 {
-                    "astId": 16913,
+                    "astId": 16952,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "configurationNumber",
                     "offset": 0,
@@ -592,27 +592,27 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(MinPQ)15720_storage": {
+        "t_struct(MinPQ)15759_storage": {
             "encoding": "inplace",
             "label": "struct MinPQ",
             "members": [
                 {
-                    "astId": 15719,
+                    "astId": 15758,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "inner",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(PQ)16349_storage"
+                    "type": "t_struct(PQ)16388_storage"
                 }
             ],
             "numberOfBytes": "96"
         },
-        "t_struct(PQ)16349_storage": {
+        "t_struct(PQ)16388_storage": {
             "encoding": "inplace",
             "label": "struct PQ",
             "members": [
                 {
-                    "astId": 16338,
+                    "astId": 16377,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "size",
                     "offset": 0,
@@ -620,7 +620,7 @@
                     "type": "t_uint16"
                 },
                 {
-                    "astId": 16343,
+                    "astId": 16382,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "addressToPos",
                     "offset": 0,
@@ -628,7 +628,7 @@
                     "type": "t_mapping(t_address,t_uint16)"
                 },
                 {
-                    "astId": 16348,
+                    "astId": 16387,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "posToAddress",
                     "offset": 0,
@@ -638,12 +638,12 @@
             ],
             "numberOfBytes": "96"
         },
-        "t_struct(ParentFinality)16609_storage": {
+        "t_struct(ParentFinality)16648_storage": {
             "encoding": "inplace",
             "label": "struct ParentFinality",
             "members": [
                 {
-                    "astId": 16606,
+                    "astId": 16645,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "height",
                     "offset": 0,
@@ -651,7 +651,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16608,
+                    "astId": 16647,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "blockHash",
                     "offset": 0,
@@ -661,35 +661,35 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(ParentValidatorsTracker)16893_storage": {
+        "t_struct(ParentValidatorsTracker)16932_storage": {
             "encoding": "inplace",
             "label": "struct ParentValidatorsTracker",
             "members": [
                 {
-                    "astId": 16889,
+                    "astId": 16928,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "validators",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(ValidatorSet)16886_storage"
+                    "type": "t_struct(ValidatorSet)16925_storage"
                 },
                 {
-                    "astId": 16892,
+                    "astId": 16931,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "changes",
                     "offset": 0,
                     "slot": "9",
-                    "type": "t_struct(StakingChangeLog)16819_storage"
+                    "type": "t_struct(StakingChangeLog)16858_storage"
                 }
             ],
             "numberOfBytes": "352"
         },
-        "t_struct(QuorumInfo)16719_storage": {
+        "t_struct(QuorumInfo)16758_storage": {
             "encoding": "inplace",
             "label": "struct QuorumInfo",
             "members": [
                 {
-                    "astId": 16706,
+                    "astId": 16745,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "hash",
                     "offset": 0,
@@ -697,7 +697,7 @@
                     "type": "t_bytes32"
                 },
                 {
-                    "astId": 16709,
+                    "astId": 16748,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "rootHash",
                     "offset": 0,
@@ -705,7 +705,7 @@
                     "type": "t_bytes32"
                 },
                 {
-                    "astId": 16712,
+                    "astId": 16751,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "threshold",
                     "offset": 0,
@@ -713,7 +713,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16715,
+                    "astId": 16754,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "currentWeight",
                     "offset": 0,
@@ -721,7 +721,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16718,
+                    "astId": 16757,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "reached",
                     "offset": 0,
@@ -731,20 +731,20 @@
             ],
             "numberOfBytes": "160"
         },
-        "t_struct(QuorumMap)16750_storage": {
+        "t_struct(QuorumMap)16789_storage": {
             "encoding": "inplace",
             "label": "struct QuorumMap",
             "members": [
                 {
-                    "astId": 16723,
+                    "astId": 16762,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "quorumObjKind",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_enum(QuorumObjKind)16703"
+                    "type": "t_enum(QuorumObjKind)16742"
                 },
                 {
-                    "astId": 16726,
+                    "astId": 16765,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "retentionHeight",
                     "offset": 0,
@@ -752,15 +752,15 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16732,
+                    "astId": 16771,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "quorumInfo",
                     "offset": 0,
                     "slot": "2",
-                    "type": "t_mapping(t_uint256,t_struct(QuorumInfo)16719_storage)"
+                    "type": "t_mapping(t_uint256,t_struct(QuorumInfo)16758_storage)"
                 },
                 {
-                    "astId": 16736,
+                    "astId": 16775,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "incompleteQuorums",
                     "offset": 0,
@@ -768,7 +768,7 @@
                     "type": "t_struct(UintSet)3508_storage"
                 },
                 {
-                    "astId": 16742,
+                    "astId": 16781,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "quorumSignatureSenders",
                     "offset": 0,
@@ -776,7 +776,7 @@
                     "type": "t_mapping(t_uint256,t_struct(AddressSet)3351_storage)"
                 },
                 {
-                    "astId": 16749,
+                    "astId": 16788,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "quorumSignatures",
                     "offset": 0,
@@ -809,20 +809,20 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(StakingChange)16800_storage": {
+        "t_struct(StakingChange)16839_storage": {
             "encoding": "inplace",
             "label": "struct StakingChange",
             "members": [
                 {
-                    "astId": 16795,
+                    "astId": 16834,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "op",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_enum(StakingOperation)16792"
+                    "type": "t_enum(StakingOperation)16831"
                 },
                 {
-                    "astId": 16797,
+                    "astId": 16836,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "payload",
                     "offset": 0,
@@ -830,7 +830,7 @@
                     "type": "t_bytes_storage"
                 },
                 {
-                    "astId": 16799,
+                    "astId": 16838,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "validator",
                     "offset": 0,
@@ -840,12 +840,12 @@
             ],
             "numberOfBytes": "96"
         },
-        "t_struct(StakingChangeLog)16819_storage": {
+        "t_struct(StakingChangeLog)16858_storage": {
             "encoding": "inplace",
             "label": "struct StakingChangeLog",
             "members": [
                 {
-                    "astId": 16809,
+                    "astId": 16848,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "nextConfigurationNumber",
                     "offset": 0,
@@ -853,7 +853,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 16812,
+                    "astId": 16851,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "startConfigurationNumber",
                     "offset": 8,
@@ -861,38 +861,38 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 16818,
+                    "astId": 16857,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "changes",
                     "offset": 0,
                     "slot": "1",
-                    "type": "t_mapping(t_uint64,t_struct(StakingChange)16800_storage)"
+                    "type": "t_mapping(t_uint64,t_struct(StakingChange)16839_storage)"
                 }
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(StorableMsg)16682_storage": {
+        "t_struct(StorableMsg)16721_storage": {
             "encoding": "inplace",
             "label": "struct StorableMsg",
             "members": [
                 {
-                    "astId": 16668,
+                    "astId": 16707,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "from",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(IPCAddress)16900_storage"
+                    "type": "t_struct(IPCAddress)16939_storage"
                 },
                 {
-                    "astId": 16671,
+                    "astId": 16710,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "to",
                     "offset": 0,
                     "slot": "4",
-                    "type": "t_struct(IPCAddress)16900_storage"
+                    "type": "t_struct(IPCAddress)16939_storage"
                 },
                 {
-                    "astId": 16673,
+                    "astId": 16712,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "value",
                     "offset": 0,
@@ -900,7 +900,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16675,
+                    "astId": 16714,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "nonce",
                     "offset": 0,
@@ -908,7 +908,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 16677,
+                    "astId": 16716,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "method",
                     "offset": 8,
@@ -916,7 +916,7 @@
                     "type": "t_bytes4"
                 },
                 {
-                    "astId": 16679,
+                    "astId": 16718,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "params",
                     "offset": 0,
@@ -924,7 +924,7 @@
                     "type": "t_bytes_storage"
                 },
                 {
-                    "astId": 16681,
+                    "astId": 16720,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "fee",
                     "offset": 0,
@@ -934,12 +934,12 @@
             ],
             "numberOfBytes": "384"
         },
-        "t_struct(Subnet)16787_storage": {
+        "t_struct(Subnet)16826_storage": {
             "encoding": "inplace",
             "label": "struct Subnet",
             "members": [
                 {
-                    "astId": 16772,
+                    "astId": 16811,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "stake",
                     "offset": 0,
@@ -947,7 +947,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16774,
+                    "astId": 16813,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "genesisEpoch",
                     "offset": 0,
@@ -955,7 +955,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16776,
+                    "astId": 16815,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "circSupply",
                     "offset": 0,
@@ -963,7 +963,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16778,
+                    "astId": 16817,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "topDownNonce",
                     "offset": 0,
@@ -971,7 +971,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 16780,
+                    "astId": 16819,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "appliedBottomUpNonce",
                     "offset": 8,
@@ -979,30 +979,30 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 16783,
+                    "astId": 16822,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "status",
                     "offset": 16,
                     "slot": "3",
-                    "type": "t_enum(Status)5165"
+                    "type": "t_enum(Status)5184"
                 },
                 {
-                    "astId": 16786,
+                    "astId": 16825,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "id",
                     "offset": 0,
                     "slot": "4",
-                    "type": "t_struct(SubnetID)16770_storage"
+                    "type": "t_struct(SubnetID)16809_storage"
                 }
             ],
             "numberOfBytes": "192"
         },
-        "t_struct(SubnetID)16770_storage": {
+        "t_struct(SubnetID)16809_storage": {
             "encoding": "inplace",
             "label": "struct SubnetID",
             "members": [
                 {
-                    "astId": 16765,
+                    "astId": 16804,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "root",
                     "offset": 0,
@@ -1010,7 +1010,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 16769,
+                    "astId": 16808,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "route",
                     "offset": 0,
@@ -1035,12 +1035,12 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(Validator)16907_storage": {
+        "t_struct(Validator)16946_storage": {
             "encoding": "inplace",
             "label": "struct Validator",
             "members": [
                 {
-                    "astId": 16902,
+                    "astId": 16941,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "weight",
                     "offset": 0,
@@ -1048,7 +1048,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16904,
+                    "astId": 16943,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "addr",
                     "offset": 0,
@@ -1056,7 +1056,7 @@
                     "type": "t_address"
                 },
                 {
-                    "astId": 16906,
+                    "astId": 16945,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "metadata",
                     "offset": 0,
@@ -1066,12 +1066,12 @@
             ],
             "numberOfBytes": "96"
         },
-        "t_struct(ValidatorInfo)16857_storage": {
+        "t_struct(ValidatorInfo)16896_storage": {
             "encoding": "inplace",
             "label": "struct ValidatorInfo",
             "members": [
                 {
-                    "astId": 16849,
+                    "astId": 16888,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "federatedPower",
                     "offset": 0,
@@ -1079,7 +1079,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16851,
+                    "astId": 16890,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "confirmedCollateral",
                     "offset": 0,
@@ -1087,7 +1087,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16853,
+                    "astId": 16892,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "totalCollateral",
                     "offset": 0,
@@ -1095,7 +1095,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16856,
+                    "astId": 16895,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "metadata",
                     "offset": 0,
@@ -1105,20 +1105,20 @@
             ],
             "numberOfBytes": "128"
         },
-        "t_struct(ValidatorSet)16886_storage": {
+        "t_struct(ValidatorSet)16925_storage": {
             "encoding": "inplace",
             "label": "struct ValidatorSet",
             "members": [
                 {
-                    "astId": 16865,
+                    "astId": 16904,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "permissionMode",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_enum(PermissionMode)16861"
+                    "type": "t_enum(PermissionMode)16900"
                 },
                 {
-                    "astId": 16868,
+                    "astId": 16907,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "activeLimit",
                     "offset": 1,
@@ -1126,7 +1126,7 @@
                     "type": "t_uint16"
                 },
                 {
-                    "astId": 16871,
+                    "astId": 16910,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "totalConfirmedCollateral",
                     "offset": 0,
@@ -1134,28 +1134,28 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16877,
+                    "astId": 16916,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "validators",
                     "offset": 0,
                     "slot": "2",
-                    "type": "t_mapping(t_address,t_struct(ValidatorInfo)16857_storage)"
+                    "type": "t_mapping(t_address,t_struct(ValidatorInfo)16896_storage)"
                 },
                 {
-                    "astId": 16881,
+                    "astId": 16920,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "activeValidators",
                     "offset": 0,
                     "slot": "3",
-                    "type": "t_struct(MinPQ)15720_storage"
+                    "type": "t_struct(MinPQ)15759_storage"
                 },
                 {
-                    "astId": 16885,
+                    "astId": 16924,
                     "contract": "src/lib/LibGatewayActorStorage.sol:GatewayActorModifiers",
                     "label": "waitingValidators",
                     "offset": 0,
                     "slot": "6",
-                    "type": "t_struct(MaxPQ)15102_storage"
+                    "type": "t_struct(MaxPQ)15141_storage"
                 }
             ],
             "numberOfBytes": "288"

--- a/.storage-layouts/GatewayDiamond.json
+++ b/.storage-layouts/GatewayDiamond.json
@@ -6,7 +6,7 @@
             "label": "s",
             "offset": 0,
             "slot": "0",
-            "type": "t_struct(GatewayActorStorage)10607_storage"
+            "type": "t_struct(GatewayActorStorage)10621_storage"
         }
     ],
     "types": {
@@ -27,14 +27,14 @@
             "label": "bytes32[]",
             "numberOfBytes": "32"
         },
-        "t_array(t_struct(CrossMsg)16665_storage)dyn_storage": {
-            "base": "t_struct(CrossMsg)16665_storage",
+        "t_array(t_struct(CrossMsg)16704_storage)dyn_storage": {
+            "base": "t_struct(CrossMsg)16704_storage",
             "encoding": "dynamic_array",
             "label": "struct CrossMsg[]",
             "numberOfBytes": "32"
         },
-        "t_array(t_struct(Validator)16907_storage)dyn_storage": {
-            "base": "t_struct(Validator)16907_storage",
+        "t_array(t_struct(Validator)16946_storage)dyn_storage": {
+            "base": "t_struct(Validator)16946_storage",
             "encoding": "dynamic_array",
             "label": "struct Validator[]",
             "numberOfBytes": "32"
@@ -59,22 +59,22 @@
             "label": "bytes",
             "numberOfBytes": "32"
         },
-        "t_enum(PermissionMode)16861": {
+        "t_enum(PermissionMode)16900": {
             "encoding": "inplace",
             "label": "enum PermissionMode",
             "numberOfBytes": "1"
         },
-        "t_enum(QuorumObjKind)16703": {
+        "t_enum(QuorumObjKind)16742": {
             "encoding": "inplace",
             "label": "enum QuorumObjKind",
             "numberOfBytes": "1"
         },
-        "t_enum(StakingOperation)16792": {
+        "t_enum(StakingOperation)16831": {
             "encoding": "inplace",
             "label": "enum StakingOperation",
             "numberOfBytes": "1"
         },
-        "t_enum(Status)5165": {
+        "t_enum(Status)5184": {
             "encoding": "inplace",
             "label": "enum Status",
             "numberOfBytes": "1"
@@ -86,12 +86,12 @@
             "numberOfBytes": "32",
             "value": "t_bytes_storage"
         },
-        "t_mapping(t_address,t_struct(ValidatorInfo)16857_storage)": {
+        "t_mapping(t_address,t_struct(ValidatorInfo)16896_storage)": {
             "encoding": "mapping",
             "key": "t_address",
             "label": "mapping(address => struct ValidatorInfo)",
             "numberOfBytes": "32",
-            "value": "t_struct(ValidatorInfo)16857_storage"
+            "value": "t_struct(ValidatorInfo)16896_storage"
         },
         "t_mapping(t_address,t_uint16)": {
             "encoding": "mapping",
@@ -100,19 +100,19 @@
             "numberOfBytes": "32",
             "value": "t_uint16"
         },
-        "t_mapping(t_bytes32,t_struct(CrossMsg)16665_storage)": {
+        "t_mapping(t_bytes32,t_struct(CrossMsg)16704_storage)": {
             "encoding": "mapping",
             "key": "t_bytes32",
             "label": "mapping(bytes32 => struct CrossMsg)",
             "numberOfBytes": "32",
-            "value": "t_struct(CrossMsg)16665_storage"
+            "value": "t_struct(CrossMsg)16704_storage"
         },
-        "t_mapping(t_bytes32,t_struct(Subnet)16787_storage)": {
+        "t_mapping(t_bytes32,t_struct(Subnet)16826_storage)": {
             "encoding": "mapping",
             "key": "t_bytes32",
             "label": "mapping(bytes32 => struct Subnet)",
             "numberOfBytes": "32",
-            "value": "t_struct(Subnet)16787_storage"
+            "value": "t_struct(Subnet)16826_storage"
         },
         "t_mapping(t_bytes32,t_uint256)": {
             "encoding": "mapping",
@@ -142,40 +142,40 @@
             "numberOfBytes": "32",
             "value": "t_struct(AddressSet)3351_storage"
         },
-        "t_mapping(t_uint256,t_struct(BottomUpCheckpoint)16623_storage)": {
+        "t_mapping(t_uint256,t_struct(BottomUpCheckpoint)16662_storage)": {
             "encoding": "mapping",
             "key": "t_uint256",
             "label": "mapping(uint256 => struct BottomUpCheckpoint)",
             "numberOfBytes": "32",
-            "value": "t_struct(BottomUpCheckpoint)16623_storage"
+            "value": "t_struct(BottomUpCheckpoint)16662_storage"
         },
-        "t_mapping(t_uint256,t_struct(BottomUpMsgBatch)16636_storage)": {
+        "t_mapping(t_uint256,t_struct(BottomUpMsgBatch)16675_storage)": {
             "encoding": "mapping",
             "key": "t_uint256",
             "label": "mapping(uint256 => struct BottomUpMsgBatch)",
             "numberOfBytes": "32",
-            "value": "t_struct(BottomUpMsgBatch)16636_storage"
+            "value": "t_struct(BottomUpMsgBatch)16675_storage"
         },
-        "t_mapping(t_uint256,t_struct(ParentFinality)16609_storage)": {
+        "t_mapping(t_uint256,t_struct(ParentFinality)16648_storage)": {
             "encoding": "mapping",
             "key": "t_uint256",
             "label": "mapping(uint256 => struct ParentFinality)",
             "numberOfBytes": "32",
-            "value": "t_struct(ParentFinality)16609_storage"
+            "value": "t_struct(ParentFinality)16648_storage"
         },
-        "t_mapping(t_uint256,t_struct(QuorumInfo)16719_storage)": {
+        "t_mapping(t_uint256,t_struct(QuorumInfo)16758_storage)": {
             "encoding": "mapping",
             "key": "t_uint256",
             "label": "mapping(uint256 => struct QuorumInfo)",
             "numberOfBytes": "32",
-            "value": "t_struct(QuorumInfo)16719_storage"
+            "value": "t_struct(QuorumInfo)16758_storage"
         },
-        "t_mapping(t_uint64,t_struct(StakingChange)16800_storage)": {
+        "t_mapping(t_uint64,t_struct(StakingChange)16839_storage)": {
             "encoding": "mapping",
             "key": "t_uint64",
             "label": "mapping(uint64 => struct StakingChange)",
             "numberOfBytes": "32",
-            "value": "t_struct(StakingChange)16800_storage"
+            "value": "t_struct(StakingChange)16839_storage"
         },
         "t_struct(AddressSet)3351_storage": {
             "encoding": "inplace",
@@ -192,20 +192,20 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(BottomUpCheckpoint)16623_storage": {
+        "t_struct(BottomUpCheckpoint)16662_storage": {
             "encoding": "inplace",
             "label": "struct BottomUpCheckpoint",
             "members": [
                 {
-                    "astId": 16613,
+                    "astId": 16652,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "subnetID",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(SubnetID)16770_storage"
+                    "type": "t_struct(SubnetID)16809_storage"
                 },
                 {
-                    "astId": 16616,
+                    "astId": 16655,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "blockHeight",
                     "offset": 0,
@@ -213,7 +213,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16619,
+                    "astId": 16658,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "blockHash",
                     "offset": 0,
@@ -221,7 +221,7 @@
                     "type": "t_bytes32"
                 },
                 {
-                    "astId": 16622,
+                    "astId": 16661,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "nextConfigurationNumber",
                     "offset": 0,
@@ -231,20 +231,20 @@
             ],
             "numberOfBytes": "160"
         },
-        "t_struct(BottomUpMsgBatch)16636_storage": {
+        "t_struct(BottomUpMsgBatch)16675_storage": {
             "encoding": "inplace",
             "label": "struct BottomUpMsgBatch",
             "members": [
                 {
-                    "astId": 16627,
+                    "astId": 16666,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "subnetID",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(SubnetID)16770_storage"
+                    "type": "t_struct(SubnetID)16809_storage"
                 },
                 {
-                    "astId": 16630,
+                    "astId": 16669,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "blockHeight",
                     "offset": 0,
@@ -252,30 +252,30 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16635,
+                    "astId": 16674,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "msgs",
                     "offset": 0,
                     "slot": "3",
-                    "type": "t_array(t_struct(CrossMsg)16665_storage)dyn_storage"
+                    "type": "t_array(t_struct(CrossMsg)16704_storage)dyn_storage"
                 }
             ],
             "numberOfBytes": "128"
         },
-        "t_struct(CrossMsg)16665_storage": {
+        "t_struct(CrossMsg)16704_storage": {
             "encoding": "inplace",
             "label": "struct CrossMsg",
             "members": [
                 {
-                    "astId": 16662,
+                    "astId": 16701,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "message",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(StorableMsg)16682_storage"
+                    "type": "t_struct(StorableMsg)16721_storage"
                 },
                 {
-                    "astId": 16664,
+                    "astId": 16703,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "wrapped",
                     "offset": 0,
@@ -285,12 +285,12 @@
             ],
             "numberOfBytes": "416"
         },
-        "t_struct(FvmAddress)16689_storage": {
+        "t_struct(FvmAddress)16728_storage": {
             "encoding": "inplace",
             "label": "struct FvmAddress",
             "members": [
                 {
-                    "astId": 16686,
+                    "astId": 16725,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "addrType",
                     "offset": 0,
@@ -298,7 +298,7 @@
                     "type": "t_uint8"
                 },
                 {
-                    "astId": 16688,
+                    "astId": 16727,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "payload",
                     "offset": 0,
@@ -308,28 +308,28 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(GatewayActorStorage)10607_storage": {
+        "t_struct(GatewayActorStorage)10621_storage": {
             "encoding": "inplace",
             "label": "struct GatewayActorStorage",
             "members": [
                 {
-                    "astId": 10509,
+                    "astId": 10523,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "subnets",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_mapping(t_bytes32,t_struct(Subnet)16787_storage)"
+                    "type": "t_mapping(t_bytes32,t_struct(Subnet)16826_storage)"
                 },
                 {
-                    "astId": 10515,
+                    "astId": 10529,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "finalitiesMap",
                     "offset": 0,
                     "slot": "1",
-                    "type": "t_mapping(t_uint256,t_struct(ParentFinality)16609_storage)"
+                    "type": "t_mapping(t_uint256,t_struct(ParentFinality)16648_storage)"
                 },
                 {
-                    "astId": 10518,
+                    "astId": 10532,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "latestParentHeight",
                     "offset": 0,
@@ -337,63 +337,63 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 10524,
+                    "astId": 10538,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "postbox",
                     "offset": 0,
                     "slot": "3",
-                    "type": "t_mapping(t_bytes32,t_struct(CrossMsg)16665_storage)"
+                    "type": "t_mapping(t_bytes32,t_struct(CrossMsg)16704_storage)"
                 },
                 {
-                    "astId": 10528,
+                    "astId": 10542,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "currentMembership",
                     "offset": 0,
                     "slot": "4",
-                    "type": "t_struct(Membership)16914_storage"
+                    "type": "t_struct(Membership)16953_storage"
                 },
                 {
-                    "astId": 10532,
+                    "astId": 10546,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "lastMembership",
                     "offset": 0,
                     "slot": "6",
-                    "type": "t_struct(Membership)16914_storage"
-                },
-                {
-                    "astId": 10538,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "bottomUpCheckpoints",
-                    "offset": 0,
-                    "slot": "8",
-                    "type": "t_mapping(t_uint256,t_struct(BottomUpCheckpoint)16623_storage)"
-                },
-                {
-                    "astId": 10544,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "bottomUpMsgBatches",
-                    "offset": 0,
-                    "slot": "9",
-                    "type": "t_mapping(t_uint256,t_struct(BottomUpMsgBatch)16636_storage)"
-                },
-                {
-                    "astId": 10548,
-                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
-                    "label": "checkpointQuorumMap",
-                    "offset": 0,
-                    "slot": "10",
-                    "type": "t_struct(QuorumMap)16750_storage"
+                    "type": "t_struct(Membership)16953_storage"
                 },
                 {
                     "astId": 10552,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+                    "label": "bottomUpCheckpoints",
+                    "offset": 0,
+                    "slot": "8",
+                    "type": "t_mapping(t_uint256,t_struct(BottomUpCheckpoint)16662_storage)"
+                },
+                {
+                    "astId": 10558,
+                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+                    "label": "bottomUpMsgBatches",
+                    "offset": 0,
+                    "slot": "9",
+                    "type": "t_mapping(t_uint256,t_struct(BottomUpMsgBatch)16675_storage)"
+                },
+                {
+                    "astId": 10562,
+                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
+                    "label": "checkpointQuorumMap",
+                    "offset": 0,
+                    "slot": "10",
+                    "type": "t_struct(QuorumMap)16789_storage"
+                },
+                {
+                    "astId": 10566,
+                    "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "bottomUpMsgBatchQuorumMap",
                     "offset": 0,
                     "slot": "17",
-                    "type": "t_struct(QuorumMap)16750_storage"
+                    "type": "t_struct(QuorumMap)16789_storage"
                 },
                 {
-                    "astId": 10556,
+                    "astId": 10570,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "subnetKeys",
                     "offset": 0,
@@ -401,15 +401,15 @@
                     "type": "t_array(t_bytes32)dyn_storage"
                 },
                 {
-                    "astId": 10560,
+                    "astId": 10574,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "networkName",
                     "offset": 0,
                     "slot": "25",
-                    "type": "t_struct(SubnetID)16770_storage"
+                    "type": "t_struct(SubnetID)16809_storage"
                 },
                 {
-                    "astId": 10563,
+                    "astId": 10577,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "minStake",
                     "offset": 0,
@@ -417,7 +417,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 10566,
+                    "astId": 10580,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "minCrossMsgFee",
                     "offset": 0,
@@ -425,7 +425,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 10569,
+                    "astId": 10583,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "majorityPercentage",
                     "offset": 0,
@@ -433,7 +433,7 @@
                     "type": "t_uint8"
                 },
                 {
-                    "astId": 10572,
+                    "astId": 10586,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "bottomUpNonce",
                     "offset": 1,
@@ -441,7 +441,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 10575,
+                    "astId": 10589,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "appliedTopDownNonce",
                     "offset": 9,
@@ -449,7 +449,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 10578,
+                    "astId": 10592,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "totalSubnets",
                     "offset": 17,
@@ -457,7 +457,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 10581,
+                    "astId": 10595,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "bottomUpCheckPeriod",
                     "offset": 0,
@@ -465,7 +465,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 10584,
+                    "astId": 10598,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "bottomUpMsgBatchPeriod",
                     "offset": 0,
@@ -473,7 +473,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 10587,
+                    "astId": 10601,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "maxMsgsPerBottomUpBatch",
                     "offset": 0,
@@ -481,15 +481,15 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 10591,
+                    "astId": 10605,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "validatorsTracker",
                     "offset": 0,
                     "slot": "33",
-                    "type": "t_struct(ParentValidatorsTracker)16893_storage"
+                    "type": "t_struct(ParentValidatorsTracker)16932_storage"
                 },
                 {
-                    "astId": 10594,
+                    "astId": 10608,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "maxTreeDepth",
                     "offset": 0,
@@ -497,7 +497,7 @@
                     "type": "t_uint8"
                 },
                 {
-                    "astId": 10597,
+                    "astId": 10611,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "generalPurposeCrossMsg",
                     "offset": 1,
@@ -505,7 +505,7 @@
                     "type": "t_bool"
                 },
                 {
-                    "astId": 10600,
+                    "astId": 10614,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "multiLevelCrossMsg",
                     "offset": 2,
@@ -513,7 +513,7 @@
                     "type": "t_bool"
                 },
                 {
-                    "astId": 10603,
+                    "astId": 10617,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "checkpointRelayerRewards",
                     "offset": 3,
@@ -521,7 +521,7 @@
                     "type": "t_bool"
                 },
                 {
-                    "astId": 10606,
+                    "astId": 10620,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "crossMsgRelayerRewards",
                     "offset": 4,
@@ -531,58 +531,58 @@
             ],
             "numberOfBytes": "1440"
         },
-        "t_struct(IPCAddress)16900_storage": {
+        "t_struct(IPCAddress)16939_storage": {
             "encoding": "inplace",
             "label": "struct IPCAddress",
             "members": [
                 {
-                    "astId": 16896,
+                    "astId": 16935,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "subnetId",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(SubnetID)16770_storage"
+                    "type": "t_struct(SubnetID)16809_storage"
                 },
                 {
-                    "astId": 16899,
+                    "astId": 16938,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "rawAddress",
                     "offset": 0,
                     "slot": "2",
-                    "type": "t_struct(FvmAddress)16689_storage"
+                    "type": "t_struct(FvmAddress)16728_storage"
                 }
             ],
             "numberOfBytes": "128"
         },
-        "t_struct(MaxPQ)15102_storage": {
+        "t_struct(MaxPQ)15141_storage": {
             "encoding": "inplace",
             "label": "struct MaxPQ",
             "members": [
                 {
-                    "astId": 15101,
+                    "astId": 15140,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "inner",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(PQ)16349_storage"
+                    "type": "t_struct(PQ)16388_storage"
                 }
             ],
             "numberOfBytes": "96"
         },
-        "t_struct(Membership)16914_storage": {
+        "t_struct(Membership)16953_storage": {
             "encoding": "inplace",
             "label": "struct Membership",
             "members": [
                 {
-                    "astId": 16911,
+                    "astId": 16950,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "validators",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_array(t_struct(Validator)16907_storage)dyn_storage"
+                    "type": "t_array(t_struct(Validator)16946_storage)dyn_storage"
                 },
                 {
-                    "astId": 16913,
+                    "astId": 16952,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "configurationNumber",
                     "offset": 0,
@@ -592,27 +592,27 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(MinPQ)15720_storage": {
+        "t_struct(MinPQ)15759_storage": {
             "encoding": "inplace",
             "label": "struct MinPQ",
             "members": [
                 {
-                    "astId": 15719,
+                    "astId": 15758,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "inner",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(PQ)16349_storage"
+                    "type": "t_struct(PQ)16388_storage"
                 }
             ],
             "numberOfBytes": "96"
         },
-        "t_struct(PQ)16349_storage": {
+        "t_struct(PQ)16388_storage": {
             "encoding": "inplace",
             "label": "struct PQ",
             "members": [
                 {
-                    "astId": 16338,
+                    "astId": 16377,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "size",
                     "offset": 0,
@@ -620,7 +620,7 @@
                     "type": "t_uint16"
                 },
                 {
-                    "astId": 16343,
+                    "astId": 16382,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "addressToPos",
                     "offset": 0,
@@ -628,7 +628,7 @@
                     "type": "t_mapping(t_address,t_uint16)"
                 },
                 {
-                    "astId": 16348,
+                    "astId": 16387,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "posToAddress",
                     "offset": 0,
@@ -638,12 +638,12 @@
             ],
             "numberOfBytes": "96"
         },
-        "t_struct(ParentFinality)16609_storage": {
+        "t_struct(ParentFinality)16648_storage": {
             "encoding": "inplace",
             "label": "struct ParentFinality",
             "members": [
                 {
-                    "astId": 16606,
+                    "astId": 16645,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "height",
                     "offset": 0,
@@ -651,7 +651,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16608,
+                    "astId": 16647,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "blockHash",
                     "offset": 0,
@@ -661,35 +661,35 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(ParentValidatorsTracker)16893_storage": {
+        "t_struct(ParentValidatorsTracker)16932_storage": {
             "encoding": "inplace",
             "label": "struct ParentValidatorsTracker",
             "members": [
                 {
-                    "astId": 16889,
+                    "astId": 16928,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "validators",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(ValidatorSet)16886_storage"
+                    "type": "t_struct(ValidatorSet)16925_storage"
                 },
                 {
-                    "astId": 16892,
+                    "astId": 16931,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "changes",
                     "offset": 0,
                     "slot": "9",
-                    "type": "t_struct(StakingChangeLog)16819_storage"
+                    "type": "t_struct(StakingChangeLog)16858_storage"
                 }
             ],
             "numberOfBytes": "352"
         },
-        "t_struct(QuorumInfo)16719_storage": {
+        "t_struct(QuorumInfo)16758_storage": {
             "encoding": "inplace",
             "label": "struct QuorumInfo",
             "members": [
                 {
-                    "astId": 16706,
+                    "astId": 16745,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "hash",
                     "offset": 0,
@@ -697,7 +697,7 @@
                     "type": "t_bytes32"
                 },
                 {
-                    "astId": 16709,
+                    "astId": 16748,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "rootHash",
                     "offset": 0,
@@ -705,7 +705,7 @@
                     "type": "t_bytes32"
                 },
                 {
-                    "astId": 16712,
+                    "astId": 16751,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "threshold",
                     "offset": 0,
@@ -713,7 +713,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16715,
+                    "astId": 16754,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "currentWeight",
                     "offset": 0,
@@ -721,7 +721,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16718,
+                    "astId": 16757,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "reached",
                     "offset": 0,
@@ -731,20 +731,20 @@
             ],
             "numberOfBytes": "160"
         },
-        "t_struct(QuorumMap)16750_storage": {
+        "t_struct(QuorumMap)16789_storage": {
             "encoding": "inplace",
             "label": "struct QuorumMap",
             "members": [
                 {
-                    "astId": 16723,
+                    "astId": 16762,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "quorumObjKind",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_enum(QuorumObjKind)16703"
+                    "type": "t_enum(QuorumObjKind)16742"
                 },
                 {
-                    "astId": 16726,
+                    "astId": 16765,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "retentionHeight",
                     "offset": 0,
@@ -752,15 +752,15 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16732,
+                    "astId": 16771,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "quorumInfo",
                     "offset": 0,
                     "slot": "2",
-                    "type": "t_mapping(t_uint256,t_struct(QuorumInfo)16719_storage)"
+                    "type": "t_mapping(t_uint256,t_struct(QuorumInfo)16758_storage)"
                 },
                 {
-                    "astId": 16736,
+                    "astId": 16775,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "incompleteQuorums",
                     "offset": 0,
@@ -768,7 +768,7 @@
                     "type": "t_struct(UintSet)3508_storage"
                 },
                 {
-                    "astId": 16742,
+                    "astId": 16781,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "quorumSignatureSenders",
                     "offset": 0,
@@ -776,7 +776,7 @@
                     "type": "t_mapping(t_uint256,t_struct(AddressSet)3351_storage)"
                 },
                 {
-                    "astId": 16749,
+                    "astId": 16788,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "quorumSignatures",
                     "offset": 0,
@@ -809,20 +809,20 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(StakingChange)16800_storage": {
+        "t_struct(StakingChange)16839_storage": {
             "encoding": "inplace",
             "label": "struct StakingChange",
             "members": [
                 {
-                    "astId": 16795,
+                    "astId": 16834,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "op",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_enum(StakingOperation)16792"
+                    "type": "t_enum(StakingOperation)16831"
                 },
                 {
-                    "astId": 16797,
+                    "astId": 16836,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "payload",
                     "offset": 0,
@@ -830,7 +830,7 @@
                     "type": "t_bytes_storage"
                 },
                 {
-                    "astId": 16799,
+                    "astId": 16838,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "validator",
                     "offset": 0,
@@ -840,12 +840,12 @@
             ],
             "numberOfBytes": "96"
         },
-        "t_struct(StakingChangeLog)16819_storage": {
+        "t_struct(StakingChangeLog)16858_storage": {
             "encoding": "inplace",
             "label": "struct StakingChangeLog",
             "members": [
                 {
-                    "astId": 16809,
+                    "astId": 16848,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "nextConfigurationNumber",
                     "offset": 0,
@@ -853,7 +853,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 16812,
+                    "astId": 16851,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "startConfigurationNumber",
                     "offset": 8,
@@ -861,38 +861,38 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 16818,
+                    "astId": 16857,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "changes",
                     "offset": 0,
                     "slot": "1",
-                    "type": "t_mapping(t_uint64,t_struct(StakingChange)16800_storage)"
+                    "type": "t_mapping(t_uint64,t_struct(StakingChange)16839_storage)"
                 }
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(StorableMsg)16682_storage": {
+        "t_struct(StorableMsg)16721_storage": {
             "encoding": "inplace",
             "label": "struct StorableMsg",
             "members": [
                 {
-                    "astId": 16668,
+                    "astId": 16707,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "from",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(IPCAddress)16900_storage"
+                    "type": "t_struct(IPCAddress)16939_storage"
                 },
                 {
-                    "astId": 16671,
+                    "astId": 16710,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "to",
                     "offset": 0,
                     "slot": "4",
-                    "type": "t_struct(IPCAddress)16900_storage"
+                    "type": "t_struct(IPCAddress)16939_storage"
                 },
                 {
-                    "astId": 16673,
+                    "astId": 16712,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "value",
                     "offset": 0,
@@ -900,7 +900,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16675,
+                    "astId": 16714,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "nonce",
                     "offset": 0,
@@ -908,7 +908,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 16677,
+                    "astId": 16716,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "method",
                     "offset": 8,
@@ -916,7 +916,7 @@
                     "type": "t_bytes4"
                 },
                 {
-                    "astId": 16679,
+                    "astId": 16718,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "params",
                     "offset": 0,
@@ -924,7 +924,7 @@
                     "type": "t_bytes_storage"
                 },
                 {
-                    "astId": 16681,
+                    "astId": 16720,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "fee",
                     "offset": 0,
@@ -934,12 +934,12 @@
             ],
             "numberOfBytes": "384"
         },
-        "t_struct(Subnet)16787_storage": {
+        "t_struct(Subnet)16826_storage": {
             "encoding": "inplace",
             "label": "struct Subnet",
             "members": [
                 {
-                    "astId": 16772,
+                    "astId": 16811,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "stake",
                     "offset": 0,
@@ -947,7 +947,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16774,
+                    "astId": 16813,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "genesisEpoch",
                     "offset": 0,
@@ -955,7 +955,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16776,
+                    "astId": 16815,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "circSupply",
                     "offset": 0,
@@ -963,7 +963,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16778,
+                    "astId": 16817,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "topDownNonce",
                     "offset": 0,
@@ -971,7 +971,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 16780,
+                    "astId": 16819,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "appliedBottomUpNonce",
                     "offset": 8,
@@ -979,30 +979,30 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 16783,
+                    "astId": 16822,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "status",
                     "offset": 16,
                     "slot": "3",
-                    "type": "t_enum(Status)5165"
+                    "type": "t_enum(Status)5184"
                 },
                 {
-                    "astId": 16786,
+                    "astId": 16825,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "id",
                     "offset": 0,
                     "slot": "4",
-                    "type": "t_struct(SubnetID)16770_storage"
+                    "type": "t_struct(SubnetID)16809_storage"
                 }
             ],
             "numberOfBytes": "192"
         },
-        "t_struct(SubnetID)16770_storage": {
+        "t_struct(SubnetID)16809_storage": {
             "encoding": "inplace",
             "label": "struct SubnetID",
             "members": [
                 {
-                    "astId": 16765,
+                    "astId": 16804,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "root",
                     "offset": 0,
@@ -1010,7 +1010,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 16769,
+                    "astId": 16808,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "route",
                     "offset": 0,
@@ -1035,12 +1035,12 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(Validator)16907_storage": {
+        "t_struct(Validator)16946_storage": {
             "encoding": "inplace",
             "label": "struct Validator",
             "members": [
                 {
-                    "astId": 16902,
+                    "astId": 16941,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "weight",
                     "offset": 0,
@@ -1048,7 +1048,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16904,
+                    "astId": 16943,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "addr",
                     "offset": 0,
@@ -1056,7 +1056,7 @@
                     "type": "t_address"
                 },
                 {
-                    "astId": 16906,
+                    "astId": 16945,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "metadata",
                     "offset": 0,
@@ -1066,12 +1066,12 @@
             ],
             "numberOfBytes": "96"
         },
-        "t_struct(ValidatorInfo)16857_storage": {
+        "t_struct(ValidatorInfo)16896_storage": {
             "encoding": "inplace",
             "label": "struct ValidatorInfo",
             "members": [
                 {
-                    "astId": 16849,
+                    "astId": 16888,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "federatedPower",
                     "offset": 0,
@@ -1079,7 +1079,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16851,
+                    "astId": 16890,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "confirmedCollateral",
                     "offset": 0,
@@ -1087,7 +1087,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16853,
+                    "astId": 16892,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "totalCollateral",
                     "offset": 0,
@@ -1095,7 +1095,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16856,
+                    "astId": 16895,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "metadata",
                     "offset": 0,
@@ -1105,20 +1105,20 @@
             ],
             "numberOfBytes": "128"
         },
-        "t_struct(ValidatorSet)16886_storage": {
+        "t_struct(ValidatorSet)16925_storage": {
             "encoding": "inplace",
             "label": "struct ValidatorSet",
             "members": [
                 {
-                    "astId": 16865,
+                    "astId": 16904,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "permissionMode",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_enum(PermissionMode)16861"
+                    "type": "t_enum(PermissionMode)16900"
                 },
                 {
-                    "astId": 16868,
+                    "astId": 16907,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "activeLimit",
                     "offset": 1,
@@ -1126,7 +1126,7 @@
                     "type": "t_uint16"
                 },
                 {
-                    "astId": 16871,
+                    "astId": 16910,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "totalConfirmedCollateral",
                     "offset": 0,
@@ -1134,28 +1134,28 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16877,
+                    "astId": 16916,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "validators",
                     "offset": 0,
                     "slot": "2",
-                    "type": "t_mapping(t_address,t_struct(ValidatorInfo)16857_storage)"
+                    "type": "t_mapping(t_address,t_struct(ValidatorInfo)16896_storage)"
                 },
                 {
-                    "astId": 16881,
+                    "astId": 16920,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "activeValidators",
                     "offset": 0,
                     "slot": "3",
-                    "type": "t_struct(MinPQ)15720_storage"
+                    "type": "t_struct(MinPQ)15759_storage"
                 },
                 {
-                    "astId": 16885,
+                    "astId": 16924,
                     "contract": "src/GatewayDiamond.sol:GatewayDiamond",
                     "label": "waitingValidators",
                     "offset": 0,
                     "slot": "6",
-                    "type": "t_struct(MaxPQ)15102_storage"
+                    "type": "t_struct(MaxPQ)15141_storage"
                 }
             ],
             "numberOfBytes": "288"

--- a/.storage-layouts/SubnetActorDiamond.json
+++ b/.storage-layouts/SubnetActorDiamond.json
@@ -6,7 +6,7 @@
             "label": "s",
             "offset": 0,
             "slot": "0",
-            "type": "t_struct(SubnetActorStorage)14298_storage"
+            "type": "t_struct(SubnetActorStorage)14337_storage"
         }
     ],
     "types": {
@@ -27,8 +27,8 @@
             "label": "bytes32[]",
             "numberOfBytes": "32"
         },
-        "t_array(t_struct(Validator)16907_storage)dyn_storage": {
-            "base": "t_struct(Validator)16907_storage",
+        "t_array(t_struct(Validator)16946_storage)dyn_storage": {
+            "base": "t_struct(Validator)16946_storage",
             "encoding": "dynamic_array",
             "label": "struct Validator[]",
             "numberOfBytes": "32"
@@ -48,17 +48,17 @@
             "label": "bytes",
             "numberOfBytes": "32"
         },
-        "t_enum(ConsensusType)5151": {
+        "t_enum(ConsensusType)5170": {
             "encoding": "inplace",
             "label": "enum ConsensusType",
             "numberOfBytes": "1"
         },
-        "t_enum(PermissionMode)16861": {
+        "t_enum(PermissionMode)16900": {
             "encoding": "inplace",
             "label": "enum PermissionMode",
             "numberOfBytes": "1"
         },
-        "t_enum(StakingOperation)16792": {
+        "t_enum(StakingOperation)16831": {
             "encoding": "inplace",
             "label": "enum StakingOperation",
             "numberOfBytes": "1"
@@ -75,19 +75,19 @@
             "numberOfBytes": "32",
             "value": "t_string_storage"
         },
-        "t_mapping(t_address,t_struct(AddressStakingReleases)16836_storage)": {
+        "t_mapping(t_address,t_struct(AddressStakingReleases)16875_storage)": {
             "encoding": "mapping",
             "key": "t_address",
             "label": "mapping(address => struct AddressStakingReleases)",
             "numberOfBytes": "32",
-            "value": "t_struct(AddressStakingReleases)16836_storage"
+            "value": "t_struct(AddressStakingReleases)16875_storage"
         },
-        "t_mapping(t_address,t_struct(ValidatorInfo)16857_storage)": {
+        "t_mapping(t_address,t_struct(ValidatorInfo)16896_storage)": {
             "encoding": "mapping",
             "key": "t_address",
             "label": "mapping(address => struct ValidatorInfo)",
             "numberOfBytes": "32",
-            "value": "t_struct(ValidatorInfo)16857_storage"
+            "value": "t_struct(ValidatorInfo)16896_storage"
         },
         "t_mapping(t_address,t_uint16)": {
             "encoding": "mapping",
@@ -117,12 +117,12 @@
             "numberOfBytes": "32",
             "value": "t_address"
         },
-        "t_mapping(t_uint16,t_struct(StakingRelease)16826_storage)": {
+        "t_mapping(t_uint16,t_struct(StakingRelease)16865_storage)": {
             "encoding": "mapping",
             "key": "t_uint16",
             "label": "mapping(uint16 => struct StakingRelease)",
             "numberOfBytes": "32",
-            "value": "t_struct(StakingRelease)16826_storage"
+            "value": "t_struct(StakingRelease)16865_storage"
         },
         "t_mapping(t_uint256,t_struct(AddressSet)3351_storage)": {
             "encoding": "mapping",
@@ -131,19 +131,19 @@
             "numberOfBytes": "32",
             "value": "t_struct(AddressSet)3351_storage"
         },
-        "t_mapping(t_uint256,t_struct(BottomUpCheckpoint)16623_storage)": {
+        "t_mapping(t_uint256,t_struct(BottomUpCheckpoint)16662_storage)": {
             "encoding": "mapping",
             "key": "t_uint256",
             "label": "mapping(uint256 => struct BottomUpCheckpoint)",
             "numberOfBytes": "32",
-            "value": "t_struct(BottomUpCheckpoint)16623_storage"
+            "value": "t_struct(BottomUpCheckpoint)16662_storage"
         },
-        "t_mapping(t_uint64,t_struct(StakingChange)16800_storage)": {
+        "t_mapping(t_uint64,t_struct(StakingChange)16839_storage)": {
             "encoding": "mapping",
             "key": "t_uint64",
             "label": "mapping(uint64 => struct StakingChange)",
             "numberOfBytes": "32",
-            "value": "t_struct(StakingChange)16800_storage"
+            "value": "t_struct(StakingChange)16839_storage"
         },
         "t_string_storage": {
             "encoding": "bytes",
@@ -165,12 +165,12 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(AddressStakingReleases)16836_storage": {
+        "t_struct(AddressStakingReleases)16875_storage": {
             "encoding": "inplace",
             "label": "struct AddressStakingReleases",
             "members": [
                 {
-                    "astId": 16828,
+                    "astId": 16867,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "length",
                     "offset": 0,
@@ -178,7 +178,7 @@
                     "type": "t_uint16"
                 },
                 {
-                    "astId": 16830,
+                    "astId": 16869,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "startIdx",
                     "offset": 2,
@@ -186,30 +186,30 @@
                     "type": "t_uint16"
                 },
                 {
-                    "astId": 16835,
+                    "astId": 16874,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "releases",
                     "offset": 0,
                     "slot": "1",
-                    "type": "t_mapping(t_uint16,t_struct(StakingRelease)16826_storage)"
+                    "type": "t_mapping(t_uint16,t_struct(StakingRelease)16865_storage)"
                 }
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(BottomUpCheckpoint)16623_storage": {
+        "t_struct(BottomUpCheckpoint)16662_storage": {
             "encoding": "inplace",
             "label": "struct BottomUpCheckpoint",
             "members": [
                 {
-                    "astId": 16613,
+                    "astId": 16652,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "subnetID",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(SubnetID)16770_storage"
+                    "type": "t_struct(SubnetID)16809_storage"
                 },
                 {
-                    "astId": 16616,
+                    "astId": 16655,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "blockHeight",
                     "offset": 0,
@@ -217,7 +217,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16619,
+                    "astId": 16658,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "blockHash",
                     "offset": 0,
@@ -225,7 +225,7 @@
                     "type": "t_bytes32"
                 },
                 {
-                    "astId": 16622,
+                    "astId": 16661,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "nextConfigurationNumber",
                     "offset": 0,
@@ -235,12 +235,12 @@
             ],
             "numberOfBytes": "160"
         },
-        "t_struct(BottomUpMsgBatchInfo)16641_storage": {
+        "t_struct(BottomUpMsgBatchInfo)16680_storage": {
             "encoding": "inplace",
             "label": "struct BottomUpMsgBatchInfo",
             "members": [
                 {
-                    "astId": 16638,
+                    "astId": 16677,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "blockHeight",
                     "offset": 0,
@@ -248,7 +248,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16640,
+                    "astId": 16679,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "hash",
                     "offset": 0,
@@ -258,42 +258,42 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(MaxPQ)15102_storage": {
+        "t_struct(MaxPQ)15141_storage": {
             "encoding": "inplace",
             "label": "struct MaxPQ",
             "members": [
                 {
-                    "astId": 15101,
+                    "astId": 15140,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "inner",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(PQ)16349_storage"
+                    "type": "t_struct(PQ)16388_storage"
                 }
             ],
             "numberOfBytes": "96"
         },
-        "t_struct(MinPQ)15720_storage": {
+        "t_struct(MinPQ)15759_storage": {
             "encoding": "inplace",
             "label": "struct MinPQ",
             "members": [
                 {
-                    "astId": 15719,
+                    "astId": 15758,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "inner",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(PQ)16349_storage"
+                    "type": "t_struct(PQ)16388_storage"
                 }
             ],
             "numberOfBytes": "96"
         },
-        "t_struct(PQ)16349_storage": {
+        "t_struct(PQ)16388_storage": {
             "encoding": "inplace",
             "label": "struct PQ",
             "members": [
                 {
-                    "astId": 16338,
+                    "astId": 16377,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "size",
                     "offset": 0,
@@ -301,7 +301,7 @@
                     "type": "t_uint16"
                 },
                 {
-                    "astId": 16343,
+                    "astId": 16382,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "addressToPos",
                     "offset": 0,
@@ -309,7 +309,7 @@
                     "type": "t_mapping(t_address,t_uint16)"
                 },
                 {
-                    "astId": 16348,
+                    "astId": 16387,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "posToAddress",
                     "offset": 0,
@@ -319,12 +319,12 @@
             ],
             "numberOfBytes": "96"
         },
-        "t_struct(RelayerRewardsInfo)16659_storage": {
+        "t_struct(RelayerRewardsInfo)16698_storage": {
             "encoding": "inplace",
             "label": "struct RelayerRewardsInfo",
             "members": [
                 {
-                    "astId": 16646,
+                    "astId": 16685,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "rewards",
                     "offset": 0,
@@ -332,7 +332,7 @@
                     "type": "t_mapping(t_address,t_uint256)"
                 },
                 {
-                    "astId": 16652,
+                    "astId": 16691,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "checkpointRewarded",
                     "offset": 0,
@@ -340,7 +340,7 @@
                     "type": "t_mapping(t_uint256,t_struct(AddressSet)3351_storage)"
                 },
                 {
-                    "astId": 16658,
+                    "astId": 16697,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "batchRewarded",
                     "offset": 0,
@@ -373,20 +373,20 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(StakingChange)16800_storage": {
+        "t_struct(StakingChange)16839_storage": {
             "encoding": "inplace",
             "label": "struct StakingChange",
             "members": [
                 {
-                    "astId": 16795,
+                    "astId": 16834,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "op",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_enum(StakingOperation)16792"
+                    "type": "t_enum(StakingOperation)16831"
                 },
                 {
-                    "astId": 16797,
+                    "astId": 16836,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "payload",
                     "offset": 0,
@@ -394,7 +394,7 @@
                     "type": "t_bytes_storage"
                 },
                 {
-                    "astId": 16799,
+                    "astId": 16838,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "validator",
                     "offset": 0,
@@ -404,12 +404,12 @@
             ],
             "numberOfBytes": "96"
         },
-        "t_struct(StakingChangeLog)16819_storage": {
+        "t_struct(StakingChangeLog)16858_storage": {
             "encoding": "inplace",
             "label": "struct StakingChangeLog",
             "members": [
                 {
-                    "astId": 16809,
+                    "astId": 16848,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "nextConfigurationNumber",
                     "offset": 0,
@@ -417,7 +417,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 16812,
+                    "astId": 16851,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "startConfigurationNumber",
                     "offset": 8,
@@ -425,22 +425,22 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 16818,
+                    "astId": 16857,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "changes",
                     "offset": 0,
                     "slot": "1",
-                    "type": "t_mapping(t_uint64,t_struct(StakingChange)16800_storage)"
+                    "type": "t_mapping(t_uint64,t_struct(StakingChange)16839_storage)"
                 }
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(StakingRelease)16826_storage": {
+        "t_struct(StakingRelease)16865_storage": {
             "encoding": "inplace",
             "label": "struct StakingRelease",
             "members": [
                 {
-                    "astId": 16822,
+                    "astId": 16861,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "releaseAt",
                     "offset": 0,
@@ -448,7 +448,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16825,
+                    "astId": 16864,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "amount",
                     "offset": 0,
@@ -458,12 +458,12 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(StakingReleaseQueue)16846_storage": {
+        "t_struct(StakingReleaseQueue)16885_storage": {
             "encoding": "inplace",
             "label": "struct StakingReleaseQueue",
             "members": [
                 {
-                    "astId": 16839,
+                    "astId": 16878,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "lockingDuration",
                     "offset": 0,
@@ -471,38 +471,38 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16845,
+                    "astId": 16884,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "releases",
                     "offset": 0,
                     "slot": "1",
-                    "type": "t_mapping(t_address,t_struct(AddressStakingReleases)16836_storage)"
+                    "type": "t_mapping(t_address,t_struct(AddressStakingReleases)16875_storage)"
                 }
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(SubnetActorStorage)14298_storage": {
+        "t_struct(SubnetActorStorage)14337_storage": {
             "encoding": "inplace",
             "label": "struct SubnetActorStorage",
             "members": [
                 {
-                    "astId": 14205,
+                    "astId": 14244,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "committedCheckpoints",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_mapping(t_uint256,t_struct(BottomUpCheckpoint)16623_storage)"
+                    "type": "t_mapping(t_uint256,t_struct(BottomUpCheckpoint)16662_storage)"
                 },
                 {
-                    "astId": 14210,
+                    "astId": 14249,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "genesisValidators",
                     "offset": 0,
                     "slot": "1",
-                    "type": "t_array(t_struct(Validator)16907_storage)dyn_storage"
+                    "type": "t_array(t_struct(Validator)16946_storage)dyn_storage"
                 },
                 {
-                    "astId": 14213,
+                    "astId": 14252,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "genesisCircSupply",
                     "offset": 0,
@@ -510,7 +510,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 14218,
+                    "astId": 14257,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "genesisBalance",
                     "offset": 0,
@@ -518,7 +518,7 @@
                     "type": "t_mapping(t_address,t_uint256)"
                 },
                 {
-                    "astId": 14222,
+                    "astId": 14261,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "genesisBalanceKeys",
                     "offset": 0,
@@ -526,7 +526,7 @@
                     "type": "t_array(t_address)dyn_storage"
                 },
                 {
-                    "astId": 14225,
+                    "astId": 14264,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "lastBottomUpCheckpointHeight",
                     "offset": 0,
@@ -534,15 +534,15 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 14229,
+                    "astId": 14268,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "lastBottomUpBatch",
                     "offset": 0,
                     "slot": "6",
-                    "type": "t_struct(BottomUpMsgBatchInfo)16641_storage"
+                    "type": "t_struct(BottomUpMsgBatchInfo)16680_storage"
                 },
                 {
-                    "astId": 14232,
+                    "astId": 14271,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "bottomUpMsgBatchPeriod",
                     "offset": 0,
@@ -550,7 +550,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 14235,
+                    "astId": 14274,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "maxMsgsPerBottomUpBatch",
                     "offset": 0,
@@ -558,7 +558,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 14238,
+                    "astId": 14277,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "minActivationCollateral",
                     "offset": 0,
@@ -566,7 +566,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 14241,
+                    "astId": 14280,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "bottomUpCheckPeriod",
                     "offset": 0,
@@ -574,7 +574,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 14244,
+                    "astId": 14283,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "minValidators",
                     "offset": 0,
@@ -582,7 +582,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 14246,
+                    "astId": 14285,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "currentSubnetHash",
                     "offset": 0,
@@ -590,7 +590,7 @@
                     "type": "t_bytes32"
                 },
                 {
-                    "astId": 14249,
+                    "astId": 14288,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "ipcGatewayAddr",
                     "offset": 0,
@@ -598,7 +598,7 @@
                     "type": "t_address"
                 },
                 {
-                    "astId": 14252,
+                    "astId": 14291,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "majorityPercentage",
                     "offset": 20,
@@ -606,7 +606,7 @@
                     "type": "t_uint8"
                 },
                 {
-                    "astId": 14255,
+                    "astId": 14294,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "minCrossMsgFee",
                     "offset": 0,
@@ -614,23 +614,23 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 14259,
+                    "astId": 14298,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "parentId",
                     "offset": 0,
                     "slot": "16",
-                    "type": "t_struct(SubnetID)16770_storage"
+                    "type": "t_struct(SubnetID)16809_storage"
                 },
                 {
-                    "astId": 14263,
+                    "astId": 14302,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "consensus",
                     "offset": 0,
                     "slot": "18",
-                    "type": "t_enum(ConsensusType)5151"
+                    "type": "t_enum(ConsensusType)5170"
                 },
                 {
-                    "astId": 14266,
+                    "astId": 14305,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "bootstrapped",
                     "offset": 1,
@@ -638,7 +638,7 @@
                     "type": "t_bool"
                 },
                 {
-                    "astId": 14269,
+                    "astId": 14308,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "killed",
                     "offset": 2,
@@ -646,31 +646,31 @@
                     "type": "t_bool"
                 },
                 {
-                    "astId": 14273,
+                    "astId": 14312,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "validatorSet",
                     "offset": 0,
                     "slot": "19",
-                    "type": "t_struct(ValidatorSet)16886_storage"
+                    "type": "t_struct(ValidatorSet)16925_storage"
                 },
                 {
-                    "astId": 14277,
+                    "astId": 14316,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "changeSet",
                     "offset": 0,
                     "slot": "28",
-                    "type": "t_struct(StakingChangeLog)16819_storage"
+                    "type": "t_struct(StakingChangeLog)16858_storage"
                 },
                 {
-                    "astId": 14281,
+                    "astId": 14320,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "releaseQueue",
                     "offset": 0,
                     "slot": "30",
-                    "type": "t_struct(StakingReleaseQueue)16846_storage"
+                    "type": "t_struct(StakingReleaseQueue)16885_storage"
                 },
                 {
-                    "astId": 14284,
+                    "astId": 14323,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "powerScale",
                     "offset": 0,
@@ -678,15 +678,15 @@
                     "type": "t_int8"
                 },
                 {
-                    "astId": 14288,
+                    "astId": 14327,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "relayerRewards",
                     "offset": 0,
                     "slot": "33",
-                    "type": "t_struct(RelayerRewardsInfo)16659_storage"
+                    "type": "t_struct(RelayerRewardsInfo)16698_storage"
                 },
                 {
-                    "astId": 14293,
+                    "astId": 14332,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "bootstrapNodes",
                     "offset": 0,
@@ -694,7 +694,7 @@
                     "type": "t_mapping(t_address,t_string_storage)"
                 },
                 {
-                    "astId": 14297,
+                    "astId": 14336,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "bootstrapOwners",
                     "offset": 0,
@@ -704,12 +704,12 @@
             ],
             "numberOfBytes": "1248"
         },
-        "t_struct(SubnetID)16770_storage": {
+        "t_struct(SubnetID)16809_storage": {
             "encoding": "inplace",
             "label": "struct SubnetID",
             "members": [
                 {
-                    "astId": 16765,
+                    "astId": 16804,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "root",
                     "offset": 0,
@@ -717,7 +717,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 16769,
+                    "astId": 16808,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "route",
                     "offset": 0,
@@ -727,12 +727,12 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(Validator)16907_storage": {
+        "t_struct(Validator)16946_storage": {
             "encoding": "inplace",
             "label": "struct Validator",
             "members": [
                 {
-                    "astId": 16902,
+                    "astId": 16941,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "weight",
                     "offset": 0,
@@ -740,7 +740,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16904,
+                    "astId": 16943,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "addr",
                     "offset": 0,
@@ -748,7 +748,7 @@
                     "type": "t_address"
                 },
                 {
-                    "astId": 16906,
+                    "astId": 16945,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "metadata",
                     "offset": 0,
@@ -758,12 +758,12 @@
             ],
             "numberOfBytes": "96"
         },
-        "t_struct(ValidatorInfo)16857_storage": {
+        "t_struct(ValidatorInfo)16896_storage": {
             "encoding": "inplace",
             "label": "struct ValidatorInfo",
             "members": [
                 {
-                    "astId": 16849,
+                    "astId": 16888,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "federatedPower",
                     "offset": 0,
@@ -771,7 +771,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16851,
+                    "astId": 16890,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "confirmedCollateral",
                     "offset": 0,
@@ -779,7 +779,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16853,
+                    "astId": 16892,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "totalCollateral",
                     "offset": 0,
@@ -787,7 +787,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16856,
+                    "astId": 16895,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "metadata",
                     "offset": 0,
@@ -797,20 +797,20 @@
             ],
             "numberOfBytes": "128"
         },
-        "t_struct(ValidatorSet)16886_storage": {
+        "t_struct(ValidatorSet)16925_storage": {
             "encoding": "inplace",
             "label": "struct ValidatorSet",
             "members": [
                 {
-                    "astId": 16865,
+                    "astId": 16904,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "permissionMode",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_enum(PermissionMode)16861"
+                    "type": "t_enum(PermissionMode)16900"
                 },
                 {
-                    "astId": 16868,
+                    "astId": 16907,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "activeLimit",
                     "offset": 1,
@@ -818,7 +818,7 @@
                     "type": "t_uint16"
                 },
                 {
-                    "astId": 16871,
+                    "astId": 16910,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "totalConfirmedCollateral",
                     "offset": 0,
@@ -826,28 +826,28 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16877,
+                    "astId": 16916,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "validators",
                     "offset": 0,
                     "slot": "2",
-                    "type": "t_mapping(t_address,t_struct(ValidatorInfo)16857_storage)"
+                    "type": "t_mapping(t_address,t_struct(ValidatorInfo)16896_storage)"
                 },
                 {
-                    "astId": 16881,
+                    "astId": 16920,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "activeValidators",
                     "offset": 0,
                     "slot": "3",
-                    "type": "t_struct(MinPQ)15720_storage"
+                    "type": "t_struct(MinPQ)15759_storage"
                 },
                 {
-                    "astId": 16885,
+                    "astId": 16924,
                     "contract": "src/SubnetActorDiamond.sol:SubnetActorDiamond",
                     "label": "waitingValidators",
                     "offset": 0,
                     "slot": "6",
-                    "type": "t_struct(MaxPQ)15102_storage"
+                    "type": "t_struct(MaxPQ)15141_storage"
                 }
             ],
             "numberOfBytes": "288"

--- a/.storage-layouts/SubnetActorModifiers.json
+++ b/.storage-layouts/SubnetActorModifiers.json
@@ -1,12 +1,12 @@
 {
     "storage": [
         {
-            "astId": 14312,
+            "astId": 14351,
             "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
             "label": "s",
             "offset": 0,
             "slot": "0",
-            "type": "t_struct(SubnetActorStorage)14298_storage"
+            "type": "t_struct(SubnetActorStorage)14337_storage"
         }
     ],
     "types": {
@@ -27,8 +27,8 @@
             "label": "bytes32[]",
             "numberOfBytes": "32"
         },
-        "t_array(t_struct(Validator)16907_storage)dyn_storage": {
-            "base": "t_struct(Validator)16907_storage",
+        "t_array(t_struct(Validator)16946_storage)dyn_storage": {
+            "base": "t_struct(Validator)16946_storage",
             "encoding": "dynamic_array",
             "label": "struct Validator[]",
             "numberOfBytes": "32"
@@ -48,17 +48,17 @@
             "label": "bytes",
             "numberOfBytes": "32"
         },
-        "t_enum(ConsensusType)5151": {
+        "t_enum(ConsensusType)5170": {
             "encoding": "inplace",
             "label": "enum ConsensusType",
             "numberOfBytes": "1"
         },
-        "t_enum(PermissionMode)16861": {
+        "t_enum(PermissionMode)16900": {
             "encoding": "inplace",
             "label": "enum PermissionMode",
             "numberOfBytes": "1"
         },
-        "t_enum(StakingOperation)16792": {
+        "t_enum(StakingOperation)16831": {
             "encoding": "inplace",
             "label": "enum StakingOperation",
             "numberOfBytes": "1"
@@ -75,19 +75,19 @@
             "numberOfBytes": "32",
             "value": "t_string_storage"
         },
-        "t_mapping(t_address,t_struct(AddressStakingReleases)16836_storage)": {
+        "t_mapping(t_address,t_struct(AddressStakingReleases)16875_storage)": {
             "encoding": "mapping",
             "key": "t_address",
             "label": "mapping(address => struct AddressStakingReleases)",
             "numberOfBytes": "32",
-            "value": "t_struct(AddressStakingReleases)16836_storage"
+            "value": "t_struct(AddressStakingReleases)16875_storage"
         },
-        "t_mapping(t_address,t_struct(ValidatorInfo)16857_storage)": {
+        "t_mapping(t_address,t_struct(ValidatorInfo)16896_storage)": {
             "encoding": "mapping",
             "key": "t_address",
             "label": "mapping(address => struct ValidatorInfo)",
             "numberOfBytes": "32",
-            "value": "t_struct(ValidatorInfo)16857_storage"
+            "value": "t_struct(ValidatorInfo)16896_storage"
         },
         "t_mapping(t_address,t_uint16)": {
             "encoding": "mapping",
@@ -117,12 +117,12 @@
             "numberOfBytes": "32",
             "value": "t_address"
         },
-        "t_mapping(t_uint16,t_struct(StakingRelease)16826_storage)": {
+        "t_mapping(t_uint16,t_struct(StakingRelease)16865_storage)": {
             "encoding": "mapping",
             "key": "t_uint16",
             "label": "mapping(uint16 => struct StakingRelease)",
             "numberOfBytes": "32",
-            "value": "t_struct(StakingRelease)16826_storage"
+            "value": "t_struct(StakingRelease)16865_storage"
         },
         "t_mapping(t_uint256,t_struct(AddressSet)3351_storage)": {
             "encoding": "mapping",
@@ -131,19 +131,19 @@
             "numberOfBytes": "32",
             "value": "t_struct(AddressSet)3351_storage"
         },
-        "t_mapping(t_uint256,t_struct(BottomUpCheckpoint)16623_storage)": {
+        "t_mapping(t_uint256,t_struct(BottomUpCheckpoint)16662_storage)": {
             "encoding": "mapping",
             "key": "t_uint256",
             "label": "mapping(uint256 => struct BottomUpCheckpoint)",
             "numberOfBytes": "32",
-            "value": "t_struct(BottomUpCheckpoint)16623_storage"
+            "value": "t_struct(BottomUpCheckpoint)16662_storage"
         },
-        "t_mapping(t_uint64,t_struct(StakingChange)16800_storage)": {
+        "t_mapping(t_uint64,t_struct(StakingChange)16839_storage)": {
             "encoding": "mapping",
             "key": "t_uint64",
             "label": "mapping(uint64 => struct StakingChange)",
             "numberOfBytes": "32",
-            "value": "t_struct(StakingChange)16800_storage"
+            "value": "t_struct(StakingChange)16839_storage"
         },
         "t_string_storage": {
             "encoding": "bytes",
@@ -165,12 +165,12 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(AddressStakingReleases)16836_storage": {
+        "t_struct(AddressStakingReleases)16875_storage": {
             "encoding": "inplace",
             "label": "struct AddressStakingReleases",
             "members": [
                 {
-                    "astId": 16828,
+                    "astId": 16867,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "length",
                     "offset": 0,
@@ -178,7 +178,7 @@
                     "type": "t_uint16"
                 },
                 {
-                    "astId": 16830,
+                    "astId": 16869,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "startIdx",
                     "offset": 2,
@@ -186,30 +186,30 @@
                     "type": "t_uint16"
                 },
                 {
-                    "astId": 16835,
+                    "astId": 16874,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "releases",
                     "offset": 0,
                     "slot": "1",
-                    "type": "t_mapping(t_uint16,t_struct(StakingRelease)16826_storage)"
+                    "type": "t_mapping(t_uint16,t_struct(StakingRelease)16865_storage)"
                 }
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(BottomUpCheckpoint)16623_storage": {
+        "t_struct(BottomUpCheckpoint)16662_storage": {
             "encoding": "inplace",
             "label": "struct BottomUpCheckpoint",
             "members": [
                 {
-                    "astId": 16613,
+                    "astId": 16652,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "subnetID",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(SubnetID)16770_storage"
+                    "type": "t_struct(SubnetID)16809_storage"
                 },
                 {
-                    "astId": 16616,
+                    "astId": 16655,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "blockHeight",
                     "offset": 0,
@@ -217,7 +217,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16619,
+                    "astId": 16658,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "blockHash",
                     "offset": 0,
@@ -225,7 +225,7 @@
                     "type": "t_bytes32"
                 },
                 {
-                    "astId": 16622,
+                    "astId": 16661,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "nextConfigurationNumber",
                     "offset": 0,
@@ -235,12 +235,12 @@
             ],
             "numberOfBytes": "160"
         },
-        "t_struct(BottomUpMsgBatchInfo)16641_storage": {
+        "t_struct(BottomUpMsgBatchInfo)16680_storage": {
             "encoding": "inplace",
             "label": "struct BottomUpMsgBatchInfo",
             "members": [
                 {
-                    "astId": 16638,
+                    "astId": 16677,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "blockHeight",
                     "offset": 0,
@@ -248,7 +248,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16640,
+                    "astId": 16679,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "hash",
                     "offset": 0,
@@ -258,42 +258,42 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(MaxPQ)15102_storage": {
+        "t_struct(MaxPQ)15141_storage": {
             "encoding": "inplace",
             "label": "struct MaxPQ",
             "members": [
                 {
-                    "astId": 15101,
+                    "astId": 15140,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "inner",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(PQ)16349_storage"
+                    "type": "t_struct(PQ)16388_storage"
                 }
             ],
             "numberOfBytes": "96"
         },
-        "t_struct(MinPQ)15720_storage": {
+        "t_struct(MinPQ)15759_storage": {
             "encoding": "inplace",
             "label": "struct MinPQ",
             "members": [
                 {
-                    "astId": 15719,
+                    "astId": 15758,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "inner",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_struct(PQ)16349_storage"
+                    "type": "t_struct(PQ)16388_storage"
                 }
             ],
             "numberOfBytes": "96"
         },
-        "t_struct(PQ)16349_storage": {
+        "t_struct(PQ)16388_storage": {
             "encoding": "inplace",
             "label": "struct PQ",
             "members": [
                 {
-                    "astId": 16338,
+                    "astId": 16377,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "size",
                     "offset": 0,
@@ -301,7 +301,7 @@
                     "type": "t_uint16"
                 },
                 {
-                    "astId": 16343,
+                    "astId": 16382,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "addressToPos",
                     "offset": 0,
@@ -309,7 +309,7 @@
                     "type": "t_mapping(t_address,t_uint16)"
                 },
                 {
-                    "astId": 16348,
+                    "astId": 16387,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "posToAddress",
                     "offset": 0,
@@ -319,12 +319,12 @@
             ],
             "numberOfBytes": "96"
         },
-        "t_struct(RelayerRewardsInfo)16659_storage": {
+        "t_struct(RelayerRewardsInfo)16698_storage": {
             "encoding": "inplace",
             "label": "struct RelayerRewardsInfo",
             "members": [
                 {
-                    "astId": 16646,
+                    "astId": 16685,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "rewards",
                     "offset": 0,
@@ -332,7 +332,7 @@
                     "type": "t_mapping(t_address,t_uint256)"
                 },
                 {
-                    "astId": 16652,
+                    "astId": 16691,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "checkpointRewarded",
                     "offset": 0,
@@ -340,7 +340,7 @@
                     "type": "t_mapping(t_uint256,t_struct(AddressSet)3351_storage)"
                 },
                 {
-                    "astId": 16658,
+                    "astId": 16697,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "batchRewarded",
                     "offset": 0,
@@ -373,20 +373,20 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(StakingChange)16800_storage": {
+        "t_struct(StakingChange)16839_storage": {
             "encoding": "inplace",
             "label": "struct StakingChange",
             "members": [
                 {
-                    "astId": 16795,
+                    "astId": 16834,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "op",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_enum(StakingOperation)16792"
+                    "type": "t_enum(StakingOperation)16831"
                 },
                 {
-                    "astId": 16797,
+                    "astId": 16836,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "payload",
                     "offset": 0,
@@ -394,7 +394,7 @@
                     "type": "t_bytes_storage"
                 },
                 {
-                    "astId": 16799,
+                    "astId": 16838,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "validator",
                     "offset": 0,
@@ -404,12 +404,12 @@
             ],
             "numberOfBytes": "96"
         },
-        "t_struct(StakingChangeLog)16819_storage": {
+        "t_struct(StakingChangeLog)16858_storage": {
             "encoding": "inplace",
             "label": "struct StakingChangeLog",
             "members": [
                 {
-                    "astId": 16809,
+                    "astId": 16848,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "nextConfigurationNumber",
                     "offset": 0,
@@ -417,7 +417,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 16812,
+                    "astId": 16851,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "startConfigurationNumber",
                     "offset": 8,
@@ -425,22 +425,22 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 16818,
+                    "astId": 16857,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "changes",
                     "offset": 0,
                     "slot": "1",
-                    "type": "t_mapping(t_uint64,t_struct(StakingChange)16800_storage)"
+                    "type": "t_mapping(t_uint64,t_struct(StakingChange)16839_storage)"
                 }
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(StakingRelease)16826_storage": {
+        "t_struct(StakingRelease)16865_storage": {
             "encoding": "inplace",
             "label": "struct StakingRelease",
             "members": [
                 {
-                    "astId": 16822,
+                    "astId": 16861,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "releaseAt",
                     "offset": 0,
@@ -448,7 +448,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16825,
+                    "astId": 16864,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "amount",
                     "offset": 0,
@@ -458,12 +458,12 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(StakingReleaseQueue)16846_storage": {
+        "t_struct(StakingReleaseQueue)16885_storage": {
             "encoding": "inplace",
             "label": "struct StakingReleaseQueue",
             "members": [
                 {
-                    "astId": 16839,
+                    "astId": 16878,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "lockingDuration",
                     "offset": 0,
@@ -471,38 +471,38 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16845,
+                    "astId": 16884,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "releases",
                     "offset": 0,
                     "slot": "1",
-                    "type": "t_mapping(t_address,t_struct(AddressStakingReleases)16836_storage)"
+                    "type": "t_mapping(t_address,t_struct(AddressStakingReleases)16875_storage)"
                 }
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(SubnetActorStorage)14298_storage": {
+        "t_struct(SubnetActorStorage)14337_storage": {
             "encoding": "inplace",
             "label": "struct SubnetActorStorage",
             "members": [
                 {
-                    "astId": 14205,
+                    "astId": 14244,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "committedCheckpoints",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_mapping(t_uint256,t_struct(BottomUpCheckpoint)16623_storage)"
+                    "type": "t_mapping(t_uint256,t_struct(BottomUpCheckpoint)16662_storage)"
                 },
                 {
-                    "astId": 14210,
+                    "astId": 14249,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "genesisValidators",
                     "offset": 0,
                     "slot": "1",
-                    "type": "t_array(t_struct(Validator)16907_storage)dyn_storage"
+                    "type": "t_array(t_struct(Validator)16946_storage)dyn_storage"
                 },
                 {
-                    "astId": 14213,
+                    "astId": 14252,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "genesisCircSupply",
                     "offset": 0,
@@ -510,7 +510,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 14218,
+                    "astId": 14257,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "genesisBalance",
                     "offset": 0,
@@ -518,7 +518,7 @@
                     "type": "t_mapping(t_address,t_uint256)"
                 },
                 {
-                    "astId": 14222,
+                    "astId": 14261,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "genesisBalanceKeys",
                     "offset": 0,
@@ -526,7 +526,7 @@
                     "type": "t_array(t_address)dyn_storage"
                 },
                 {
-                    "astId": 14225,
+                    "astId": 14264,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "lastBottomUpCheckpointHeight",
                     "offset": 0,
@@ -534,15 +534,15 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 14229,
+                    "astId": 14268,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "lastBottomUpBatch",
                     "offset": 0,
                     "slot": "6",
-                    "type": "t_struct(BottomUpMsgBatchInfo)16641_storage"
+                    "type": "t_struct(BottomUpMsgBatchInfo)16680_storage"
                 },
                 {
-                    "astId": 14232,
+                    "astId": 14271,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "bottomUpMsgBatchPeriod",
                     "offset": 0,
@@ -550,7 +550,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 14235,
+                    "astId": 14274,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "maxMsgsPerBottomUpBatch",
                     "offset": 0,
@@ -558,7 +558,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 14238,
+                    "astId": 14277,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "minActivationCollateral",
                     "offset": 0,
@@ -566,7 +566,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 14241,
+                    "astId": 14280,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "bottomUpCheckPeriod",
                     "offset": 0,
@@ -574,7 +574,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 14244,
+                    "astId": 14283,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "minValidators",
                     "offset": 0,
@@ -582,7 +582,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 14246,
+                    "astId": 14285,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "currentSubnetHash",
                     "offset": 0,
@@ -590,7 +590,7 @@
                     "type": "t_bytes32"
                 },
                 {
-                    "astId": 14249,
+                    "astId": 14288,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "ipcGatewayAddr",
                     "offset": 0,
@@ -598,7 +598,7 @@
                     "type": "t_address"
                 },
                 {
-                    "astId": 14252,
+                    "astId": 14291,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "majorityPercentage",
                     "offset": 20,
@@ -606,7 +606,7 @@
                     "type": "t_uint8"
                 },
                 {
-                    "astId": 14255,
+                    "astId": 14294,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "minCrossMsgFee",
                     "offset": 0,
@@ -614,23 +614,23 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 14259,
+                    "astId": 14298,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "parentId",
                     "offset": 0,
                     "slot": "16",
-                    "type": "t_struct(SubnetID)16770_storage"
+                    "type": "t_struct(SubnetID)16809_storage"
                 },
                 {
-                    "astId": 14263,
+                    "astId": 14302,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "consensus",
                     "offset": 0,
                     "slot": "18",
-                    "type": "t_enum(ConsensusType)5151"
+                    "type": "t_enum(ConsensusType)5170"
                 },
                 {
-                    "astId": 14266,
+                    "astId": 14305,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "bootstrapped",
                     "offset": 1,
@@ -638,7 +638,7 @@
                     "type": "t_bool"
                 },
                 {
-                    "astId": 14269,
+                    "astId": 14308,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "killed",
                     "offset": 2,
@@ -646,31 +646,31 @@
                     "type": "t_bool"
                 },
                 {
-                    "astId": 14273,
+                    "astId": 14312,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "validatorSet",
                     "offset": 0,
                     "slot": "19",
-                    "type": "t_struct(ValidatorSet)16886_storage"
+                    "type": "t_struct(ValidatorSet)16925_storage"
                 },
                 {
-                    "astId": 14277,
+                    "astId": 14316,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "changeSet",
                     "offset": 0,
                     "slot": "28",
-                    "type": "t_struct(StakingChangeLog)16819_storage"
+                    "type": "t_struct(StakingChangeLog)16858_storage"
                 },
                 {
-                    "astId": 14281,
+                    "astId": 14320,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "releaseQueue",
                     "offset": 0,
                     "slot": "30",
-                    "type": "t_struct(StakingReleaseQueue)16846_storage"
+                    "type": "t_struct(StakingReleaseQueue)16885_storage"
                 },
                 {
-                    "astId": 14284,
+                    "astId": 14323,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "powerScale",
                     "offset": 0,
@@ -678,15 +678,15 @@
                     "type": "t_int8"
                 },
                 {
-                    "astId": 14288,
+                    "astId": 14327,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "relayerRewards",
                     "offset": 0,
                     "slot": "33",
-                    "type": "t_struct(RelayerRewardsInfo)16659_storage"
+                    "type": "t_struct(RelayerRewardsInfo)16698_storage"
                 },
                 {
-                    "astId": 14293,
+                    "astId": 14332,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "bootstrapNodes",
                     "offset": 0,
@@ -694,7 +694,7 @@
                     "type": "t_mapping(t_address,t_string_storage)"
                 },
                 {
-                    "astId": 14297,
+                    "astId": 14336,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "bootstrapOwners",
                     "offset": 0,
@@ -704,12 +704,12 @@
             ],
             "numberOfBytes": "1248"
         },
-        "t_struct(SubnetID)16770_storage": {
+        "t_struct(SubnetID)16809_storage": {
             "encoding": "inplace",
             "label": "struct SubnetID",
             "members": [
                 {
-                    "astId": 16765,
+                    "astId": 16804,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "root",
                     "offset": 0,
@@ -717,7 +717,7 @@
                     "type": "t_uint64"
                 },
                 {
-                    "astId": 16769,
+                    "astId": 16808,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "route",
                     "offset": 0,
@@ -727,12 +727,12 @@
             ],
             "numberOfBytes": "64"
         },
-        "t_struct(Validator)16907_storage": {
+        "t_struct(Validator)16946_storage": {
             "encoding": "inplace",
             "label": "struct Validator",
             "members": [
                 {
-                    "astId": 16902,
+                    "astId": 16941,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "weight",
                     "offset": 0,
@@ -740,7 +740,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16904,
+                    "astId": 16943,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "addr",
                     "offset": 0,
@@ -748,7 +748,7 @@
                     "type": "t_address"
                 },
                 {
-                    "astId": 16906,
+                    "astId": 16945,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "metadata",
                     "offset": 0,
@@ -758,12 +758,12 @@
             ],
             "numberOfBytes": "96"
         },
-        "t_struct(ValidatorInfo)16857_storage": {
+        "t_struct(ValidatorInfo)16896_storage": {
             "encoding": "inplace",
             "label": "struct ValidatorInfo",
             "members": [
                 {
-                    "astId": 16849,
+                    "astId": 16888,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "federatedPower",
                     "offset": 0,
@@ -771,7 +771,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16851,
+                    "astId": 16890,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "confirmedCollateral",
                     "offset": 0,
@@ -779,7 +779,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16853,
+                    "astId": 16892,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "totalCollateral",
                     "offset": 0,
@@ -787,7 +787,7 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16856,
+                    "astId": 16895,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "metadata",
                     "offset": 0,
@@ -797,20 +797,20 @@
             ],
             "numberOfBytes": "128"
         },
-        "t_struct(ValidatorSet)16886_storage": {
+        "t_struct(ValidatorSet)16925_storage": {
             "encoding": "inplace",
             "label": "struct ValidatorSet",
             "members": [
                 {
-                    "astId": 16865,
+                    "astId": 16904,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "permissionMode",
                     "offset": 0,
                     "slot": "0",
-                    "type": "t_enum(PermissionMode)16861"
+                    "type": "t_enum(PermissionMode)16900"
                 },
                 {
-                    "astId": 16868,
+                    "astId": 16907,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "activeLimit",
                     "offset": 1,
@@ -818,7 +818,7 @@
                     "type": "t_uint16"
                 },
                 {
-                    "astId": 16871,
+                    "astId": 16910,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "totalConfirmedCollateral",
                     "offset": 0,
@@ -826,28 +826,28 @@
                     "type": "t_uint256"
                 },
                 {
-                    "astId": 16877,
+                    "astId": 16916,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "validators",
                     "offset": 0,
                     "slot": "2",
-                    "type": "t_mapping(t_address,t_struct(ValidatorInfo)16857_storage)"
+                    "type": "t_mapping(t_address,t_struct(ValidatorInfo)16896_storage)"
                 },
                 {
-                    "astId": 16881,
+                    "astId": 16920,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "activeValidators",
                     "offset": 0,
                     "slot": "3",
-                    "type": "t_struct(MinPQ)15720_storage"
+                    "type": "t_struct(MinPQ)15759_storage"
                 },
                 {
-                    "astId": 16885,
+                    "astId": 16924,
                     "contract": "src/lib/LibSubnetActorStorage.sol:SubnetActorModifiers",
                     "label": "waitingValidators",
                     "offset": 0,
                     "slot": "6",
-                    "type": "t_struct(MaxPQ)15102_storage"
+                    "type": "t_struct(MaxPQ)15141_storage"
                 }
             ],
             "numberOfBytes": "288"

--- a/src/SubnetActorDiamond.sol
+++ b/src/SubnetActorDiamond.sol
@@ -43,7 +43,7 @@ contract SubnetActorDiamond {
         if (params.bottomUpCheckPeriod == 0) {
             revert InvalidSubmissionPeriod();
         }
-        if (params.minActivationCollateral == 0) {
+        if (params.permissionMode != PermissionMode.Federated && params.minActivationCollateral == 0) {
             revert InvalidCollateral();
         }
         if (params.majorityPercentage < 51 || params.majorityPercentage > 100) {
@@ -61,6 +61,11 @@ contract SubnetActorDiamond {
         ds.supportedInterfaces[type(IERC165).interfaceId] = true;
         ds.supportedInterfaces[type(IDiamondCut).interfaceId] = true;
         ds.supportedInterfaces[type(IDiamondLoupe).interfaceId] = true;
+
+        if (params.permissionMode == PermissionMode.Federated) {
+            // ignore min activation collateral for now
+            params.minActivationCollateral = 0;
+        }
 
         s.parentId = params.parentId;
         s.ipcGatewayAddr = params.ipcGatewayAddr;

--- a/src/errors/IPCErrors.sol
+++ b/src/errors/IPCErrors.sol
@@ -78,3 +78,5 @@ error CannotFindSubnet();
 error UnknownSubnet();
 error MethodNotAllowed(string reason);
 error InvalidFederationPayload();
+error DuplicatedGenesisValidator();
+error NotEnoughGenesisValidators();

--- a/src/gateway/GatewayManagerFacet.sol
+++ b/src/gateway/GatewayManagerFacet.sol
@@ -34,10 +34,6 @@ contract GatewayManagerFacet is GatewayActorModifiers, ReentrancyGuard {
             revert NotEnoughFunds();
         }
         uint256 collateral = msg.value - genesisCircSupply;
-        if (collateral < s.minStake) {
-            revert NotEnoughCollateral();
-        }
-
         SubnetID memory subnetId = s.networkName.createSubnetId(msg.sender);
 
         (bool registered, Subnet storage subnet) = LibGateway.getSubnet(subnetId);

--- a/src/lib/LibStaking.sol
+++ b/src/lib/LibStaking.sol
@@ -440,6 +440,12 @@ library LibStaking {
 
     // =============== Operations directly confirm =============
 
+    /// @notice Set the validator federated power directly without queueing the request
+    function setFederatedPowerWithConfirm(address validator, uint256 power) internal {
+        SubnetActorStorage storage s = LibSubnetActorStorage.appStorage();
+        s.validatorSet.confirmFederatedPower(validator, power);
+    }
+
     /// @notice Set the validator metadata directly without queueing the request
     function setMetadataWithConfirm(address validator, bytes calldata metadata) internal {
         SubnetActorStorage storage s = LibSubnetActorStorage.appStorage();

--- a/src/subnet/SubnetActorManagerFacet.sol
+++ b/src/subnet/SubnetActorManagerFacet.sol
@@ -518,6 +518,8 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Pausable
         }
     }
 
+    /// @notice method that allows the contract owner to set the validators' federated power before
+    /// @notice subnet has already been bootstrapped.
     function preBootstrapSetFederatedPower(
         address[] calldata validators,
         bytes[] calldata publicKeys,

--- a/src/subnet/SubnetActorManagerFacet.sol
+++ b/src/subnet/SubnetActorManagerFacet.sol
@@ -533,6 +533,8 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Pausable
                 revert NotOwnerOfPublicKey();
             }
 
+            // performing deduplication
+            // validator should have no power when first added
             if (LibStaking.getPower(validators[i]) > 0) {
                 revert DuplicatedGenesisValidator();
             }
@@ -540,13 +542,14 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Pausable
             LibStaking.setMetadataWithConfirm(validators[i], publicKeys[i]);
             LibStaking.setFederatedPowerWithConfirm(validators[i], powers[i]);
 
-            s.genesisValidators.push(Validator({addr: validators[0], weight: powers[i], metadata: publicKeys[i]}));
+            s.genesisValidators.push(Validator({addr: validators[i], weight: powers[i], metadata: publicKeys[i]}));
 
             unchecked {
                 ++i;
             }
         }
 
+        // check duplication first then check length
         if (length <= s.minValidators) {
             revert NotEnoughGenesisValidators();
         }

--- a/src/subnet/SubnetActorManagerFacet.sol
+++ b/src/subnet/SubnetActorManagerFacet.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity 0.8.19;
 
-import {InvalidBatchEpoch, MaxMsgsPerBatchExceeded, BatchWithNoMessages, InvalidFederationPayload, SubnetAlreadyBootstrapped, NotEnoughFunds, CollateralIsZero, CannotReleaseZero, NotOwnerOfPublicKey, EmptyAddress, NotEnoughBalance, NotEnoughCollateral, NotValidator, NotAllValidatorsHaveLeft, NotStakedBefore, InvalidSignatureErr, InvalidCheckpointEpoch, InvalidPublicKeyLength, MethodNotAllowed} from "../errors/IPCErrors.sol";
+import {InvalidBatchEpoch, NotEnoughGenesisValidators, DuplicatedGenesisValidator, MaxMsgsPerBatchExceeded, BatchWithNoMessages, InvalidFederationPayload, SubnetAlreadyBootstrapped, NotEnoughFunds, CollateralIsZero, CannotReleaseZero, NotOwnerOfPublicKey, EmptyAddress, NotEnoughBalance, NotEnoughCollateral, NotValidator, NotAllValidatorsHaveLeft, NotStakedBefore, InvalidSignatureErr, InvalidCheckpointEpoch, InvalidPublicKeyLength, MethodNotAllowed} from "../errors/IPCErrors.sol";
 import {IGateway} from "../interfaces/IGateway.sol";
 import {ISubnetActor} from "../interfaces/ISubnetActor.sol";
 import {QuorumObjKind} from "../structs/Quorum.sol";
@@ -229,19 +229,10 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Pausable
             revert InvalidFederationPayload();
         }
 
-        uint256 length = validators.length;
-        for (uint256 i; i < length; ) {
-            // check addresses
-            address convertedAddress = publicKeyToAddress(publicKeys[i]);
-            if (convertedAddress != validators[i]) {
-                revert NotOwnerOfPublicKey();
-            }
-
-            LibStaking.setFederatedPower({validator: validators[i], metadata: publicKeys[i], amount: powers[i]});
-
-            unchecked {
-                ++i;
-            }
+        if (s.bootstrapped) {
+            postBootstrapSetFederatedPower(validators, publicKeys, powers);
+        } else {
+            preBootstrapSetFederatedPower(validators, publicKeys, powers);
         }
     }
 
@@ -521,6 +512,69 @@ contract SubnetActorManagerFacet is ISubnetActor, SubnetActorModifiers, Pausable
                 // exit after removing the key
                 break;
             }
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    function preBootstrapSetFederatedPower(
+        address[] calldata validators,
+        bytes[] calldata publicKeys,
+        uint256[] calldata powers
+    ) internal {
+        uint256 length = validators.length;
+        for (uint256 i; i < length; ) {
+            // check addresses
+            address convertedAddress = publicKeyToAddress(publicKeys[i]);
+            if (convertedAddress != validators[i]) {
+                revert NotOwnerOfPublicKey();
+            }
+
+            if (LibStaking.getPower(validators[i]) > 0) {
+                revert DuplicatedGenesisValidator();
+            }
+
+            LibStaking.setMetadataWithConfirm(validators[i], publicKeys[i]);
+            LibStaking.setFederatedPowerWithConfirm(validators[i], powers[i]);
+
+            s.genesisValidators.push(Validator({addr: validators[0], weight: powers[i], metadata: publicKeys[i]}));
+
+            unchecked {
+                ++i;
+            }
+        }
+
+        if (length <= s.minValidators) {
+            revert NotEnoughGenesisValidators();
+        }
+
+        s.bootstrapped = true;
+        emit SubnetBootstrapped(s.genesisValidators);
+
+        // register adding the genesis circulating supply (if it exists)
+        IGateway(s.ipcGatewayAddr).register{value: s.genesisCircSupply}(s.genesisCircSupply);
+    }
+
+    /// @notice method that allows the contract owner to set the validators' federated power after
+    /// @notice subnet has already been bootstrapped.
+    function postBootstrapSetFederatedPower(
+        address[] calldata validators,
+        bytes[] calldata publicKeys,
+        uint256[] calldata powers
+    ) internal {
+        uint256 length = validators.length;
+        for (uint256 i; i < length; ) {
+            // check addresses
+            address convertedAddress = publicKeyToAddress(publicKeys[i]);
+            if (convertedAddress != validators[i]) {
+                revert NotOwnerOfPublicKey();
+            }
+
+            // no need to do deduplication as set directly set the power, there wont be any addition of
+            // federated power.
+            LibStaking.setFederatedPower({validator: validators[i], metadata: publicKeys[i], amount: powers[i]});
+
             unchecked {
                 ++i;
             }

--- a/test/integration/GatewayDiamond.t.sol
+++ b/test/integration/GatewayDiamond.t.sol
@@ -283,13 +283,6 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         require(subnets.length == numberOfSubnets, "unexpected length");
     }
 
-    function testGatewayDiamond_Register_Fail_InsufficientCollateral(uint256 collateral) public {
-        vm.assume(collateral < DEFAULT_COLLATERAL_AMOUNT);
-        vm.expectRevert(NotEnoughCollateral.selector);
-
-        gwManager.register{value: collateral}(0);
-    }
-
     function testGatewayDiamond_Register_Fail_SubnetAlreadyExists() public {
         registerSubnet(DEFAULT_COLLATERAL_AMOUNT, address(this));
 

--- a/test/integration/SubnetActorDiamond.t.sol
+++ b/test/integration/SubnetActorDiamond.t.sol
@@ -1493,18 +1493,25 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         require(saGetter.isActiveValidator(validators[1]), "not active validator 1");
         require(!saGetter.isActiveValidator(validators[2]), "2 should not be active validator");
 
-        // change in validator power
+        // change in validator power, changing validator 2's power to 10001.
+
+        // store validator 0's data in new variables
         address prevV = validators[0];
         uint256 prevPrivateKey = privKeys[0];
 
+        // creating duplicates of validator 2's data
         validators[0] = validators[2];
         publicKeys[0] = publicKeys[2];
-        powers[2] = 10001;
+
+        // the latest validator 2's power, so we have a duplicate of validator 2's power
+        powers[0] = 9999; // lower than validator 0's power, will not kick validator 1 off
+        powers[2] = 10001; // higher than validator 0's power, will kick validator 1 off
 
         saManager.setFederatedPower(validators, publicKeys, powers);
 
         confirmChange(prevV, prevPrivateKey, validators[1], privKeys[1]);
 
+        // we should see validator 0 kicked off
         require(!saGetter.isActiveValidator(prevV), "0 should not be active validator");
         require(saGetter.isActiveValidator(validators[1]), "not active validator 1");
         require(saGetter.isActiveValidator(validators[2]), "not active validator 2");


### PR DESCRIPTION
Bootstrap federated validation by setting the genesis validators. It does a check on the `bootstrapped` field. If `bootstrapped`, then we call `postBootstrapSetFederatedPower` else we call `preBootstrapSetFederatedPower`. In `preBootstrapSetFederatedPower`, we also update the genesis validators as well.