### PR TITLE
fix rust binding

### DIFF
--- a/binding/build.rs
+++ b/binding/build.rs
@@ -40,7 +40,10 @@ fn main() {
         "GatewayDiamond",
         "GatewayManagerFacet",
         "GatewayGetterFacet",
-        "GatewayRouterFacet",
+        "BottomUpRouterFacet",
+        "CheckpointingFacet",
+        "TopDownFinalityFacet",
+        "XnetMessagingFacet",
         "GatewayMessengerFacet",
         "SubnetActorDiamond",
         "SubnetActorGetterFacet",
@@ -78,7 +81,8 @@ fn main() {
     let fvm_address_conversion = vec![
         "GatewayManagerFacet",
         "GatewayGetterFacet",
-        "GatewayRouterFacet",
+        "BottomUpRouterFacet",
+        "XnetMessagingFacet",
         "GatewayMessengerFacet",
         "SubnetActorManagerFacet",
         "LibGateway",
@@ -96,7 +100,9 @@ fn main() {
     .unwrap();
     let common_type_conversion = vec![
         ("GatewayGetterFacet", "SubnetActorManagerFacet"),
-        ("SubnetActorGetterFacet", "GatewayRouterFacet"),
+        ("SubnetActorGetterFacet", "BottomUpRouterFacet"),
+        ("SubnetActorGetterFacet", "CheckpointingFacet"),
+        ("SubnetActorGetterFacet", "XnetMessagingFacet"),
     ];
     for (contract1, contract2) in common_type_conversion {
         writeln!(


### PR DESCRIPTION
With the breakdown of `RouterFacet` into multiple smaller facets, the rust binding build file needs to updated with latest changes, otherwise it's broken.