### PR TITLE
use Forge vm TryFfi cheat code in tests and retry flaky getSelectors script N=10 times

### DIFF
--- a/test/IntegrationTestBase.sol
+++ b/test/IntegrationTestBase.sol
@@ -71,10 +71,10 @@ contract TestRegistry is Test, TestParams {
     SubnetGetterFacet registrySubnetGetterFacet;
 
     constructor() {
-        registerSubnetFacetSelectors = TestUtils.generateSelectors(vm, "RegisterSubnetFacet");
-        registerSubnetGetterFacetSelectors = TestUtils.generateSelectors(vm, "SubnetGetterFacet");
-        registerCutterSelectors = TestUtils.generateSelectors(vm, "DiamondCutFacet");
-        registerLouperSelectors = TestUtils.generateSelectors(vm, "DiamondLoupeFacet");
+        registerSubnetFacetSelectors = TestUtils.generateSelectors("RegisterSubnetFacet");
+        registerSubnetGetterFacetSelectors = TestUtils.generateSelectors("SubnetGetterFacet");
+        registerCutterSelectors = TestUtils.generateSelectors("DiamondCutFacet");
+        registerLouperSelectors = TestUtils.generateSelectors("DiamondLoupeFacet");
     }
 }
 
@@ -95,12 +95,12 @@ contract TestGatewayActor is Test, TestParams {
     DiamondLoupeFacet gwLouper;
 
     constructor() {
-        gwRouterSelectors = TestUtils.generateSelectors(vm, "GatewayRouterFacet");
-        gwGetterSelectors = TestUtils.generateSelectors(vm, "GatewayGetterFacet");
-        gwManagerSelectors = TestUtils.generateSelectors(vm, "GatewayManagerFacet");
-        gwMessengerSelectors = TestUtils.generateSelectors(vm, "GatewayMessengerFacet");
-        gwCutterSelectors = TestUtils.generateSelectors(vm, "DiamondCutFacet");
-        gwLoupeSelectors = TestUtils.generateSelectors(vm, "DiamondLoupeFacet");
+        gwRouterSelectors = TestUtils.generateSelectors("GatewayRouterFacet");
+        gwGetterSelectors = TestUtils.generateSelectors("GatewayGetterFacet");
+        gwManagerSelectors = TestUtils.generateSelectors("GatewayManagerFacet");
+        gwMessengerSelectors = TestUtils.generateSelectors("GatewayMessengerFacet");
+        gwCutterSelectors = TestUtils.generateSelectors("DiamondCutFacet");
+        gwLoupeSelectors = TestUtils.generateSelectors("DiamondLoupeFacet");
     }
 
     function defaultGatewayParams() internal pure virtual returns (GatewayDiamond.ConstructorParams memory) {
@@ -133,11 +133,11 @@ contract TestSubnetActor is Test, TestParams {
     DiamondLoupeFacet saLouper;
 
     constructor() {
-        saGetterSelectors = TestUtils.generateSelectors(vm, "SubnetActorGetterFacet");
-        saManagerSelectors = TestUtils.generateSelectors(vm, "SubnetActorManagerFacet");
-        saManagerMockedSelectors = TestUtils.generateSelectors(vm, "SubnetActorManagerFacetMock");
-        saCutterSelectors = TestUtils.generateSelectors(vm, "DiamondCutFacet");
-        saLouperSelectors = TestUtils.generateSelectors(vm, "DiamondLoupeFacet");
+        saGetterSelectors = TestUtils.generateSelectors("SubnetActorGetterFacet");
+        saManagerSelectors = TestUtils.generateSelectors("SubnetActorManagerFacet");
+        saManagerMockedSelectors = TestUtils.generateSelectors("SubnetActorManagerFacetMock");
+        saCutterSelectors = TestUtils.generateSelectors("DiamondCutFacet");
+        saLouperSelectors = TestUtils.generateSelectors("DiamondLoupeFacet");
     }
 
     function defaultSubnetActorParamsWithGateway(

--- a/test/helpers/VmTryFfi.sol
+++ b/test/helpers/VmTryFfi.sol
@@ -1,0 +1,15 @@
+// Automatically generated from `foundry-cheatcodes` Vm definitions. Do not modify manually.
+// This interface is just for internal testing purposes. Use `forge-std` instead.
+
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.19;
+
+interface VmTryFfi {
+    function tryFfi(string[] calldata commandInput) external returns (FfiResult memory result);
+
+    struct FfiResult {
+        int32 exitCode;
+        bytes stdout;
+        bytes stderr;
+    }
+}

--- a/test/integration/GatewayDiamond.t.sol
+++ b/test/integration/GatewayDiamond.t.sol
@@ -86,7 +86,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
 
         DiamondCutFacet gwDiamondCutter = DiamondCutFacet(address(gatewayDiamond));
         IDiamond.FacetCut[] memory gwDiamondCut = new IDiamond.FacetCut[](1);
-        bytes4[] memory ncGetterSelectors = TestUtils.generateSelectors(vm, "NumberContractFacetSeven");
+        bytes4[] memory ncGetterSelectors = TestUtils.generateSelectors("NumberContractFacetSeven");
 
         gwDiamondCut[0] = (
             IDiamond.FacetCut({
@@ -105,7 +105,7 @@ contract GatewayActorDiamondTest is Test, IntegrationTestBase {
         NumberContractFacetSeven gwNumberContract = NumberContractFacetSeven(address(gatewayDiamond));
         assert(gwNumberContract.getNum() == 7);
 
-        ncGetterSelectors = TestUtils.generateSelectors(vm, "NumberContractFacetEight");
+        ncGetterSelectors = TestUtils.generateSelectors("NumberContractFacetEight");
         gwDiamondCut[0] = (
             IDiamond.FacetCut({
                 facetAddress: address(ncFacetB),

--- a/test/integration/SubnetActorDiamond.t.sol
+++ b/test/integration/SubnetActorDiamond.t.sol
@@ -915,7 +915,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
 
         DiamondCutFacet saDiamondCutter = DiamondCutFacet(address(saDiamond));
         IDiamond.FacetCut[] memory saDiamondCut = new IDiamond.FacetCut[](1);
-        bytes4[] memory ncGetterSelectors = TestUtils.generateSelectors(vm, "NumberContractFacetSeven");
+        bytes4[] memory ncGetterSelectors = TestUtils.generateSelectors("NumberContractFacetSeven");
 
         saDiamondCut[0] = (
             IDiamond.FacetCut({
@@ -934,7 +934,7 @@ contract SubnetActorDiamondTest is Test, IntegrationTestBase {
         NumberContractFacetSeven saNumberContract = NumberContractFacetSeven(address(saDiamond));
         assert(saNumberContract.getNum() == 7);
 
-        ncGetterSelectors = TestUtils.generateSelectors(vm, "NumberContractFacetEight");
+        ncGetterSelectors = TestUtils.generateSelectors("NumberContractFacetEight");
         saDiamondCut[0] = (
             IDiamond.FacetCut({
                 facetAddress: address(ncFacetB),


### PR DESCRIPTION
our tests have been flaky and failing due to the call to getSelectors from our solidity tests to our python code. There is a safer function within forge to use named TryFfi that returns the error code of the sub process. This PR uses that api method in order to make a retry N=10 times feature of our code to attempt to mitigate any flakiness that may be coming from within forge.

related issue https://github.com/consensus-shipyard/ipc-monorepo/issues/10

