### PR TITLE
Expose lib quorum

### DIFF
--- a/binding/build.rs
+++ b/binding/build.rs
@@ -51,6 +51,7 @@ fn main() {
         "LibStaking",
         "LibStakingChangeLog",
         "LibGateway",
+        "LibQuorum",
     ] {
         let module_name = camel_to_snake(contract_name);
         let input_path =


### PR DESCRIPTION
Expose lib quorum in `binding` folder so that downstream repos can import this.